### PR TITLE
feat(execute): subcomando che execute con worktree aislado + PR draft

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/chichex/che/internal/flow/execute"
+	"github.com/spf13/cobra"
+)
+
+var (
+	executeAgentFlag      string
+	executeValidatorsFlag string
+)
+
+var executeCmd = &cobra.Command{
+	Use:   "execute <issue-ref>",
+	Short: "ejecuta un issue en status:plan: worktree aislado + PR draft + validadores disparados",
+	Long: `execute toma la referencia a un issue ya explorado por 'che explore'
+(en status:plan, con ct:plan), parsea la sección "## Plan consolidado" de
+su body, abre un worktree aislado en .worktrees/issue-<N> sobre una branch
+exec/<N>-<slug>, invoca al agente para aplicar el plan, commitea los
+cambios, pushea la branch y abre/actualiza un PR draft contra main. Al
+terminar dispara los validadores (sin esperar) y transiciona el issue a
+status:executed + awaiting-human.
+
+Formatos aceptados para <issue-ref>:
+  che execute 42
+  che execute https://github.com/owner/repo/issues/42
+  che execute owner/repo#42
+
+Agentes disponibles (--agent): opus (default, binario 'claude'), codex, gemini.
+Validadores (--validators): 1-3 separados por coma, pueden repetir tipo
+(ej: 'codex,gemini' o 'codex,codex,gemini'). Usar 'none' para no
+dispararlos (útil para tests/CI).
+
+Este subcomando es la ruta no-interactiva (scripting/CI). La TUI de che
+(invocable con 'che' sin args) usa el mismo flow por dentro.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		agent, err := execute.ParseAgent(executeAgentFlag)
+		if err != nil {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+			os.Stderr.WriteString("error: invalid --agent: " + err.Error() + "\n")
+			os.Exit(int(execute.ExitSemantic))
+		}
+		validators, err := execute.ParseValidators(executeValidatorsFlag)
+		if err != nil {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+			os.Stderr.WriteString("error: invalid --validators: " + err.Error() + "\n")
+			os.Exit(int(execute.ExitSemantic))
+		}
+		code := execute.Run(args[0], execute.Opts{
+			Stdout:     cmd.OutOrStdout(),
+			Stderr:     cmd.ErrOrStderr(),
+			Agent:      agent,
+			Validators: validators,
+		})
+		if code != execute.ExitOK {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+			os.Exit(int(code))
+		}
+		return nil
+	},
+}
+
+func init() {
+	executeCmd.Flags().StringVar(&executeAgentFlag, "agent", string(execute.DefaultAgent),
+		"ejecutor a usar: opus | codex | gemini")
+	executeCmd.Flags().StringVar(&executeValidatorsFlag, "validators", "none",
+		"1-3 validadores separados por coma (opus|codex|gemini), o 'none' para no disparar")
+	rootCmd.AddCommand(executeCmd)
+}

--- a/cmd/fake/main.go
+++ b/cmd/fake/main.go
@@ -27,17 +27,21 @@ import (
 )
 
 type matcher struct {
-	ID            string   `json:"id"`
-	ArgsRegex     string   `json:"args_regex,omitempty"`
-	StdinContains string   `json:"stdin_contains,omitempty"`
-	Consume       bool     `json:"consume,omitempty"`
-	CaptureStdin  bool     `json:"capture_stdin,omitempty"`
-	Stdout        string   `json:"stdout,omitempty"`
-	StdoutFile    string   `json:"stdout_file,omitempty"`
-	Stderr        string   `json:"stderr,omitempty"`
-	Exit          int      `json:"exit,omitempty"`
-	Passthrough   bool     `json:"passthrough,omitempty"` // reserved for git passthrough mode
-	PassthroughTo string   `json:"passthrough_to,omitempty"`
+	ID            string            `json:"id"`
+	ArgsRegex     string            `json:"args_regex,omitempty"`
+	StdinContains string            `json:"stdin_contains,omitempty"`
+	Consume       bool              `json:"consume,omitempty"`
+	CaptureStdin  bool              `json:"capture_stdin,omitempty"`
+	Stdout        string            `json:"stdout,omitempty"`
+	StdoutFile    string            `json:"stdout_file,omitempty"`
+	Stderr        string            `json:"stderr,omitempty"`
+	Exit          int               `json:"exit,omitempty"`
+	Passthrough   bool              `json:"passthrough,omitempty"` // reserved for git passthrough mode
+	PassthroughTo string            `json:"passthrough_to,omitempty"`
+	// TouchFiles lista paths (relativos al cwd donde se ejecutó el fake) que
+	// el fake debe crear con el contenido dado al matchear. Usado por tests
+	// de execute para simular que el agente modificó archivos en el worktree.
+	TouchFiles map[string]string `json:"touch_files,omitempty"`
 }
 
 type script struct {
@@ -145,6 +149,16 @@ func main() {
 			os.Exit(2)
 		}
 		stdoutBody = string(data)
+	}
+
+	// Side effects: touch_files escribe archivos en cwd para simular que
+	// el agente produjo cambios.
+	for relPath, content := range matched.TouchFiles {
+		dir := filepath.Dir(relPath)
+		if dir != "." && dir != "" {
+			_ = os.MkdirAll(dir, 0o755)
+		}
+		_ = os.WriteFile(relPath, []byte(content), 0o644)
 	}
 
 	_, _ = io.WriteString(os.Stdout, stdoutBody)

--- a/e2e/execute_test.go
+++ b/e2e/execute_test.go
@@ -398,22 +398,13 @@ func runIn(t *testing.T, dir, bin string, args ...string) {
 	}
 }
 
-// scriptExecutePrechecks scriptea los 3 prechecks: git remote, gh auth, gh pr
-// list (scope check). Cuando se usa con un repo git real, NO hay que
-// scriptear git — es el real del sistema.
+// scriptExecutePrechecks scriptea los prechecks: gh auth status (auth) y gh
+// auth status -t (scope check). Cuando se usa con un repo git real, NO hay
+// que scriptear git — es el real del sistema.
 func scriptExecutePrechecks(env *harness.Env) {
-	// git remote get-url origin → lo tira git real del sistema (tenemos
-	// origin agregado en setupExecuteEnv). Pero precheckGitHubRemote exige
-	// que la URL contenga "github.com" — el remote es un path bare. Usamos
-	// el fake git solo para esa llamada. Pero si ya quitamos el fake…
-	// Solución: agregamos un remote falso "github.com" reescribiendo el
-	// origin antes de cada test. Mejor: modificamos el helper para que el
-	// remote apunte a un URL github.com + el push usa otro remote.
-	//
-	// Por simplicidad, redirigimos solo `git remote get-url origin`
-	// reinyectando el fake git SOLO para ese call pattern, y todo lo demás
-	// queda en el git real. Pero no podemos mezclar así — el fake es un
-	// único binario. Alternativa: cambiar el origin URL después del init.
-	env.ExpectGh(`^auth status`).RespondStdout("Logged in as acme\n", 0)
-	env.ExpectGh(`^pr list --limit 1`).RespondStdout("[]\n", 0)
+	// Primer call: auth status (sin -t). Chequeo de login.
+	env.ExpectGh(`^auth status$`).Consumable().RespondStdout("Logged in as acme\n", 0)
+	// Segundo call: auth status -t. Incluye scopes válidos.
+	env.ExpectGh(`^auth status -t`).Consumable().RespondStdout(
+		"github.com\n  - Token: gho_xxx\n  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'\n", 0)
 }

--- a/e2e/execute_test.go
+++ b/e2e/execute_test.go
@@ -351,10 +351,13 @@ func TestExecute_NoChanges_ExistingPR_Rollback(t *testing.T) {
 
 // setupExecuteEnv prepara un repo git real en env.RepoDir + quita el fake de
 // git (dejamos el git real del sistema para que worktree y commits funcionen).
+// El env var CHE_EXEC_SKIP_FETCH=1 salta el `git fetch origin main` que
+// ahora es obligatorio — los tests usan bare remotes locales sin red.
 func setupExecuteEnv(t *testing.T) *harness.Env {
 	t.Helper()
 	env := harness.New(t)
 	env.RemoveFake("git")
+	env.SetEnv("CHE_EXEC_SKIP_FETCH", "1")
 
 	// init repo + commit inicial.
 	runIn(t, env.RepoDir, "git", "init", "-q", "-b", "main")

--- a/e2e/execute_test.go
+++ b/e2e/execute_test.go
@@ -1,0 +1,318 @@
+package e2e_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chichex/che/e2e/harness"
+)
+
+// TestExecute_CommandExists verifica que `che execute --help` renderice.
+func TestExecute_CommandExists(t *testing.T) {
+	t.Parallel()
+	env := harness.New(t)
+	out := env.MustRun("execute", "--help")
+	harness.AssertContains(t, out, "execute")
+	harness.AssertContains(t, out, "Plan consolidado")
+}
+
+// TestExecute_MissingArg_ExitNonZero: cobra requiere 1 arg posicional.
+func TestExecute_MissingArg_ExitNonZero(t *testing.T) {
+	t.Parallel()
+	env := harness.New(t)
+	r := env.Run("execute")
+	if r.ExitCode == 0 {
+		t.Fatalf("expected non-zero exit\nstderr: %s", r.Stderr)
+	}
+}
+
+// TestExecute_InvalidAgent_Exit3: --agent bogus rechazado antes de tocar red.
+func TestExecute_InvalidAgent_Exit3(t *testing.T) {
+	t.Parallel()
+	env := harness.New(t)
+	r := env.Run("execute", "--agent", "bogus", "42")
+	if r.ExitCode != 3 {
+		t.Fatalf("expected exit 3, got %d\nstderr: %s", r.ExitCode, r.Stderr)
+	}
+	env.Invocations().AssertNotCalled(t, "gh")
+	env.Invocations().AssertNotCalled(t, "claude")
+}
+
+// TestExecute_NoGitRepo_Exit2: preflight falla si no estamos en un repo git.
+func TestExecute_NoGitRepo_Exit2(t *testing.T) {
+	t.Parallel()
+	env := harness.New(t)
+	// Sin init de git; el fake git devuelve error para rev-parse.
+	env.ExpectGit(`^rev-parse --show-toplevel`).RespondExitWithError(128, "fatal: not a git repo\n")
+
+	r := env.Run("execute", "42")
+	if r.ExitCode != 2 {
+		t.Fatalf("expected exit 2, got %d\nstderr: %s", r.ExitCode, r.Stderr)
+	}
+	env.Invocations().AssertNotCalled(t, "claude")
+}
+
+// TestExecute_GoldenPath: issue válido → worktree + claude + commit + push
+// + PR create + label transitions + comment.
+func TestExecute_GoldenPath(t *testing.T) {
+	env := setupExecuteEnv(t)
+	scriptExecutePrechecks(env)
+	env.ExpectGh(`^issue view 42`).RespondStdoutFromFixture("execute/gh_issue_view_ready.json", 0)
+
+	// No hay PR existente para la branch.
+	env.ExpectGh(`^pr list --head exec/42-`).RespondStdout("[]\n", 0)
+
+	// Label transitions: plan → executing (1er edit), executing → executed (2do).
+	env.ExpectGh(`^label create `).RespondStdout("ok\n", 0)
+	env.ExpectGh(`^issue edit 42 `).Consumable().RespondStdout("ok\n", 0)
+
+	// El agente claude "escribe" un archivo en el worktree.
+	env.ExpectAgent("claude").
+		WhenArgsMatch(`ingeniero senior ejecutando`).
+		TouchFile("IMPLEMENTATION.md", "did the thing\n").
+		RespondStdout("ok\n", 0)
+
+	// Crear PR.
+	env.ExpectGh(`^pr create --draft`).
+		RespondStdout("https://github.com/acme/demo/pull/7\n", 0)
+
+	// Segunda edit (executing → executed) + comment final.
+	env.ExpectGh(`^issue edit 42 `).Consumable().RespondStdout("ok\n", 0)
+	env.ExpectGh(`^issue comment 42 --body-file`).
+		RespondStdout("https://github.com/acme/demo/issues/42#issuecomment-xyz\n", 0)
+
+	out := env.MustRun("execute", "--validators", "none", "42")
+	harness.AssertContains(t, out, "Executed")
+	harness.AssertContains(t, out, "https://github.com/acme/demo/pull/7")
+
+	inv := env.Invocations()
+	if len(inv.For("claude")) != 1 {
+		t.Fatalf("expected 1 claude call, got %d", len(inv.For("claude")))
+	}
+	prCreates := inv.FindCalls("gh", "pr", "create")
+	if len(prCreates) != 1 {
+		t.Fatalf("expected 1 gh pr create, got %d", len(prCreates))
+	}
+	prCreates[0].AssertArgsContain(t, "--draft", "--base", "main")
+
+	edits := inv.FindCalls("gh", "issue", "edit", "42")
+	if len(edits) != 2 {
+		t.Fatalf("expected 2 issue edits (lock + unlock), got %d", len(edits))
+	}
+	// Primer edit: plan → executing.
+	edits[0].AssertArgsContain(t, "--add-label", "status:executing")
+	// Segundo edit: executing → executed + awaiting-human.
+	edits[1].AssertArgsContain(t, "--add-label", "status:executed")
+	edits[1].AssertArgsContain(t, "--add-label", "status:awaiting-human")
+
+	if comments := inv.FindCalls("gh", "issue", "comment", "42", "--body-file"); len(comments) != 1 {
+		t.Fatalf("expected 1 issue comment, got %d", len(comments))
+	}
+}
+
+// TestExecute_IssueNotStatusPlan_Exit3: issue sin status:plan (está en idea) → exit 3.
+func TestExecute_IssueNotStatusPlan_Exit3(t *testing.T) {
+	env := setupExecuteEnv(t)
+	scriptExecutePrechecks(env)
+	env.ExpectGh(`^issue view 42`).RespondStdoutFromFixture("execute/gh_issue_view_not_plan.json", 0)
+
+	r := env.Run("execute", "--validators", "none", "42")
+	if r.ExitCode != 3 {
+		t.Fatalf("expected exit 3, got %d\nstderr: %s", r.ExitCode, r.Stderr)
+	}
+	harness.AssertContains(t, r.Stderr, "status:plan")
+	env.Invocations().AssertNotCalled(t, "claude")
+}
+
+// TestExecute_IssueAwaitingHuman_Exit3: issue con awaiting-human → exit 3.
+func TestExecute_IssueAwaitingHuman_Exit3(t *testing.T) {
+	env := setupExecuteEnv(t)
+	scriptExecutePrechecks(env)
+	env.ExpectGh(`^issue view 42`).RespondStdoutFromFixture("execute/gh_issue_view_awaiting.json", 0)
+
+	r := env.Run("execute", "--validators", "none", "42")
+	if r.ExitCode != 3 {
+		t.Fatalf("expected exit 3, got %d\nstderr: %s", r.ExitCode, r.Stderr)
+	}
+	harness.AssertContains(t, r.Stderr, "awaiting-human")
+	env.Invocations().AssertNotCalled(t, "claude")
+}
+
+// TestExecute_IssueAlreadyExecuting_Exit3: otro run dejó status:executing → refuse.
+func TestExecute_IssueAlreadyExecuting_Exit3(t *testing.T) {
+	env := setupExecuteEnv(t)
+	scriptExecutePrechecks(env)
+	env.ExpectGh(`^issue view 42`).RespondStdoutFromFixture("execute/gh_issue_view_executing.json", 0)
+
+	r := env.Run("execute", "--validators", "none", "42")
+	if r.ExitCode != 3 {
+		t.Fatalf("expected exit 3, got %d\nstderr: %s", r.ExitCode, r.Stderr)
+	}
+	harness.AssertContains(t, r.Stderr, "executing")
+}
+
+// TestExecute_Idempotency_UpdatesExistingPR: segundo run con PR abierto
+// reutiliza ese PR en vez de crear uno nuevo.
+func TestExecute_Idempotency_UpdatesExistingPR(t *testing.T) {
+	env := setupExecuteEnv(t)
+	scriptExecutePrechecks(env)
+	env.ExpectGh(`^issue view 42`).RespondStdoutFromFixture("execute/gh_issue_view_ready.json", 0)
+
+	// PR existente para la branch exec/42-*.
+	env.ExpectGh(`^pr list --head exec/42-`).RespondStdout(
+		`[{"url":"https://github.com/acme/demo/pull/7","number":7}]`, 0)
+
+	env.ExpectGh(`^label create `).RespondStdout("ok\n", 0)
+	env.ExpectGh(`^issue edit 42 `).Consumable().RespondStdout("ok\n", 0)
+
+	env.ExpectAgent("claude").
+		WhenArgsMatch(`ingeniero senior ejecutando`).
+		TouchFile("IMPLEMENTATION_V2.md", "update\n").
+		RespondStdout("ok\n", 0)
+
+	env.ExpectGh(`^issue edit 42 `).Consumable().RespondStdout("ok\n", 0)
+	env.ExpectGh(`^issue comment 42 --body-file`).RespondStdout("ok\n", 0)
+
+	out := env.MustRun("execute", "--validators", "none", "42")
+	harness.AssertContains(t, out, "https://github.com/acme/demo/pull/7")
+
+	inv := env.Invocations()
+	if creates := inv.FindCalls("gh", "pr", "create"); len(creates) != 0 {
+		t.Fatalf("expected 0 gh pr create on idempotent run, got %d", len(creates))
+	}
+}
+
+// TestExecute_AgentFails_Rollback: claude falla → worktree limpio + label
+// vuelve a status:plan.
+func TestExecute_AgentFails_Rollback(t *testing.T) {
+	env := setupExecuteEnv(t)
+	scriptExecutePrechecks(env)
+	env.ExpectGh(`^issue view 42`).RespondStdoutFromFixture("execute/gh_issue_view_ready.json", 0)
+	env.ExpectGh(`^pr list --head exec/42-`).RespondStdout("[]\n", 0)
+
+	env.ExpectGh(`^label create `).RespondStdout("ok\n", 0)
+	// 1er edit: lock; 2do edit: rollback.
+	env.ExpectGh(`^issue edit 42 `).Consumable().RespondStdout("ok\n", 0)
+	env.ExpectGh(`^issue edit 42 `).Consumable().RespondStdout("ok\n", 0)
+
+	env.ExpectAgent("claude").
+		WhenArgsMatch(`ingeniero senior ejecutando`).
+		RespondExitWithError(1, "claude exploded\n")
+
+	r := env.Run("execute", "--validators", "none", "42")
+	if r.ExitCode != 2 {
+		t.Fatalf("expected exit 2 (retry), got %d\nstderr: %s", r.ExitCode, r.Stderr)
+	}
+
+	inv := env.Invocations()
+	if creates := inv.FindCalls("gh", "pr", "create"); len(creates) > 0 {
+		t.Fatalf("expected 0 gh pr create after agent failure, got %d", len(creates))
+	}
+	edits := inv.FindCalls("gh", "issue", "edit", "42")
+	if len(edits) != 2 {
+		t.Fatalf("expected 2 issue edits (lock + rollback), got %d", len(edits))
+	}
+	edits[1].AssertArgsContain(t, "--add-label", "status:plan")
+}
+
+// TestExecute_NoChanges_Rollback: claude termina sin tocar archivos → retry +
+// rollback.
+func TestExecute_NoChanges_Rollback(t *testing.T) {
+	env := setupExecuteEnv(t)
+	scriptExecutePrechecks(env)
+	env.ExpectGh(`^issue view 42`).RespondStdoutFromFixture("execute/gh_issue_view_ready.json", 0)
+	env.ExpectGh(`^pr list --head exec/42-`).RespondStdout("[]\n", 0)
+
+	env.ExpectGh(`^label create `).RespondStdout("ok\n", 0)
+	env.ExpectGh(`^issue edit 42 `).Consumable().RespondStdout("ok\n", 0)
+	env.ExpectGh(`^issue edit 42 `).Consumable().RespondStdout("ok\n", 0)
+
+	// Claude no toca archivos.
+	env.ExpectAgent("claude").
+		WhenArgsMatch(`ingeniero senior ejecutando`).
+		RespondStdout("hmm\n", 0)
+
+	r := env.Run("execute", "--validators", "none", "42")
+	if r.ExitCode != 2 {
+		t.Fatalf("expected exit 2, got %d\nstderr: %s", r.ExitCode, r.Stderr)
+	}
+	harness.AssertContains(t, r.Stderr, "sin cambios")
+}
+
+// TestExecute_ListCandidates_FiltersAwaiting: integration-style — esta prueba
+// solo verifica que `che execute` no liste issues con awaiting-human. La TUI
+// es difícil de testear directamente; chequeamos por side-effect del filter
+// cuando se corre el list interno.
+// Nota: este test no tiene sentido sin una ruta TUI; lo dejamos como test
+// unitario en execute_test.go y no acá.
+
+// ---- helpers ----
+
+// setupExecuteEnv prepara un repo git real en env.RepoDir + quita el fake de
+// git (dejamos el git real del sistema para que worktree y commits funcionen).
+func setupExecuteEnv(t *testing.T) *harness.Env {
+	t.Helper()
+	env := harness.New(t)
+	env.RemoveFake("git")
+
+	// init repo + commit inicial.
+	runIn(t, env.RepoDir, "git", "init", "-q", "-b", "main")
+	runIn(t, env.RepoDir, "git", "config", "user.email", "che@test.local")
+	runIn(t, env.RepoDir, "git", "config", "user.name", "che-test")
+	// Agregamos un origin con URL github.com (para pasar precheckGitHubRemote).
+	// Como push a github.com no va a funcionar, seteamos un pushurl separado
+	// que apunta a un bare local. `git remote get-url origin` devuelve el
+	// URL de fetch (github.com) — lo que el precheck chequea — pero los
+	// push/fetch reales van al bare sin necesidad de red. El fetch en
+	// execute se hace best-effort (ignoramos errores de `git fetch origin
+	// main`), así que no hace falta redirigir fetch.
+	bare := filepath.Join(env.RepoDir, "..", "remote.git")
+	runIn(t, "", "git", "init", "--bare", "-q", bare)
+	fakeGHURL := "https://github.com/acme/demo.git"
+	runIn(t, env.RepoDir, "git", "remote", "add", "origin", fakeGHURL)
+	runIn(t, env.RepoDir, "git", "config", "remote.origin.pushurl", bare)
+	// Push inicial del main inicial hacia el bare (usa pushurl).
+	if err := os.WriteFile(filepath.Join(env.RepoDir, "README.md"), []byte("# demo\n"), 0o644); err != nil {
+		t.Fatalf("write readme: %v", err)
+	}
+	runIn(t, env.RepoDir, "git", "add", "README.md")
+	runIn(t, env.RepoDir, "git", "commit", "-q", "-m", "initial")
+	runIn(t, env.RepoDir, "git", "push", "-q", "origin", "main")
+
+	return env
+}
+
+func runIn(t *testing.T, dir, bin string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(bin, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s: %v\n%s", bin, strings.Join(args, " "), err, out)
+	}
+}
+
+// scriptExecutePrechecks scriptea los 3 prechecks: git remote, gh auth, gh pr
+// list (scope check). Cuando se usa con un repo git real, NO hay que
+// scriptear git — es el real del sistema.
+func scriptExecutePrechecks(env *harness.Env) {
+	// git remote get-url origin → lo tira git real del sistema (tenemos
+	// origin agregado en setupExecuteEnv). Pero precheckGitHubRemote exige
+	// que la URL contenga "github.com" — el remote es un path bare. Usamos
+	// el fake git solo para esa llamada. Pero si ya quitamos el fake…
+	// Solución: agregamos un remote falso "github.com" reescribiendo el
+	// origin antes de cada test. Mejor: modificamos el helper para que el
+	// remote apunte a un URL github.com + el push usa otro remote.
+	//
+	// Por simplicidad, redirigimos solo `git remote get-url origin`
+	// reinyectando el fake git SOLO para ese call pattern, y todo lo demás
+	// queda en el git real. Pero no podemos mezclar así — el fake es un
+	// único binario. Alternativa: cambiar el origin URL después del init.
+	env.ExpectGh(`^auth status`).RespondStdout("Logged in as acme\n", 0)
+	env.ExpectGh(`^pr list --limit 1`).RespondStdout("[]\n", 0)
+}

--- a/e2e/execute_test.go
+++ b/e2e/execute_test.go
@@ -290,7 +290,54 @@ func TestExecute_NoChanges_Rollback(t *testing.T) {
 	if r.ExitCode != 2 {
 		t.Fatalf("expected exit 2, got %d\nstderr: %s", r.ExitCode, r.Stderr)
 	}
-	harness.AssertContains(t, r.Stderr, "sin cambios")
+	harness.AssertContains(t, r.Stderr, "no se generaron cambios")
+	harness.AssertContains(t, r.Stderr, "no hay PR previo")
+}
+
+// TestExecute_NoChanges_ExistingPR_Rollback: claude no toca archivos pero
+// hay un PR abierto; NO debe transicionar a executed/awaiting-human ni
+// refrescar el PR — rollback a status:plan y mensaje diferenciado.
+func TestExecute_NoChanges_ExistingPR_Rollback(t *testing.T) {
+	env := setupExecuteEnv(t)
+	scriptExecutePrechecks(env)
+	env.ExpectGh(`^issue view 42`).Consumable().RespondStdoutFromFixture("execute/gh_issue_view_ready.json", 0)
+	env.ExpectGh(`^issue view 42`).Consumable().RespondStdoutFromFixture("execute/gh_issue_view_locked_executing.json", 0)
+	// PR abierto existente.
+	env.ExpectGh(`^pr list --head exec/42-`).RespondStdout(
+		`[{"url":"https://github.com/acme/demo/pull/7","number":7}]`, 0)
+
+	env.ExpectGh(`^label create `).RespondStdout("ok\n", 0)
+	// Esperamos 2 edits: lock + rollback. NO debería haber un edit que
+	// agregue status:executed.
+	env.ExpectGh(`^issue edit 42 `).Consumable().RespondStdout("ok\n", 0)
+	env.ExpectGh(`^issue edit 42 `).Consumable().RespondStdout("ok\n", 0)
+
+	// Claude no toca archivos.
+	env.ExpectAgent("claude").
+		WhenArgsMatch(`ingeniero senior ejecutando`).
+		RespondStdout("noop\n", 0)
+
+	r := env.Run("execute", "--validators", "none", "42")
+	if r.ExitCode != 2 {
+		t.Fatalf("expected exit 2, got %d\nstderr: %s", r.ExitCode, r.Stderr)
+	}
+	harness.AssertContains(t, r.Stderr, "no se generaron cambios")
+	harness.AssertContains(t, r.Stderr, "PR no actualizado")
+
+	inv := env.Invocations()
+	// No debe haber gh pr create (había uno existente igual).
+	if creates := inv.FindCalls("gh", "pr", "create"); len(creates) != 0 {
+		t.Fatalf("expected 0 gh pr create, got %d", len(creates))
+	}
+	// Ninguno de los edits debe agregar status:executed (chequeo consecutivo).
+	edits := inv.FindCalls("gh", "issue", "edit", "42")
+	for _, e := range edits {
+		for i := 0; i+1 < len(e.Args); i++ {
+			if e.Args[i] == "--add-label" && e.Args[i+1] == "status:executed" {
+				t.Fatalf("rogue transition to status:executed: %v", e.Args)
+			}
+		}
+	}
 }
 
 // TestExecute_ListCandidates_FiltersAwaiting: integration-style — esta prueba

--- a/e2e/execute_test.go
+++ b/e2e/execute_test.go
@@ -186,11 +186,15 @@ func TestExecute_Idempotency_UpdatesExistingPR(t *testing.T) {
 }
 
 // TestExecute_AgentFails_Rollback: claude falla → worktree limpio + label
-// vuelve a status:plan.
+// vuelve a status:plan. El defer re-fetchea el issue (ownership-aware) y ve
+// que sigue con status:executing, entonces aplica el rollback.
 func TestExecute_AgentFails_Rollback(t *testing.T) {
 	env := setupExecuteEnv(t)
 	scriptExecutePrechecks(env)
-	env.ExpectGh(`^issue view 42`).RespondStdoutFromFixture("execute/gh_issue_view_ready.json", 0)
+	// 1er issue view: previo al lock (status:plan). 2do: durante rollback
+	// (status:executing — el lock sigue siendo nuestro, rollback procede).
+	env.ExpectGh(`^issue view 42`).Consumable().RespondStdoutFromFixture("execute/gh_issue_view_ready.json", 0)
+	env.ExpectGh(`^issue view 42`).Consumable().RespondStdoutFromFixture("execute/gh_issue_view_locked_executing.json", 0)
 	env.ExpectGh(`^pr list --head exec/42-`).RespondStdout("[]\n", 0)
 
 	env.ExpectGh(`^label create `).RespondStdout("ok\n", 0)
@@ -218,12 +222,59 @@ func TestExecute_AgentFails_Rollback(t *testing.T) {
 	edits[1].AssertArgsContain(t, "--add-label", "status:plan")
 }
 
+// TestExecute_AgentFails_RollbackSkippedIfLockLost: claude falla y cuando
+// el defer re-fetchea el issue, ya no tiene status:executing (otra
+// instancia transitó). El rollback NO debe aplicar el label transition.
+func TestExecute_AgentFails_RollbackSkippedIfLockLost(t *testing.T) {
+	env := setupExecuteEnv(t)
+	scriptExecutePrechecks(env)
+	// 1er issue view: status:plan (para gate). 2do issue view (en rollback):
+	// ya no tiene status:executing (otra instancia se lo robó).
+	env.ExpectGh(`^issue view 42`).Consumable().RespondStdoutFromFixture("execute/gh_issue_view_ready.json", 0)
+	env.ExpectGh(`^issue view 42`).Consumable().RespondStdoutFromFixture("execute/gh_issue_view_no_longer_executing.json", 0)
+	env.ExpectGh(`^pr list --head exec/42-`).RespondStdout("[]\n", 0)
+
+	env.ExpectGh(`^label create `).RespondStdout("ok\n", 0)
+	// Solo el 1er edit (lock) debería ocurrir; el 2do (rollback) NO.
+	env.ExpectGh(`^issue edit 42 `).Consumable().RespondStdout("ok\n", 0)
+
+	env.ExpectAgent("claude").
+		WhenArgsMatch(`ingeniero senior ejecutando`).
+		RespondExitWithError(1, "claude exploded\n")
+
+	r := env.Run("execute", "--validators", "none", "42")
+	if r.ExitCode != 2 {
+		t.Fatalf("expected exit 2 (retry), got %d\nstderr: %s", r.ExitCode, r.Stderr)
+	}
+
+	inv := env.Invocations()
+	edits := inv.FindCalls("gh", "issue", "edit", "42")
+	if len(edits) != 1 {
+		t.Fatalf("expected 1 issue edit (only lock, rollback skipped), got %d", len(edits))
+	}
+	// El único edit debe ser el lock; inspeccionamos la secuencia
+	// consecutiva `--add-label status:plan` para descartar rollback.
+	rollbackCount := 0
+	for _, e := range edits {
+		for i := 0; i+1 < len(e.Args); i++ {
+			if e.Args[i] == "--add-label" && e.Args[i+1] == "status:plan" {
+				rollbackCount++
+			}
+		}
+	}
+	if rollbackCount != 0 {
+		t.Fatalf("expected 0 rollback edits (consecutive --add-label status:plan), got %d", rollbackCount)
+	}
+	harness.AssertContains(t, r.Stderr, "rollback abortado")
+}
+
 // TestExecute_NoChanges_Rollback: claude termina sin tocar archivos → retry +
-// rollback.
+// rollback. El 2do issue view del rollback ve status:executing intacto.
 func TestExecute_NoChanges_Rollback(t *testing.T) {
 	env := setupExecuteEnv(t)
 	scriptExecutePrechecks(env)
-	env.ExpectGh(`^issue view 42`).RespondStdoutFromFixture("execute/gh_issue_view_ready.json", 0)
+	env.ExpectGh(`^issue view 42`).Consumable().RespondStdoutFromFixture("execute/gh_issue_view_ready.json", 0)
+	env.ExpectGh(`^issue view 42`).Consumable().RespondStdoutFromFixture("execute/gh_issue_view_locked_executing.json", 0)
 	env.ExpectGh(`^pr list --head exec/42-`).RespondStdout("[]\n", 0)
 
 	env.ExpectGh(`^label create `).RespondStdout("ok\n", 0)

--- a/e2e/harness/script.go
+++ b/e2e/harness/script.go
@@ -13,15 +13,16 @@ import (
 // Matcher describes how chefake should respond when an invocation to a given
 // identity (bin) satisfies the match rules.
 type Matcher struct {
-	ID            string `json:"id"`
-	ArgsRegex     string `json:"args_regex,omitempty"`
-	StdinContains string `json:"stdin_contains,omitempty"`
-	Consume       bool   `json:"consume,omitempty"`
-	CaptureStdin  bool   `json:"capture_stdin,omitempty"`
-	Stdout        string `json:"stdout,omitempty"`
-	StdoutFile    string `json:"stdout_file,omitempty"`
-	Stderr        string `json:"stderr,omitempty"`
-	Exit          int    `json:"exit"`
+	ID            string            `json:"id"`
+	ArgsRegex     string            `json:"args_regex,omitempty"`
+	StdinContains string            `json:"stdin_contains,omitempty"`
+	Consume       bool              `json:"consume,omitempty"`
+	CaptureStdin  bool              `json:"capture_stdin,omitempty"`
+	Stdout        string            `json:"stdout,omitempty"`
+	StdoutFile    string            `json:"stdout_file,omitempty"`
+	Stderr        string            `json:"stderr,omitempty"`
+	Exit          int               `json:"exit"`
+	TouchFiles    map[string]string `json:"touch_files,omitempty"`
 }
 
 // ExpectBuilder is the fluent API used to script a single matcher. Values
@@ -120,6 +121,17 @@ func (b *ExpectBuilder) RespondExitWithError(exitCode int, stderr string) *Match
 	b.m.Stderr = stderr
 	b.m.Exit = exitCode
 	return b.commit()
+}
+
+// TouchFile agenda la creación de un archivo con el contenido dado (relativo
+// al cwd donde corre el fake) al matchear. Usado por los tests de execute
+// para simular que el agente produjo cambios en el worktree.
+func (b *ExpectBuilder) TouchFile(relPath, content string) *ExpectBuilder {
+	if b.m.TouchFiles == nil {
+		b.m.TouchFiles = map[string]string{}
+	}
+	b.m.TouchFiles[relPath] = content
+	return b
 }
 
 // MatcherRef is returned from a Respond* call so the test can refer back to

--- a/e2e/testdata/execute/gh_issue_view_awaiting.json
+++ b/e2e/testdata/execute/gh_issue_view_awaiting.json
@@ -1,0 +1,12 @@
+{
+  "number": 42,
+  "title": "Implementar comando che execute",
+  "body": "## Plan consolidado\n\n**Resumen:** foo\n\n### Pasos\n1. bar\n",
+  "url": "https://github.com/acme/demo/issues/42",
+  "state": "OPEN",
+  "labels": [
+    {"name": "ct:plan"},
+    {"name": "status:plan"},
+    {"name": "status:awaiting-human"}
+  ]
+}

--- a/e2e/testdata/execute/gh_issue_view_executing.json
+++ b/e2e/testdata/execute/gh_issue_view_executing.json
@@ -1,0 +1,11 @@
+{
+  "number": 42,
+  "title": "Implementar comando che execute",
+  "body": "## Plan consolidado\n\n**Resumen:** foo\n",
+  "url": "https://github.com/acme/demo/issues/42",
+  "state": "OPEN",
+  "labels": [
+    {"name": "ct:plan"},
+    {"name": "status:executing"}
+  ]
+}

--- a/e2e/testdata/execute/gh_issue_view_locked_executing.json
+++ b/e2e/testdata/execute/gh_issue_view_locked_executing.json
@@ -1,0 +1,13 @@
+{
+  "number": 42,
+  "title": "Implementar comando che execute",
+  "body": "## Plan consolidado (post-exploración)\n\n**Resumen:** Agregar comando che execute.\n\n**Goal:** Ejecutar un issue end-to-end.\n\n### Criterios de aceptación\n- [ ] che execute registrado como subcomando cobra\n- [ ] La TUI lista solo issues con ct:plan + status:plan\n\n### Approach\nConstruir execute como copia adaptada de explore.\n\n### Pasos\n1. Crear internal/flow/execute\n2. Wirear cmd/execute.go\n\n### Fuera de alcance\n- Ciclo iter con scope-lock\n\n---\n\n## Idea original\n\nLorem\n",
+  "url": "https://github.com/acme/demo/issues/42",
+  "state": "OPEN",
+  "labels": [
+    {"name": "ct:plan"},
+    {"name": "status:executing"},
+    {"name": "type:feature"},
+    {"name": "size:l"}
+  ]
+}

--- a/e2e/testdata/execute/gh_issue_view_no_longer_executing.json
+++ b/e2e/testdata/execute/gh_issue_view_no_longer_executing.json
@@ -1,0 +1,13 @@
+{
+  "number": 42,
+  "title": "Implementar comando che execute",
+  "body": "## Plan consolidado (post-exploración)\n\n**Resumen:** Agregar comando che execute.\n\n**Goal:** Ejecutar un issue end-to-end.\n\n### Criterios de aceptación\n- [ ] che execute registrado como subcomando cobra\n- [ ] La TUI lista solo issues con ct:plan + status:plan\n\n### Approach\nConstruir execute como copia adaptada de explore.\n\n### Pasos\n1. Crear internal/flow/execute\n2. Wirear cmd/execute.go\n\n### Fuera de alcance\n- Ciclo iter con scope-lock\n\n---\n\n## Idea original\n\nLorem\n",
+  "url": "https://github.com/acme/demo/issues/42",
+  "state": "OPEN",
+  "labels": [
+    {"name": "ct:plan"},
+    {"name": "status:plan"},
+    {"name": "type:feature"},
+    {"name": "size:l"}
+  ]
+}

--- a/e2e/testdata/execute/gh_issue_view_not_plan.json
+++ b/e2e/testdata/execute/gh_issue_view_not_plan.json
@@ -1,0 +1,11 @@
+{
+  "number": 42,
+  "title": "Implementar comando che execute",
+  "body": "## Plan consolidado\n\n**Resumen:** foo\n",
+  "url": "https://github.com/acme/demo/issues/42",
+  "state": "OPEN",
+  "labels": [
+    {"name": "ct:plan"},
+    {"name": "status:idea"}
+  ]
+}

--- a/e2e/testdata/execute/gh_issue_view_ready.json
+++ b/e2e/testdata/execute/gh_issue_view_ready.json
@@ -1,0 +1,13 @@
+{
+  "number": 42,
+  "title": "Implementar comando che execute",
+  "body": "## Plan consolidado (post-exploración)\n\n**Resumen:** Agregar comando che execute.\n\n**Goal:** Ejecutar un issue end-to-end.\n\n### Criterios de aceptación\n- [ ] che execute registrado como subcomando cobra\n- [ ] La TUI lista solo issues con ct:plan + status:plan\n\n### Approach\nConstruir execute como copia adaptada de explore.\n\n### Pasos\n1. Crear internal/flow/execute\n2. Wirear cmd/execute.go\n\n### Fuera de alcance\n- Ciclo iter con scope-lock\n\n---\n\n## Idea original\n\nLorem\n",
+  "url": "https://github.com/acme/demo/issues/42",
+  "state": "OPEN",
+  "labels": [
+    {"name": "ct:plan"},
+    {"name": "status:plan"},
+    {"name": "type:feature"},
+    {"name": "size:l"}
+  ]
+}

--- a/internal/flow/execute/execute.go
+++ b/internal/flow/execute/execute.go
@@ -340,23 +340,31 @@ func Run(issueRef string, opts Opts) ExitCode {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return ExitRetry
 	}
-	if !hasChanges && existingPR == "" {
-		fmt.Fprintf(stderr, "error: agente terminó sin cambios en el worktree y no hay PR existente — nada que commitear\n")
+	if !hasChanges {
+		// Sin cambios, no importa si hay PR existente o no: no tenemos
+		// nada que commitear ni que refrescar. NO transicionamos a
+		// executed + awaiting-human (eso engañaría al operador). Dejamos
+		// que el defer revierta executing → plan así el issue queda
+		// disponible para otro intento. Mensaje diferenciado según haya
+		// PR previo o no.
+		if existingPR != "" {
+			fmt.Fprintf(stderr, "error: no se generaron cambios en este run; PR no actualizado (%s)\n", existingPR)
+		} else {
+			fmt.Fprintln(stderr, "error: no se generaron cambios en este run; no hay PR previo")
+		}
 		return ExitRetry
 	}
 
-	if hasChanges {
-		progress("armando commit en el worktree…")
-		if err := commitAll(wt.Path, fmt.Sprintf("feat(#%d): %s\n\nCloses #%d", issue.Number, issue.Title, issue.Number)); err != nil {
-			fmt.Fprintf(stderr, "error: %v\n", err)
-			return ExitRetry
-		}
+	progress("armando commit en el worktree…")
+	if err := commitAll(wt.Path, fmt.Sprintf("feat(#%d): %s\n\nCloses #%d", issue.Number, issue.Title, issue.Number)); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitRetry
+	}
 
-		progress("pusheando branch " + wt.Branch + "…")
-		if err := pushBranch(wt.Path, wt.Branch); err != nil {
-			fmt.Fprintf(stderr, "error: %v\n", err)
-			return ExitRetry
-		}
+	progress("pusheando branch " + wt.Branch + "…")
+	if err := pushBranch(wt.Path, wt.Branch); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitRetry
 	}
 
 	var prURL string

--- a/internal/flow/execute/execute.go
+++ b/internal/flow/execute/execute.go
@@ -878,11 +878,17 @@ func runGitIn(dir string, args ...string) error {
 
 // ---- PR ops ----
 
-// findOpenPRForBranch busca un PR abierto cuyo head-branch sea el dado.
-// Devuelve la URL si lo encuentra, "" si no. Cualquier error de gh (red,
-// permisos) se propaga.
+// findOpenPRForBranch busca un PR abierto (contra main) cuyo head-branch sea
+// el dado. Devuelve la URL si lo encuentra, "" si no. Si hay más de uno,
+// devuelve error accionable: el caso es suficientemente raro como para
+// frenar en vez de agarrar uno silenciosamente. Filtrar por --base main
+// evita falsos positivos si la branch tiene un PR abierto contra otra base.
 func findOpenPRForBranch(branch string) (string, error) {
-	cmd := exec.Command("gh", "pr", "list", "--head", branch, "--state", "open", "--json", "url,number")
+	cmd := exec.Command("gh", "pr", "list",
+		"--head", branch,
+		"--base", "main",
+		"--state", "open",
+		"--json", "url,number")
 	out, err := cmd.Output()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
@@ -899,6 +905,13 @@ func findOpenPRForBranch(branch string) (string, error) {
 	}
 	if len(prs) == 0 {
 		return "", nil
+	}
+	if len(prs) > 1 {
+		urls := make([]string, 0, len(prs))
+		for _, p := range prs {
+			urls = append(urls, p.URL)
+		}
+		return "", fmt.Errorf("múltiples PRs abiertos encontrados para head-branch %s (PRs: %v), resolver manualmente", branch, urls)
 	}
 	return prs[0].URL, nil
 }

--- a/internal/flow/execute/execute.go
+++ b/internal/flow/execute/execute.go
@@ -101,6 +101,20 @@ var AgentTimeout = func() time.Duration {
 	return 15 * time.Minute
 }()
 
+// ValidatorsWaitTimeout es cuánto esperamos a que las goroutines de
+// validadores terminen antes de retornar de Run. Es el timeout del wait,
+// no del agente validador en sí — cada validador individualmente está
+// acotado por AgentTimeout. Configurable con CHE_EXEC_VALIDATORS_WAIT_SECS
+// (default 600s = 10min).
+var ValidatorsWaitTimeout = func() time.Duration {
+	if s := strings.TrimSpace(os.Getenv("CHE_EXEC_VALIDATORS_WAIT_SECS")); s != "" {
+		if n, err := time.ParseDuration(s + "s"); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 10 * time.Minute
+}()
+
 // Opts agrupa los writers, la callback de progreso y el agente ejecutor.
 type Opts struct {
 	Stdout     io.Writer
@@ -346,10 +360,18 @@ func Run(issueRef string, opts Opts) ExitCode {
 		}
 	}
 
-	// Disparar validadores (fire-and-forget). NO esperamos por ellos.
+	// Disparar validadores y esperar con timeout acotado. Originalmente esto
+	// era fire-and-forget, pero cmd/execute.go hace os.Exit(code) apenas Run
+	// retorna — eso mataba las goroutines antes de que postearan comments.
+	// Ahora esperamos hasta ValidatorsWaitTimeout (env configurable); si
+	// expira, logeamos y retornamos igual (los validadores que queden siguen
+	// en background pero el proceso se va a cortar).
+	var validatorsDone <-chan int
+	validatorsTotal := 0
 	if !opts.SkipValidators && len(opts.Validators) > 0 {
 		progress(fmt.Sprintf("disparando %d validador(es) sobre el PR…", len(opts.Validators)))
-		fireValidators(prURL, issue, plan, opts.Validators)
+		validatorsDone = fireValidators(prURL, issue, plan, opts.Validators)
+		validatorsTotal = len(opts.Validators)
 	}
 
 	progress("transicionando issue a status:executed + awaiting-human…")
@@ -365,10 +387,41 @@ func Run(issueRef string, opts Opts) ExitCode {
 	}
 
 	succeeded = true
+
+	// Esperar a los validadores (si los hay) antes de retornar, para que el
+	// os.Exit del caller no los mate. Feedback incremental a stdout.
+	if validatorsDone != nil && validatorsTotal > 0 {
+		waitValidators(stdout, validatorsDone, validatorsTotal, ValidatorsWaitTimeout)
+	}
+
 	fmt.Fprintf(stdout, "Executed %s\n", issue.URL)
 	fmt.Fprintf(stdout, "PR: %s\n", prURL)
 	fmt.Fprintln(stdout, "Done.")
 	return ExitOK
+}
+
+// waitValidators lee del canal una señal por validador que terminó y emite
+// progreso "esperando validadores (k/total)…" hasta total o hasta timeout.
+// Si expira el timeout, imprime cuántos quedaron y retorna — los que sigan
+// corriendo van a morir cuando el proceso termine.
+func waitValidators(stdout io.Writer, done <-chan int, total int, timeout time.Duration) {
+	completed := 0
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	for completed < total {
+		select {
+		case _, ok := <-done:
+			if !ok {
+				// Canal cerrado antes de tiempo (no debería pasar, pero defendernos).
+				return
+			}
+			completed++
+			fmt.Fprintf(stdout, "esperando validadores (%d/%d)…\n", completed, total)
+		case <-timer.C:
+			fmt.Fprintf(stdout, "timeout: %d/%d validadores completaron, el resto sigue corriendo en background\n", completed, total)
+			return
+		}
+	}
 }
 
 // ListCandidates devuelve los issues abiertos con ct:plan + status:plan que
@@ -867,11 +920,23 @@ func createDraftPR(wtPath, branch string, issue *Issue) (string, error) {
 
 // fireValidators lanza una goroutine por validator que invoca al agente con
 // el prompt de validación de diff y postea el resultado como PR comment.
-// NO esperamos: la función retorna inmediatamente.
-func fireValidators(prURL string, issue *Issue, plan *ConsolidatedPlan, validators []Validator) {
-	for _, v := range validators {
-		v := v
+// Devuelve un canal que recibe una señal (el índice del validator) cada vez
+// que una goroutine termina. El caller puede leer hasta len(validators)
+// señales y aplicar su propio timeout. El canal tiene buffer = len(validators)
+// así las goroutines nunca se bloquean si el caller deja de drenarlo.
+func fireValidators(prURL string, issue *Issue, plan *ConsolidatedPlan, validators []Validator) <-chan int {
+	done := make(chan int, len(validators))
+	for i, v := range validators {
+		i, v := i, v
 		go func() {
+			defer func() {
+				// Non-blocking send: si el canal está lleno (no debería con
+				// buffer = len(validators)), no nos colgamos.
+				select {
+				case done <- i:
+				default:
+				}
+			}()
 			prompt := buildValidatorPrompt(issue, plan)
 			ctx, cancel := context.WithTimeout(context.Background(), AgentTimeout)
 			defer cancel()
@@ -881,6 +946,7 @@ func fireValidators(prURL string, issue *Issue, plan *ConsolidatedPlan, validato
 			_ = postPRComment(prURL, body)
 		}()
 	}
+	return done
 }
 
 func buildValidatorPrompt(issue *Issue, plan *ConsolidatedPlan) string {

--- a/internal/flow/execute/execute.go
+++ b/internal/flow/execute/execute.go
@@ -290,6 +290,18 @@ func Run(issueRef string, opts Opts) ExitCode {
 		if wt != nil {
 			_ = wt.Cleanup(repoRoot, false)
 		}
+		// Rollback ownership-aware: re-fetch el issue y verificar que
+		// status:executing siga siendo nuestro lock antes de revertirlo.
+		// Si otra instancia ya transitó, pisaríamos su estado.
+		current, fetchErr := fetchIssue(issueRef)
+		if fetchErr != nil {
+			fmt.Fprintf(stderr, "warning: rollback no aplicado: no se pudo re-fetch el issue (%v) — revisá labels a mano\n", fetchErr)
+			return
+		}
+		if !current.HasLabel(labels.StatusExecuting) {
+			fmt.Fprintln(stderr, "rollback abortado: el issue ya no está en status:executing (owner=otro)")
+			return
+		}
 		if err := labels.Apply(issueRef, labels.StatusExecuting, labels.StatusPlan); err != nil {
 			fmt.Fprintf(stderr, "warning: rollback failed: %v — revisá labels del issue a mano\n", err)
 		}

--- a/internal/flow/execute/execute.go
+++ b/internal/flow/execute/execute.go
@@ -1,0 +1,962 @@
+// Package execute implements flow 03 — tomar un issue en status:plan, armar
+// un worktree aislado, invocar al agente para producir el diff, abrir/actualizar
+// un PR draft contra main y transicionar el issue a status:executed +
+// awaiting-human. La lógica vive acá (pura, testeable) para que el subcomando
+// `che execute` y la TUI compartan la misma implementación.
+//
+// NOTA: este paquete es deliberadamente una copia adaptada de
+// `internal/flow/explore/` (no reusa su plumbing todavía) — la deuda de
+// extraer lo común a `internal/flow/common/` queda para un issue futuro
+// cuando execute esté validado end-to-end contra un issue real.
+package execute
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/chichex/che/internal/labels"
+)
+
+// ExitCode es el código de salida semántico para el caller.
+type ExitCode int
+
+const (
+	ExitOK       ExitCode = 0
+	ExitRetry    ExitCode = 2 // error remediable (red, gh/git falla, rollback aplicado)
+	ExitSemantic ExitCode = 3 // ref vacío, issue sin ct:plan, ya ejecutándose, agente inválido
+)
+
+// Agent identifica qué ejecutor usar. Replica el enum de explore para no
+// acoplar los paquetes; cuando se extraiga `internal/flow/common/`, los dos
+// enums migran allá.
+type Agent string
+
+const (
+	AgentOpus   Agent = "opus"
+	AgentCodex  Agent = "codex"
+	AgentGemini Agent = "gemini"
+)
+
+const DefaultAgent = AgentOpus
+
+var ValidAgents = []Agent{AgentOpus, AgentCodex, AgentGemini}
+
+// Binary devuelve el nombre del ejecutable correspondiente al agente.
+func (a Agent) Binary() string {
+	switch a {
+	case AgentOpus:
+		return "claude"
+	case AgentCodex:
+		return "codex"
+	case AgentGemini:
+		return "gemini"
+	}
+	return ""
+}
+
+// InvokeArgs devuelve los args de línea de comando para cada CLI en modo
+// no-interactivo.
+func (a Agent) InvokeArgs(prompt string) []string {
+	switch a {
+	case AgentOpus:
+		return []string{"-p", prompt, "--output-format", "text"}
+	case AgentCodex:
+		return []string{"exec", "--full-auto", prompt}
+	case AgentGemini:
+		return []string{"-p", prompt}
+	}
+	return nil
+}
+
+// ParseAgent normaliza un string a Agent.
+func ParseAgent(s string) (Agent, error) {
+	s = strings.ToLower(strings.TrimSpace(s))
+	for _, a := range ValidAgents {
+		if string(a) == s {
+			return a, nil
+		}
+	}
+	return "", fmt.Errorf("unknown agent %q; valid: opus, codex, gemini", s)
+}
+
+// AgentTimeout para llamadas al CLI del agente. execute tiene un default
+// mayor que explore porque generar diff + tool use es típicamente más largo
+// que devolver un JSON de análisis.
+var AgentTimeout = func() time.Duration {
+	if s := strings.TrimSpace(os.Getenv("CHE_EXEC_AGENT_TIMEOUT_SECS")); s != "" {
+		if n, err := time.ParseDuration(s + "s"); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 15 * time.Minute
+}()
+
+// Opts agrupa los writers, la callback de progreso y el agente ejecutor.
+type Opts struct {
+	Stdout     io.Writer
+	Stderr     io.Writer
+	OnProgress func(string)
+	Agent      Agent
+	// Validators son los agentes que postean findings en el PR después de
+	// crearlo. execute NO espera por ellos (fire-and-forget).
+	Validators []Validator
+	// SkipValidators puede usarse en tests/CI para omitir el disparo de
+	// validadores aunque se hayan pasado en Validators.
+	SkipValidators bool
+}
+
+// Validator es una re-declaración del enum de explore para no acoplar los
+// paquetes. Instance permite repetir tipo (codex×2) aunque execute en v1 no
+// lo requiera; queda para futuro.
+type Validator struct {
+	Agent    Agent
+	Instance int
+}
+
+// ParseValidators parsea "codex,gemini" o "none".
+func ParseValidators(s string) ([]Validator, error) {
+	s = strings.TrimSpace(s)
+	if s == "" || strings.EqualFold(s, "none") {
+		return nil, nil
+	}
+	parts := strings.Split(s, ",")
+	if len(parts) < 1 || len(parts) > 3 {
+		return nil, fmt.Errorf("validators: need 1-3 items (or `none`), got %d", len(parts))
+	}
+	counts := map[Agent]int{}
+	out := make([]Validator, 0, len(parts))
+	for _, p := range parts {
+		a, err := ParseAgent(p)
+		if err != nil {
+			return nil, fmt.Errorf("validators: %w", err)
+		}
+		counts[a]++
+		out = append(out, Validator{Agent: a, Instance: counts[a]})
+	}
+	return out, nil
+}
+
+// Issue modela el subset del output de `gh issue view --json ...`.
+type Issue struct {
+	Number int     `json:"number"`
+	Title  string  `json:"title"`
+	Body   string  `json:"body"`
+	URL    string  `json:"url"`
+	State  string  `json:"state"`
+	Labels []Label `json:"labels"`
+}
+
+type Label struct {
+	Name string `json:"name"`
+}
+
+func (i *Issue) HasLabel(name string) bool {
+	for _, l := range i.Labels {
+		if l.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// Candidate es la vista mínima usada por la TUI al listar issues.
+type Candidate struct {
+	Number int
+	Title  string
+}
+
+// ConsolidatedPlan es el subset del body consolidado que execute usa para
+// armar el prompt del ejecutor. Mantiene los mismos nombres que
+// explore.ConsolidatedPlan pero evita importar explore para no acoplar.
+type ConsolidatedPlan struct {
+	Summary            string
+	Goal               string
+	AcceptanceCriteria []string
+	Approach           string
+	Steps              []string
+	OutOfScope         []string
+}
+
+// Run ejecuta el flow completo sobre un issue. Decisiones claves:
+//   - Preflight: repo git + gh auth + gh pr list (scope check).
+//   - Transition status:plan → status:executing (lock).
+//   - Crear worktree .worktrees/issue-N sobre branch exec/N-<slug>.
+//   - Invocar agente, commit en el worktree, push.
+//   - Crear o actualizar PR draft contra main con Closes #<n>.
+//   - Fire-and-forget validadores sobre el diff del PR.
+//   - Transition status:executing → status:executed + awaiting-human.
+//   - Comentario al issue con link al PR.
+//   - Rollback: si algo falla después del lock, revertir a status:plan y
+//     limpiar worktree.
+func Run(issueRef string, opts Opts) ExitCode {
+	stdout, stderr := opts.Stdout, opts.Stderr
+	progress := opts.OnProgress
+	if progress == nil {
+		progress = func(string) {}
+	}
+
+	issueRef = strings.TrimSpace(issueRef)
+	if issueRef == "" {
+		fmt.Fprintln(stderr, "error: issue ref is empty")
+		return ExitSemantic
+	}
+
+	agent := opts.Agent
+	if agent == "" {
+		agent = DefaultAgent
+	}
+	if agent.Binary() == "" {
+		fmt.Fprintf(stderr, "error: unknown agent %q\n", agent)
+		return ExitSemantic
+	}
+
+	progress("chequeando repo git y auth de GitHub…")
+	repoRoot, err := repoToplevel()
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitRetry
+	}
+	if err := precheckGitHubRemote(); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitRetry
+	}
+	if err := precheckGhAuth(); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitRetry
+	}
+	if err := precheckPRScopes(); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitRetry
+	}
+
+	progress("obteniendo issue desde GitHub…")
+	issue, err := fetchIssue(issueRef)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: fetching issue: %v\n", err)
+		return ExitRetry
+	}
+
+	if err := gate(issue); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitSemantic
+	}
+
+	plan, err := parseConsolidatedPlan(issue.Body)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitSemantic
+	}
+
+	// Transition plan → executing. Desde acá se lockea el issue.
+	progress("transicionando issue a status:executing…")
+	if err := labels.Apply(issueRef, labels.StatusPlan, labels.StatusExecuting); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitRetry
+	}
+
+	// Defer de rollback: si algo falla, volver a plan.
+	var (
+		succeeded bool
+		wt        *Worktree
+	)
+	defer func() {
+		if succeeded {
+			return
+		}
+		if wt != nil {
+			_ = wt.Cleanup(repoRoot, false)
+		}
+		if err := labels.Apply(issueRef, labels.StatusExecuting, labels.StatusPlan); err != nil {
+			fmt.Fprintf(stderr, "warning: rollback failed: %v — revisá labels del issue a mano\n", err)
+		}
+	}()
+
+	slug := Slugify(issue.Title)
+	progress(fmt.Sprintf("creando worktree .worktrees/issue-%d (branch exec/%d-%s)…", issue.Number, issue.Number, slug))
+	wt, err = CreateWorktree(WorktreeOpts{
+		RepoRoot: repoRoot,
+		IssueNum: issue.Number,
+		Slug:     slug,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitRetry
+	}
+
+	// Antes de invocar al agente, chequeamos si ya hay un PR abierto para
+	// esta branch — si lo hay, estamos en modo "re-ejecutar" (idempotente)
+	// y vamos a actualizarlo después de pushear los nuevos commits.
+	existingPR, err := findOpenPRForBranch(wt.Branch)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitRetry
+	}
+
+	progress(fmt.Sprintf("invocando a %s en el worktree…", agent))
+	if err := runAgent(agent, wt.Path, buildPrompt(issue, plan), progress); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitRetry
+	}
+
+	progress("chequeando cambios en el worktree…")
+	hasChanges, err := worktreeHasChanges(wt.Path)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitRetry
+	}
+	if !hasChanges && existingPR == "" {
+		fmt.Fprintf(stderr, "error: agente terminó sin cambios en el worktree y no hay PR existente — nada que commitear\n")
+		return ExitRetry
+	}
+
+	if hasChanges {
+		progress("armando commit en el worktree…")
+		if err := commitAll(wt.Path, fmt.Sprintf("feat(#%d): %s\n\nCloses #%d", issue.Number, issue.Title, issue.Number)); err != nil {
+			fmt.Fprintf(stderr, "error: %v\n", err)
+			return ExitRetry
+		}
+
+		progress("pusheando branch " + wt.Branch + "…")
+		if err := pushBranch(wt.Path, wt.Branch); err != nil {
+			fmt.Fprintf(stderr, "error: %v\n", err)
+			return ExitRetry
+		}
+	}
+
+	var prURL string
+	if existingPR != "" {
+		progress("actualizando PR existente " + existingPR + "…")
+		prURL = existingPR
+	} else {
+		progress("creando PR draft contra main…")
+		prURL, err = createDraftPR(wt.Path, wt.Branch, issue)
+		if err != nil {
+			fmt.Fprintf(stderr, "error: %v\n", err)
+			return ExitRetry
+		}
+	}
+
+	// Disparar validadores (fire-and-forget). NO esperamos por ellos.
+	if !opts.SkipValidators && len(opts.Validators) > 0 {
+		progress(fmt.Sprintf("disparando %d validador(es) sobre el PR…", len(opts.Validators)))
+		fireValidators(prURL, issue, plan, opts.Validators)
+	}
+
+	progress("transicionando issue a status:executed + awaiting-human…")
+	if err := labels.Apply(issueRef, labels.StatusExecuting, labels.StatusExecuted); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return ExitRetry
+	}
+
+	progress("posteando comment en el issue con link al PR…")
+	if err := commentIssue(issueRef, renderIssueComment(prURL, opts.Validators)); err != nil {
+		// No es fatal — ya hicimos todo el trabajo. Lo logueamos y seguimos.
+		fmt.Fprintf(stderr, "warning: no se pudo comentar el issue: %v\n", err)
+	}
+
+	succeeded = true
+	fmt.Fprintf(stdout, "Executed %s\n", issue.URL)
+	fmt.Fprintf(stdout, "PR: %s\n", prURL)
+	fmt.Fprintln(stdout, "Done.")
+	return ExitOK
+}
+
+// ListCandidates devuelve los issues abiertos con ct:plan + status:plan que
+// no tienen awaiting-human. Estos son los candidatos a ejecutar.
+func ListCandidates() ([]Candidate, error) {
+	cmd := exec.Command("gh", "issue", "list",
+		"--label", "ct:plan",
+		"--label", "status:plan",
+		"--state", "open",
+		"--json", "number,title,labels",
+		"--limit", "50")
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("gh issue list: %s", strings.TrimSpace(string(ee.Stderr)))
+		}
+		return nil, err
+	}
+	var raw []Issue
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("parse gh issue list output: %w", err)
+	}
+	out2 := make([]Candidate, 0, len(raw))
+	for _, i := range raw {
+		if i.HasLabel(labels.StatusAwaitingHuman) {
+			continue
+		}
+		out2 = append(out2, Candidate{Number: i.Number, Title: i.Title})
+	}
+	return out2, nil
+}
+
+// ---- prechecks ----
+
+func repoToplevel() (string, error) {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", fmt.Errorf("git repo: not inside a git repository")
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func precheckGitHubRemote() error {
+	out, err := exec.Command("git", "remote", "get-url", "origin").Output()
+	if err != nil {
+		return fmt.Errorf("github remote: no origin configured")
+	}
+	url := strings.TrimSpace(string(out))
+	if !strings.Contains(url, "github.com") {
+		return fmt.Errorf("github remote: origin is not github.com: %s", url)
+	}
+	return nil
+}
+
+func precheckGhAuth() error {
+	out, err := exec.Command("gh", "auth", "status").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh auth: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// precheckPRScopes verifica que el token de gh tenga permisos para listar
+// PRs (proxy razonable para "puede crear PRs"). Un fallo acá es accionable:
+// el usuario sabe que tiene que `gh auth refresh -s repo`.
+func precheckPRScopes() error {
+	cmd := exec.Command("gh", "pr", "list", "--limit", "1", "--json", "number")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("gh pr list (scope check): %s — probá `gh auth refresh -s repo`", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// ---- issue fetch / gate ----
+
+func fetchIssue(ref string) (*Issue, error) {
+	cmd := exec.Command("gh", "issue", "view", ref,
+		"--json", "number,title,body,labels,url,state")
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("gh issue view: %s", strings.TrimSpace(string(ee.Stderr)))
+		}
+		return nil, err
+	}
+	var issue Issue
+	if err := json.Unmarshal(out, &issue); err != nil {
+		return nil, fmt.Errorf("parse gh issue view output: %w", err)
+	}
+	return &issue, nil
+}
+
+// gate valida las precondiciones para ejecutar:
+//   - Issue OPEN.
+//   - Tiene label ct:plan.
+//   - Tiene label status:plan.
+//   - NO tiene label status:awaiting-human (hay algo humano sin resolver).
+//   - NO tiene label status:executing (hay otro run en curso o quedó colgado).
+func gate(i *Issue) error {
+	if i.State != "OPEN" {
+		return fmt.Errorf("issue #%d is closed", i.Number)
+	}
+	if !i.HasLabel(labels.CtPlan) {
+		return fmt.Errorf("issue #%d is missing label ct:plan (not created by `che idea`?)", i.Number)
+	}
+	if i.HasLabel(labels.StatusExecuting) {
+		return fmt.Errorf("issue #%d is already status:executing — otro run en curso o quedó colgado; quitá el label a mano si es lo segundo", i.Number)
+	}
+	if i.HasLabel(labels.StatusAwaitingHuman) {
+		return fmt.Errorf("issue #%d tiene status:awaiting-human — resolvé primero lo que falta antes de ejecutar", i.Number)
+	}
+	if !i.HasLabel(labels.StatusPlan) {
+		return fmt.Errorf("issue #%d is not status:plan — corré `che explore %d` primero", i.Number, i.Number)
+	}
+	return nil
+}
+
+// ---- parseo del plan consolidado ----
+
+// parseConsolidatedPlan extrae las secciones del body consolidado que escribe
+// `che explore`. Es tolerante: si la sección "Plan consolidado" no existe,
+// arma un plan con summary=body y todas las demás secciones vacías — el
+// agente puede trabajar con eso aunque sea menos guiado.
+func parseConsolidatedPlan(body string) (*ConsolidatedPlan, error) {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return nil, fmt.Errorf("issue body is empty")
+	}
+
+	// Si no hay header de plan consolidado, devolvemos fallback.
+	if !strings.Contains(body, "## Plan consolidado") {
+		return &ConsolidatedPlan{Summary: body}, nil
+	}
+
+	// Extrae cada sección buscando headers conocidos.
+	p := &ConsolidatedPlan{}
+	if v := extractSection(body, "## Plan consolidado"); v != "" {
+		// La primera línea suele ser "**Resumen:** ..."
+		if idx := strings.Index(v, "**Resumen:**"); idx >= 0 {
+			rest := v[idx+len("**Resumen:**"):]
+			if nl := strings.Index(rest, "\n\n"); nl >= 0 {
+				p.Summary = strings.TrimSpace(rest[:nl])
+			} else {
+				p.Summary = strings.TrimSpace(rest)
+			}
+		}
+		if idx := strings.Index(v, "**Goal:**"); idx >= 0 {
+			rest := v[idx+len("**Goal:**"):]
+			if nl := strings.Index(rest, "\n\n"); nl >= 0 {
+				p.Goal = strings.TrimSpace(rest[:nl])
+			} else {
+				p.Goal = strings.TrimSpace(rest)
+			}
+		}
+	}
+	if v := extractSection(body, "### Criterios de aceptación"); v != "" {
+		p.AcceptanceCriteria = parseChecklist(v)
+	}
+	if v := extractSection(body, "### Approach"); v != "" {
+		p.Approach = strings.TrimSpace(v)
+	}
+	if v := extractSection(body, "### Pasos"); v != "" {
+		p.Steps = parseNumbered(v)
+	}
+	if v := extractSection(body, "### Fuera de alcance"); v != "" {
+		p.OutOfScope = parseBullets(v)
+	}
+
+	if p.Summary == "" && p.Goal == "" && len(p.Steps) == 0 {
+		return nil, fmt.Errorf("issue body has a '## Plan consolidado' header but no parseable content — revisá que `che explore` haya terminado bien")
+	}
+
+	return p, nil
+}
+
+// extractSection devuelve el texto entre un header (ej. "## X") y el próximo
+// header de nivel <= al del header dado. Devuelve "" si no encuentra.
+func extractSection(body, header string) string {
+	idx := strings.Index(body, header)
+	if idx < 0 {
+		return ""
+	}
+	rest := body[idx+len(header):]
+	// Busca el próximo "#..." a principio de línea.
+	lines := strings.Split(rest, "\n")
+	var out []string
+	// Determinar el nivel del header (# count).
+	level := 0
+	for _, c := range header {
+		if c == '#' {
+			level++
+		} else {
+			break
+		}
+	}
+	for i, line := range lines {
+		if i == 0 {
+			out = append(out, line)
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") {
+			// Contar nivel.
+			n := 0
+			for _, c := range trimmed {
+				if c == '#' {
+					n++
+				} else {
+					break
+				}
+			}
+			if n > 0 && n <= level {
+				break
+			}
+		}
+		out = append(out, line)
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
+}
+
+// parseChecklist extrae items de un bloque "- [ ] foo\n- [ ] bar".
+var checklistRe = regexp.MustCompile(`^\s*-\s*\[.\]\s*(.+)$`)
+
+func parseChecklist(s string) []string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		if m := checklistRe.FindStringSubmatch(line); m != nil {
+			out = append(out, strings.TrimSpace(m[1]))
+		}
+	}
+	return out
+}
+
+// parseNumbered extrae items de "1. foo\n2. bar".
+var numberedRe = regexp.MustCompile(`^\s*\d+\.\s+(.+)$`)
+
+func parseNumbered(s string) []string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		if m := numberedRe.FindStringSubmatch(line); m != nil {
+			out = append(out, strings.TrimSpace(m[1]))
+		}
+	}
+	return out
+}
+
+// parseBullets extrae items de "- foo\n- bar".
+var bulletRe = regexp.MustCompile(`^\s*-\s+(.+)$`)
+
+func parseBullets(s string) []string {
+	var out []string
+	for _, line := range strings.Split(s, "\n") {
+		if m := bulletRe.FindStringSubmatch(line); m != nil {
+			text := strings.TrimSpace(m[1])
+			// Saltarse checklist items que ya matchean el otro regex.
+			if !strings.HasPrefix(text, "[") {
+				out = append(out, text)
+			}
+		}
+	}
+	return out
+}
+
+// ---- prompt builder ----
+
+func buildPrompt(issue *Issue, plan *ConsolidatedPlan) string {
+	var sb strings.Builder
+	sb.WriteString(`Sos un ingeniero senior ejecutando un plan ya consolidado. Tenés acceso al filesystem del worktree actual — tu tarea es implementar el plan editando archivos directamente.
+
+Reglas:
+1. Trabajá SOLO dentro del scope del plan. No toques cosas que estén explícitamente fuera de alcance.
+2. Si el plan dice "crear archivo X", creá X. Si dice "modificar Y", modificá Y.
+3. Usá tus herramientas de edición de archivos (Read/Write/Edit) para aplicar los cambios.
+4. No commitees — eso lo hace el harness después. Tu único trabajo es dejar el worktree con los cambios listos.
+5. Si al final hay cosas del plan que no pudiste hacer (falta info, dependencia bloqueada), dejá un archivo `)
+	sb.WriteString("`EXEC_NOTES.md`")
+	sb.WriteString(` con lo que quedó pendiente — esa info va al PR body.
+
+Issue #`)
+	sb.WriteString(fmt.Sprint(issue.Number))
+	sb.WriteString(`:
+Título: ` + issue.Title + `
+
+`)
+	if plan.Summary != "" {
+		sb.WriteString("## Resumen del plan\n" + plan.Summary + "\n\n")
+	}
+	if plan.Goal != "" {
+		sb.WriteString("## Goal\n" + plan.Goal + "\n\n")
+	}
+	if len(plan.AcceptanceCriteria) > 0 {
+		sb.WriteString("## Criterios de aceptación\n")
+		for _, c := range plan.AcceptanceCriteria {
+			sb.WriteString("- " + c + "\n")
+		}
+		sb.WriteString("\n")
+	}
+	if plan.Approach != "" {
+		sb.WriteString("## Approach\n" + plan.Approach + "\n\n")
+	}
+	if len(plan.Steps) > 0 {
+		sb.WriteString("## Pasos\n")
+		for i, s := range plan.Steps {
+			sb.WriteString(fmt.Sprintf("%d. %s\n", i+1, s))
+		}
+		sb.WriteString("\n")
+	}
+	if len(plan.OutOfScope) > 0 {
+		sb.WriteString("## Fuera de alcance (NO toques esto)\n")
+		for _, s := range plan.OutOfScope {
+			sb.WriteString("- " + s + "\n")
+		}
+		sb.WriteString("\n")
+	}
+	sb.WriteString("Arrancá. Cuando termines, el harness va a chequear el diff y crear el PR.\n")
+	return sb.String()
+}
+
+// ---- agente runner ----
+
+// runAgent invoca al CLI del agente con el prompt construido, corriendo con
+// cwd en el worktree para que cualquier herramienta de file edit afecte ese
+// directorio. Usa StdoutPipe + streaming igual que explore.
+func runAgent(agent Agent, cwd, prompt string, progress func(string)) error {
+	ctx, cancel := context.WithTimeout(context.Background(), AgentTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, agent.Binary(), agent.InvokeArgs(prompt)...)
+	cmd.Dir = cwd
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting %s: %w", agent.Binary(), err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	var stderrBuf strings.Builder
+	go streamPipe(&wg, stdoutPipe, nil, progress, string(agent)+": ")
+	go streamPipe(&wg, stderrPipe, &stderrBuf, progress, string(agent)+" stderr: ")
+	wg.Wait()
+
+	waitErr := cmd.Wait()
+	if ctx.Err() == context.DeadlineExceeded {
+		return fmt.Errorf("%s timed out after %s", agent, AgentTimeout)
+	}
+	if waitErr != nil {
+		if ee, ok := waitErr.(*exec.ExitError); ok {
+			return fmt.Errorf("%s exit %d: %s", agent, ee.ExitCode(), strings.TrimSpace(stderrBuf.String()))
+		}
+		return waitErr
+	}
+	return nil
+}
+
+// streamPipe lee un pipe y reenvía las líneas al progress con un prefix.
+func streamPipe(wg *sync.WaitGroup, r io.Reader, acc *strings.Builder, progress func(string), prefix string) {
+	defer wg.Done()
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if acc != nil {
+			acc.WriteString(line + "\n")
+		}
+		if strings.TrimSpace(line) != "" && progress != nil {
+			progress(prefix + line)
+		}
+	}
+}
+
+// ---- git ops sobre el worktree ----
+
+// worktreeHasChanges devuelve true si `git status --porcelain` devuelve
+// líneas (es decir, hay archivos modificados/nuevos).
+func worktreeHasChanges(wtPath string) (bool, error) {
+	cmd := exec.Command("git", "-C", wtPath, "status", "--porcelain")
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return false, fmt.Errorf("git status: %s", strings.TrimSpace(string(ee.Stderr)))
+		}
+		return false, err
+	}
+	return strings.TrimSpace(string(out)) != "", nil
+}
+
+// commitAll hace `git add -A && git commit -F <tmp>` en el worktree.
+func commitAll(wtPath, message string) error {
+	if err := runGitIn(wtPath, "add", "-A"); err != nil {
+		return err
+	}
+	tmpDir, err := os.MkdirTemp("", "che-exec-commit-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+	msgFile := filepath.Join(tmpDir, "msg.txt")
+	if err := os.WriteFile(msgFile, []byte(message), 0o644); err != nil {
+		return err
+	}
+	if err := runGitIn(wtPath, "commit", "-F", msgFile); err != nil {
+		return err
+	}
+	return nil
+}
+
+// pushBranch empuja la branch a origin. Usa --force-with-lease para
+// re-ejecuciones idempotentes (caso de actualizar un PR existente) sin
+// pisar cambios ajenos.
+func pushBranch(wtPath, branch string) error {
+	if err := runGitIn(wtPath, "push", "--force-with-lease", "--set-upstream", "origin", branch); err != nil {
+		return err
+	}
+	return nil
+}
+
+func runGitIn(dir string, args ...string) error {
+	full := append([]string{"-C", dir}, args...)
+	cmd := exec.Command("git", full...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git %s: %s", strings.Join(args, " "), strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// ---- PR ops ----
+
+// findOpenPRForBranch busca un PR abierto cuyo head-branch sea el dado.
+// Devuelve la URL si lo encuentra, "" si no. Cualquier error de gh (red,
+// permisos) se propaga.
+func findOpenPRForBranch(branch string) (string, error) {
+	cmd := exec.Command("gh", "pr", "list", "--head", branch, "--state", "open", "--json", "url,number")
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("gh pr list: %s", strings.TrimSpace(string(ee.Stderr)))
+		}
+		return "", err
+	}
+	var prs []struct {
+		URL    string `json:"url"`
+		Number int    `json:"number"`
+	}
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return "", fmt.Errorf("parse gh pr list: %w", err)
+	}
+	if len(prs) == 0 {
+		return "", nil
+	}
+	return prs[0].URL, nil
+}
+
+// createDraftPR crea un PR draft contra main con Closes #<n> en el body.
+func createDraftPR(wtPath, branch string, issue *Issue) (string, error) {
+	tmpDir, err := os.MkdirTemp("", "che-exec-pr-*")
+	if err != nil {
+		return "", err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	body := fmt.Sprintf("Implementa el plan consolidado de #%d.\n\nCloses #%d\n", issue.Number, issue.Number)
+	bodyFile := filepath.Join(tmpDir, "pr-body.md")
+	if err := os.WriteFile(bodyFile, []byte(body), 0o644); err != nil {
+		return "", err
+	}
+
+	title := fmt.Sprintf("feat(#%d): %s", issue.Number, issue.Title)
+
+	cmd := exec.Command("gh", "pr", "create",
+		"--draft",
+		"--base", "main",
+		"--head", branch,
+		"--title", title,
+		"--body-file", bodyFile)
+	cmd.Dir = wtPath
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("gh pr create: %s", strings.TrimSpace(string(ee.Stderr)))
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// ---- validadores (fire-and-forget) ----
+
+// fireValidators lanza una goroutine por validator que invoca al agente con
+// el prompt de validación de diff y postea el resultado como PR comment.
+// NO esperamos: la función retorna inmediatamente.
+func fireValidators(prURL string, issue *Issue, plan *ConsolidatedPlan, validators []Validator) {
+	for _, v := range validators {
+		v := v
+		go func() {
+			prompt := buildValidatorPrompt(issue, plan)
+			ctx, cancel := context.WithTimeout(context.Background(), AgentTimeout)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, v.Agent.Binary(), v.Agent.InvokeArgs(prompt)...)
+			out, _ := cmd.Output()
+			body := fmt.Sprintf("## Validator %s#%d\n\n%s\n", v.Agent, v.Instance, strings.TrimSpace(string(out)))
+			_ = postPRComment(prURL, body)
+		}()
+	}
+}
+
+func buildValidatorPrompt(issue *Issue, plan *ConsolidatedPlan) string {
+	var sb strings.Builder
+	sb.WriteString("Sos un validador técnico senior. Un agente acaba de implementar un plan y abrió un PR draft. Tu tarea es revisarlo y marcar problemas — NO reimplementar nada.\n\n")
+	sb.WriteString("Chequeá específicamente:\n")
+	sb.WriteString("1. ¿El diff cubre los criterios de aceptación del plan?\n")
+	sb.WriteString("2. ¿Hay regresiones obvias, tests faltantes, o quebró builds?\n")
+	sb.WriteString("3. ¿Se metió con cosas fuera del scope del plan?\n\n")
+	sb.WriteString(fmt.Sprintf("Issue #%d — %s\n\n", issue.Number, issue.Title))
+	if plan.Summary != "" {
+		sb.WriteString("## Resumen del plan\n" + plan.Summary + "\n\n")
+	}
+	if len(plan.AcceptanceCriteria) > 0 {
+		sb.WriteString("## Criterios de aceptación\n")
+		for _, c := range plan.AcceptanceCriteria {
+			sb.WriteString("- " + c + "\n")
+		}
+		sb.WriteString("\n")
+	}
+	sb.WriteString("Podés ver el diff del PR corriendo `gh pr diff " + issue.URL + "` — revisalo y devolvé un resumen en markdown con hallazgos numerados.\n")
+	return sb.String()
+}
+
+// postPRComment postea un comment en el PR via `gh pr comment <url>`.
+func postPRComment(prURL, body string) error {
+	tmpDir, err := os.MkdirTemp("", "che-exec-prc-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+	bodyFile := filepath.Join(tmpDir, "body.md")
+	if err := os.WriteFile(bodyFile, []byte(body), 0o644); err != nil {
+		return err
+	}
+	cmd := exec.Command("gh", "pr", "comment", prURL, "--body-file", bodyFile)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh pr comment: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// ---- issue comment al final ----
+
+func renderIssueComment(prURL string, validators []Validator) string {
+	var sb strings.Builder
+	sb.WriteString("<!-- claude-cli: flow=execute role=pr-link -->\n")
+	sb.WriteString("## Ejecución completada\n\n")
+	sb.WriteString("Se abrió un PR draft con los cambios:\n\n")
+	sb.WriteString("- PR: " + prURL + "\n\n")
+	if len(validators) > 0 {
+		sb.WriteString("Los siguientes validadores están corriendo sobre el diff:\n")
+		for _, v := range validators {
+			sb.WriteString(fmt.Sprintf("- %s#%d\n", v.Agent, v.Instance))
+		}
+		sb.WriteString("\nSus findings van a aparecer como comments del PR (no de este issue).\n\n")
+	}
+	sb.WriteString("El issue quedó en `status:executed` + `status:awaiting-human` — revisá el PR + CI y mergealo cuando esté listo.\n")
+	return sb.String()
+}
+
+func commentIssue(ref, body string) error {
+	tmpDir, err := os.MkdirTemp("", "che-exec-ic-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+	bodyFile := filepath.Join(tmpDir, "body.md")
+	if err := os.WriteFile(bodyFile, []byte(body), 0o644); err != nil {
+		return err
+	}
+	cmd := exec.Command("gh", "issue", "comment", ref, "--body-file", bodyFile)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh issue comment: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/flow/execute/execute.go
+++ b/internal/flow/execute/execute.go
@@ -504,15 +504,55 @@ func precheckGhAuth() error {
 	return nil
 }
 
-// precheckPRScopes verifica que el token de gh tenga permisos para listar
-// PRs (proxy razonable para "puede crear PRs"). Un fallo acá es accionable:
-// el usuario sabe que tiene que `gh auth refresh -s repo`.
+// precheckPRScopes verifica que el token de gh tenga un scope que permita
+// crear PRs: 'repo' (privados + públicos) o 'public_repo' (sólo públicos).
+// El chequeo se hace parseando `gh auth status -t`, que imprime el token y
+// los scopes concedidos en stderr. Antes se usaba `gh pr list --limit 1`,
+// que sólo requiere scope read — un token read-only pasaba el precheck y
+// fallaba tarde en `gh pr create`, después de gastar tokens LLM y pushear.
 func precheckPRScopes() error {
-	cmd := exec.Command("gh", "pr", "list", "--limit", "1", "--json", "number")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("gh pr list (scope check): %s — probá `gh auth refresh -s repo`", strings.TrimSpace(string(out)))
+	cmd := exec.Command("gh", "auth", "status", "-t")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh auth status: %s — probá `gh auth login`", strings.TrimSpace(string(out)))
+	}
+	if !hasRepoScope(string(out)) {
+		return fmt.Errorf("el token de gh no tiene scope 'repo' o 'public_repo'; ejecutá `gh auth refresh -s repo` y reintentá")
 	}
 	return nil
+}
+
+// hasRepoScope busca 'repo' o 'public_repo' en la lista de scopes que
+// imprime `gh auth status -t`. La línea típica es:
+//
+//	- Token scopes: 'gist', 'read:org', 'repo', 'workflow'
+//
+// Matcheamos con word boundaries para no confundir 'repo' con 'repo:status'
+// (que es un scope menos privilegiado).
+func hasRepoScope(out string) bool {
+	// Normalizamos: buscamos líneas que contengan "Token scopes:" o
+	// "scopes:" (el formato exacto puede variar entre versiones de gh).
+	for _, line := range strings.Split(out, "\n") {
+		lower := strings.ToLower(line)
+		if !strings.Contains(lower, "scopes") {
+			continue
+		}
+		// Parseamos los scopes individuales separados por coma.
+		// Cada scope viene como 'nombre' (con comillas). Limpiamos las
+		// comillas y chequeamos igualdad exacta.
+		for _, raw := range strings.Split(line, ",") {
+			tok := strings.TrimSpace(raw)
+			tok = strings.Trim(tok, "'\"")
+			// quedarnos con el pedacito después del último ":" o espacio
+			if idx := strings.LastIndexAny(tok, ": "); idx >= 0 {
+				tok = strings.Trim(tok[idx+1:], "'\"")
+			}
+			if tok == "repo" || tok == "public_repo" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // ---- issue fetch / gate ----

--- a/internal/flow/execute/execute_test.go
+++ b/internal/flow/execute/execute_test.go
@@ -2,10 +2,19 @@ package execute
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 	"time"
 )
+
+// writeExecutable escribe un script y lo marca ejecutable (0o755).
+func writeExecutable(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o755)
+}
+
+func getEnv(k string) string  { return os.Getenv(k) }
+func setEnv(k, v string) error { return os.Setenv(k, v) }
 
 func TestParseConsolidatedPlan_FullBody(t *testing.T) {
 	body := `## Plan consolidado (post-exploración)
@@ -296,6 +305,63 @@ func TestWaitValidators_AllFinish(t *testing.T) {
 	}
 	if strings.Contains(out, "timeout:") {
 		t.Errorf("unexpected timeout message: %s", out)
+	}
+}
+
+// TestFindOpenPRForBranch_MultipleMatches: si gh pr list devuelve >1 PRs,
+// findOpenPRForBranch debe fallar con un mensaje accionable en vez de
+// agarrar el primero silenciosamente. Usamos un PATH temporal con un
+// script shell que simula gh — es más barato que armar un harness acá.
+func TestFindOpenPRForBranch_MultipleMatches(t *testing.T) {
+	tmp := t.TempDir()
+	fakeGH := tmp + "/gh"
+	script := `#!/bin/sh
+cat <<EOF
+[{"url":"https://github.com/acme/demo/pull/10","number":10},{"url":"https://github.com/acme/demo/pull/11","number":11}]
+EOF
+`
+	if err := writeExecutable(fakeGH, script); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	// Prepend tmp al PATH.
+	oldPath := getEnv("PATH")
+	setEnv("PATH", tmp+":"+oldPath)
+	t.Cleanup(func() { setEnv("PATH", oldPath) })
+
+	_, err := findOpenPRForBranch("exec/42-foo")
+	if err == nil {
+		t.Fatalf("expected error on multiple matches")
+	}
+	if !strings.Contains(err.Error(), "múltiples PRs") {
+		t.Errorf("wrong error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "pull/10") || !strings.Contains(err.Error(), "pull/11") {
+		t.Errorf("error should include both URLs: %v", err)
+	}
+}
+
+// TestFindOpenPRForBranch_SingleMatch: caso feliz — 1 PR, devuelve la URL.
+func TestFindOpenPRForBranch_SingleMatch(t *testing.T) {
+	tmp := t.TempDir()
+	fakeGH := tmp + "/gh"
+	script := `#!/bin/sh
+cat <<EOF
+[{"url":"https://github.com/acme/demo/pull/7","number":7}]
+EOF
+`
+	if err := writeExecutable(fakeGH, script); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	oldPath := getEnv("PATH")
+	setEnv("PATH", tmp+":"+oldPath)
+	t.Cleanup(func() { setEnv("PATH", oldPath) })
+
+	got, err := findOpenPRForBranch("exec/42-foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "https://github.com/acme/demo/pull/7" {
+		t.Errorf("unexpected URL: %q", got)
 	}
 }
 

--- a/internal/flow/execute/execute_test.go
+++ b/internal/flow/execute/execute_test.go
@@ -308,6 +308,84 @@ func TestWaitValidators_AllFinish(t *testing.T) {
 	}
 }
 
+// TestHasRepoScope_RepoPresent: scope 'repo' → pass.
+func TestHasRepoScope_RepoPresent(t *testing.T) {
+	out := "github.com\n  - Token: gho_xxx\n  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'\n"
+	if !hasRepoScope(out) {
+		t.Fatalf("expected repo scope to be detected in:\n%s", out)
+	}
+}
+
+// TestHasRepoScope_PublicRepoPresent: scope 'public_repo' → pass.
+func TestHasRepoScope_PublicRepoPresent(t *testing.T) {
+	out := "github.com\n  - Token scopes: 'gist', 'public_repo'\n"
+	if !hasRepoScope(out) {
+		t.Fatalf("expected public_repo scope to be detected in:\n%s", out)
+	}
+}
+
+// TestHasRepoScope_OnlyReadScopes: sin repo/public_repo, falla.
+func TestHasRepoScope_OnlyReadScopes(t *testing.T) {
+	out := "github.com\n  - Token scopes: 'read:org', 'read:user', 'repo:status'\n"
+	if hasRepoScope(out) {
+		t.Fatalf("unexpectedly accepted scopes without repo:\n%s", out)
+	}
+}
+
+// TestHasRepoScope_EmptyOutput: output vacío → falla.
+func TestHasRepoScope_EmptyOutput(t *testing.T) {
+	if hasRepoScope("") {
+		t.Fatal("expected false for empty output")
+	}
+}
+
+// TestPrecheckPRScopes_FakeGH_Pass: integración liviana — scripteamos un gh
+// fake que devuelve scopes válidos. precheckPRScopes debe pasar.
+func TestPrecheckPRScopes_FakeGH_Pass(t *testing.T) {
+	tmp := t.TempDir()
+	fakeGH := tmp + "/gh"
+	script := `#!/bin/sh
+echo "github.com"
+echo "  - Token: gho_xxx"
+echo "  - Token scopes: 'gist', 'read:org', 'repo', 'workflow'"
+`
+	if err := writeExecutable(fakeGH, script); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	oldPath := getEnv("PATH")
+	setEnv("PATH", tmp+":"+oldPath)
+	t.Cleanup(func() { setEnv("PATH", oldPath) })
+
+	if err := precheckPRScopes(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+}
+
+// TestPrecheckPRScopes_FakeGH_MissingScope: gh fake sin repo/public_repo →
+// error accionable.
+func TestPrecheckPRScopes_FakeGH_MissingScope(t *testing.T) {
+	tmp := t.TempDir()
+	fakeGH := tmp + "/gh"
+	script := `#!/bin/sh
+echo "github.com"
+echo "  - Token scopes: 'read:org', 'repo:status'"
+`
+	if err := writeExecutable(fakeGH, script); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	oldPath := getEnv("PATH")
+	setEnv("PATH", tmp+":"+oldPath)
+	t.Cleanup(func() { setEnv("PATH", oldPath) })
+
+	err := precheckPRScopes()
+	if err == nil {
+		t.Fatal("expected error on missing scope")
+	}
+	if !strings.Contains(err.Error(), "gh auth refresh -s repo") {
+		t.Errorf("expected actionable hint, got: %v", err)
+	}
+}
+
 // TestFindOpenPRForBranch_MultipleMatches: si gh pr list devuelve >1 PRs,
 // findOpenPRForBranch debe fallar con un mensaje accionable en vez de
 // agarrar el primero silenciosamente. Usamos un PATH temporal con un

--- a/internal/flow/execute/execute_test.go
+++ b/internal/flow/execute/execute_test.go
@@ -1,8 +1,10 @@
 package execute
 
 import (
+	"bytes"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestParseConsolidatedPlan_FullBody(t *testing.T) {
@@ -267,5 +269,56 @@ func TestExtractSection_IncludesDeeperHeaders(t *testing.T) {
 	got := extractSection(body, "## Plan consolidado")
 	if !strings.Contains(got, "### Criterios") {
 		t.Errorf("should include ### children: %q", got)
+	}
+}
+
+// TestWaitValidators_AllFinish: el wait drena N señales y retorna sin timeout,
+// emitiendo progreso acumulativo a stdout.
+func TestWaitValidators_AllFinish(t *testing.T) {
+	done := make(chan int, 2)
+	// Simulamos 2 validadores terminando en 10ms/20ms.
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		done <- 0
+		time.Sleep(10 * time.Millisecond)
+		done <- 1
+	}()
+	var buf bytes.Buffer
+	start := time.Now()
+	waitValidators(&buf, done, 2, 5*time.Second)
+	elapsed := time.Since(start)
+	if elapsed > 2*time.Second {
+		t.Fatalf("waitValidators took too long: %v", elapsed)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "(1/2)") || !strings.Contains(out, "(2/2)") {
+		t.Errorf("expected progress 1/2 and 2/2, got:\n%s", out)
+	}
+	if strings.Contains(out, "timeout:") {
+		t.Errorf("unexpected timeout message: %s", out)
+	}
+}
+
+// TestWaitValidators_Timeout: si el timeout expira antes de que terminen
+// todos, retorna sin bloquear y loguea cuántos quedaron.
+func TestWaitValidators_Timeout(t *testing.T) {
+	done := make(chan int, 2)
+	// Solo 1 de 2 termina dentro del timeout.
+	go func() {
+		done <- 0
+	}()
+	var buf bytes.Buffer
+	start := time.Now()
+	waitValidators(&buf, done, 2, 50*time.Millisecond)
+	elapsed := time.Since(start)
+	if elapsed > 1*time.Second {
+		t.Fatalf("waitValidators did not respect timeout: %v", elapsed)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "timeout:") {
+		t.Errorf("expected timeout message, got:\n%s", out)
+	}
+	if !strings.Contains(out, "1/2") {
+		t.Errorf("expected 1/2 completaron, got:\n%s", out)
 	}
 }

--- a/internal/flow/execute/execute_test.go
+++ b/internal/flow/execute/execute_test.go
@@ -1,0 +1,271 @@
+package execute
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseConsolidatedPlan_FullBody(t *testing.T) {
+	body := `## Plan consolidado (post-exploración)
+
+**Resumen:** Agregar comando che execute.
+
+**Goal:** Un desarrollador selecciona un issue y che execute lo ejecuta end-to-end.
+
+### Criterios de aceptación
+- [ ] che execute registrado como subcomando cobra
+- [ ] La TUI lista solo issues con ct:plan + status:plan
+- [ ] No tocar explore
+
+### Approach
+Construir execute como copia adaptada de explore.
+
+### Pasos
+1. Crear internal/flow/execute
+2. Wirear cmd/execute.go
+3. Agregar tests e2e
+
+### Fuera de alcance
+- Ciclo iter con scope-lock
+- Workflow GHA
+
+---
+
+## Idea original
+
+Lorem ipsum
+`
+	p, err := parseConsolidatedPlan(body)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if p.Summary != "Agregar comando che execute." {
+		t.Errorf("summary: %q", p.Summary)
+	}
+	if !strings.Contains(p.Goal, "end-to-end") {
+		t.Errorf("goal: %q", p.Goal)
+	}
+	if len(p.AcceptanceCriteria) != 3 {
+		t.Errorf("criteria: got %d items: %v", len(p.AcceptanceCriteria), p.AcceptanceCriteria)
+	}
+	if p.AcceptanceCriteria[0] != "che execute registrado como subcomando cobra" {
+		t.Errorf("criteria[0]: %q", p.AcceptanceCriteria[0])
+	}
+	if !strings.Contains(p.Approach, "copia adaptada") {
+		t.Errorf("approach: %q", p.Approach)
+	}
+	if len(p.Steps) != 3 {
+		t.Errorf("steps: got %d: %v", len(p.Steps), p.Steps)
+	}
+	if p.Steps[0] != "Crear internal/flow/execute" {
+		t.Errorf("steps[0]: %q", p.Steps[0])
+	}
+	if len(p.OutOfScope) != 2 {
+		t.Errorf("out_of_scope: got %d: %v", len(p.OutOfScope), p.OutOfScope)
+	}
+}
+
+func TestParseConsolidatedPlan_FallbackWhenNoHeader(t *testing.T) {
+	body := "Body sin plan consolidado, solo texto libre."
+	p, err := parseConsolidatedPlan(body)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if p.Summary != body {
+		t.Errorf("expected summary=body")
+	}
+	if p.Goal != "" || len(p.Steps) != 0 {
+		t.Errorf("expected empty goal/steps in fallback")
+	}
+}
+
+func TestParseConsolidatedPlan_EmptyBody(t *testing.T) {
+	if _, err := parseConsolidatedPlan(""); err == nil {
+		t.Fatalf("expected error on empty body")
+	}
+}
+
+func TestParseConsolidatedPlan_HeaderButNoContent(t *testing.T) {
+	body := "## Plan consolidado\n\n(lorem sin sub-secciones parseables)\n"
+	if _, err := parseConsolidatedPlan(body); err == nil {
+		t.Fatalf("expected error when sections missing")
+	}
+}
+
+func TestGate(t *testing.T) {
+	cases := []struct {
+		name    string
+		issue   Issue
+		wantErr string
+	}{
+		{
+			name: "ok",
+			issue: Issue{Number: 1, State: "OPEN", Labels: []Label{
+				{Name: "ct:plan"}, {Name: "status:plan"},
+			}},
+			wantErr: "",
+		},
+		{
+			name:    "closed",
+			issue:   Issue{Number: 1, State: "CLOSED"},
+			wantErr: "closed",
+		},
+		{
+			name:    "missing ct:plan",
+			issue:   Issue{Number: 1, State: "OPEN", Labels: []Label{{Name: "status:plan"}}},
+			wantErr: "ct:plan",
+		},
+		{
+			name: "executing lock",
+			issue: Issue{Number: 1, State: "OPEN", Labels: []Label{
+				{Name: "ct:plan"}, {Name: "status:executing"},
+			}},
+			wantErr: "executing",
+		},
+		{
+			name: "awaiting-human",
+			issue: Issue{Number: 1, State: "OPEN", Labels: []Label{
+				{Name: "ct:plan"}, {Name: "status:plan"}, {Name: "status:awaiting-human"},
+			}},
+			wantErr: "awaiting-human",
+		},
+		{
+			name: "not plan",
+			issue: Issue{Number: 1, State: "OPEN", Labels: []Label{
+				{Name: "ct:plan"}, {Name: "status:idea"},
+			}},
+			wantErr: "not status:plan",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := gate(&c.issue)
+			if c.wantErr == "" {
+				if err != nil {
+					t.Errorf("unexpected err: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q", c.wantErr)
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Errorf("err %q missing %q", err.Error(), c.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseAgent(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    Agent
+		wantErr bool
+	}{
+		{"opus", AgentOpus, false},
+		{"codex", AgentCodex, false},
+		{"gemini", AgentGemini, false},
+		{"OPUS", AgentOpus, false},
+		{"  codex  ", AgentCodex, false},
+		{"foo", "", true},
+		{"", "", true},
+	}
+	for _, c := range cases {
+		got, err := ParseAgent(c.in)
+		if (err != nil) != c.wantErr {
+			t.Errorf("ParseAgent(%q): err=%v wantErr=%v", c.in, err, c.wantErr)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("ParseAgent(%q): got %v want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParseValidators(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantLen int
+		wantErr bool
+	}{
+		{"", 0, false},
+		{"none", 0, false},
+		{"NONE", 0, false},
+		{"codex", 1, false},
+		{"codex,gemini", 2, false},
+		{"codex,codex,gemini", 3, false},
+		{"foo", 0, true},
+		{"codex,codex,codex,codex", 0, true},
+	}
+	for _, c := range cases {
+		got, err := ParseValidators(c.in)
+		if (err != nil) != c.wantErr {
+			t.Errorf("ParseValidators(%q): err=%v wantErr=%v", c.in, err, c.wantErr)
+			continue
+		}
+		if len(got) != c.wantLen {
+			t.Errorf("ParseValidators(%q): got %d items", c.in, len(got))
+		}
+	}
+	// Dedupe de instances:
+	got, _ := ParseValidators("codex,codex,gemini")
+	if got[0].Instance != 1 || got[1].Instance != 2 || got[2].Instance != 1 {
+		t.Errorf("instances wrong: %+v", got)
+	}
+}
+
+func TestBuildPromptIncludesPlanSections(t *testing.T) {
+	issue := &Issue{Number: 42, Title: "Implementar foo"}
+	plan := &ConsolidatedPlan{
+		Summary:            "Resumen X",
+		Goal:               "Goal X",
+		AcceptanceCriteria: []string{"crit 1", "crit 2"},
+		Approach:           "approach X",
+		Steps:              []string{"step 1", "step 2"},
+		OutOfScope:         []string{"oos 1"},
+	}
+	got := buildPrompt(issue, plan)
+	for _, need := range []string{
+		"Issue #42", "Implementar foo",
+		"Resumen X", "Goal X",
+		"crit 1", "crit 2",
+		"approach X",
+		"step 1", "step 2",
+		"oos 1",
+		"EXEC_NOTES.md",
+	} {
+		if !strings.Contains(got, need) {
+			t.Errorf("prompt missing %q", need)
+		}
+	}
+}
+
+func TestExtractSection_StopsAtNextSameLevelHeader(t *testing.T) {
+	body := `## A
+foo
+bar
+
+## B
+quux
+`
+	got := extractSection(body, "## A")
+	if strings.Contains(got, "quux") {
+		t.Errorf("section A should not include B: %q", got)
+	}
+	if !strings.Contains(got, "foo") || !strings.Contains(got, "bar") {
+		t.Errorf("section A missing content: %q", got)
+	}
+}
+
+func TestExtractSection_IncludesDeeperHeaders(t *testing.T) {
+	body := `## Plan consolidado
+**Resumen:** r
+
+### Criterios
+- [ ] crit
+`
+	got := extractSection(body, "## Plan consolidado")
+	if !strings.Contains(got, "### Criterios") {
+		t.Errorf("should include ### children: %q", got)
+	}
+}

--- a/internal/flow/execute/worktree.go
+++ b/internal/flow/execute/worktree.go
@@ -2,6 +2,7 @@ package execute
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
@@ -94,14 +95,38 @@ func CreateWorktree(opts WorktreeOpts) (*Worktree, error) {
 		return &Worktree{Path: path, Branch: branch}, nil
 	}
 
-	// Worktree no existe. Primero fetch de la base para tener la referencia
-	// actualizada. Si hay remote `origin`, actualizamos; si no, no rompemos
-	// (puede ser un repo local sin remote — caso de tests).
-	_ = runGit(opts.RepoRoot, "fetch", "origin", base)
+	// Worktree no existe. Fetch obligatorio de la base desde origin para no
+	// partir de un main local stale (si la branch nueva se crea a partir de
+	// un main viejo, el PR queda con commits obsoletos). Override con
+	// CHE_EXEC_SKIP_FETCH=1 para tests e2e con bare remotes locales.
+	skipFetch := os.Getenv("CHE_EXEC_SKIP_FETCH") == "1"
+	if !skipFetch {
+		if err := runGit(opts.RepoRoot, "fetch", "origin", base); err != nil {
+			return nil, fmt.Errorf("git fetch origin %s: %w — para tests con bare remotes locales setear CHE_EXEC_SKIP_FETCH=1", base, err)
+		}
+	}
 
 	branchExists, err := branchExists(opts.RepoRoot, branch)
 	if err != nil {
 		return nil, err
+	}
+
+	// Ref desde la que partir para nuevas branches: preferimos origin/<base>
+	// (el estado real del remote tras el fetch) antes que el <base> local,
+	// que puede estar stale. Si no hay origin/<base> (repo sin ese ref),
+	// fallback al local.
+	startRef := "origin/" + base
+	hasRemoteBase, refErr := hasRef(opts.RepoRoot, startRef)
+	if refErr != nil {
+		return nil, refErr
+	}
+	if !hasRemoteBase {
+		// Si el usuario pidió saltar el fetch (tests), no emitimos el
+		// warning — es esperable que origin/<base> no exista.
+		if !skipFetch {
+			fmt.Fprintf(os.Stderr, "warning: %s no existe, cayendo a %s local (puede estar stale)\n", startRef, base)
+		}
+		startRef = base
 	}
 
 	if branchExists {
@@ -110,12 +135,26 @@ func CreateWorktree(opts WorktreeOpts) (*Worktree, error) {
 			return nil, fmt.Errorf("git worktree add (existing branch): %w", err)
 		}
 	} else {
-		if err := runGit(opts.RepoRoot, "worktree", "add", "-b", branch, path, base); err != nil {
+		if err := runGit(opts.RepoRoot, "worktree", "add", "-b", branch, path, startRef); err != nil {
 			return nil, fmt.Errorf("git worktree add: %w", err)
 		}
 	}
 
 	return &Worktree{Path: path, Branch: branch}, nil
+}
+
+// hasRef devuelve true si la referencia git existe en el repo.
+func hasRef(repoRoot, ref string) (bool, error) {
+	cmd := exec.Command("git", "-C", repoRoot, "rev-parse", "--verify", "--quiet", ref)
+	if err := cmd.Run(); err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			if ee.ExitCode() == 1 {
+				return false, nil
+			}
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 // Cleanup elimina el worktree y (si keepBranch=false) borra la branch local.

--- a/internal/flow/execute/worktree.go
+++ b/internal/flow/execute/worktree.go
@@ -1,0 +1,229 @@
+package execute
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Worktree representa un git worktree aislado creado por `che execute` para
+// trabajar un issue sin ensuciar el cwd del usuario. Contiene la ruta
+// absoluta del worktree, el nombre de la branch creada y un closure de
+// cleanup para liberarlo.
+type Worktree struct {
+	Path    string
+	Branch  string
+	cleaned bool
+}
+
+// WorktreeOpts controla la creación del worktree. RepoRoot es la raíz del
+// repositorio donde va a vivir el directorio .worktrees (típicamente el cwd
+// del usuario detectado por `git rev-parse --show-toplevel`). BaseBranch es
+// la branch desde la que se parte (default: main). Si IssueNum o Slug están
+// vacíos, devuelve error — la combinación es parte de la convención.
+type WorktreeOpts struct {
+	RepoRoot   string
+	IssueNum   int
+	Slug       string
+	BaseBranch string // default: "main"
+}
+
+// slugRe colapsa caracteres no ASCII/no alfanuméricos a "-" para producir
+// nombres de branch/path válidos y cortos.
+var slugRe = regexp.MustCompile(`[^a-z0-9]+`)
+
+// Slugify convierte un título libre a un slug apto para nombres de branch y
+// paths. Lowercase + colapsa todo lo no alfanumérico a "-", recorta hyphens
+// al principio/final y limita a 40 chars para no desbordar nombres de
+// branches en GitHub.
+func Slugify(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	s = slugRe.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	if len(s) > 40 {
+		s = strings.TrimRight(s[:40], "-")
+	}
+	if s == "" {
+		return "issue"
+	}
+	return s
+}
+
+// CreateWorktree crea (o reutiliza) un worktree aislado en
+// <repoRoot>/.worktrees/issue-<N> sobre la branch exec/<N>-<slug>. Si el
+// worktree ya existe apuntando a la misma branch, lo reutiliza — eso
+// habilita re-ejecuciones idempotentes. Si la branch existe pero en otro
+// lado, devuelve error para evitar apropiarse de algo del usuario.
+//
+// Flujo:
+//  1. Chequea que RepoRoot sea el toplevel de un repo git.
+//  2. Mira si el worktree ya existe en la ruta esperada; si sí y apunta a la
+//     branch esperada, reutilizar.
+//  3. Si la branch existe pero el worktree no, `git worktree add` reusando
+//     la branch.
+//  4. Si ni branch ni worktree existen, `git worktree add -b <branch>
+//     <path> <base>` (crea branch desde base actualizada).
+func CreateWorktree(opts WorktreeOpts) (*Worktree, error) {
+	if opts.IssueNum <= 0 {
+		return nil, fmt.Errorf("worktree: issue number must be > 0")
+	}
+	if strings.TrimSpace(opts.Slug) == "" {
+		return nil, fmt.Errorf("worktree: slug is required")
+	}
+	if strings.TrimSpace(opts.RepoRoot) == "" {
+		return nil, fmt.Errorf("worktree: repo root is required")
+	}
+	base := opts.BaseBranch
+	if base == "" {
+		base = "main"
+	}
+
+	path := filepath.Join(opts.RepoRoot, ".worktrees", fmt.Sprintf("issue-%d", opts.IssueNum))
+	branch := fmt.Sprintf("exec/%d-%s", opts.IssueNum, opts.Slug)
+
+	existing, err := worktreeAt(opts.RepoRoot, path)
+	if err != nil {
+		return nil, err
+	}
+	if existing != "" {
+		if existing != branch {
+			return nil, fmt.Errorf("worktree %s already exists on branch %q, expected %q — remove manually with `git worktree remove %s`", path, existing, branch, path)
+		}
+		return &Worktree{Path: path, Branch: branch}, nil
+	}
+
+	// Worktree no existe. Primero fetch de la base para tener la referencia
+	// actualizada. Si hay remote `origin`, actualizamos; si no, no rompemos
+	// (puede ser un repo local sin remote — caso de tests).
+	_ = runGit(opts.RepoRoot, "fetch", "origin", base)
+
+	branchExists, err := branchExists(opts.RepoRoot, branch)
+	if err != nil {
+		return nil, err
+	}
+
+	if branchExists {
+		// Reuse branch (caso: re-ejecutar después de borrar worktree a mano).
+		if err := runGit(opts.RepoRoot, "worktree", "add", path, branch); err != nil {
+			return nil, fmt.Errorf("git worktree add (existing branch): %w", err)
+		}
+	} else {
+		if err := runGit(opts.RepoRoot, "worktree", "add", "-b", branch, path, base); err != nil {
+			return nil, fmt.Errorf("git worktree add: %w", err)
+		}
+	}
+
+	return &Worktree{Path: path, Branch: branch}, nil
+}
+
+// Cleanup elimina el worktree y (si keepBranch=false) borra la branch local.
+// Idempotente: llamar dos veces no es error.
+func (w *Worktree) Cleanup(repoRoot string, keepBranch bool) error {
+	if w == nil || w.cleaned {
+		return nil
+	}
+	w.cleaned = true
+
+	// Intentamos remove; si falla (worktree ya no existía), no reportamos
+	// error fatal — el objetivo es dejar todo limpio.
+	_ = runGit(repoRoot, "worktree", "remove", "--force", w.Path)
+
+	if !keepBranch {
+		_ = runGit(repoRoot, "branch", "-D", w.Branch)
+	}
+	return nil
+}
+
+// worktreeAt devuelve la branch actualmente checkouteada en un path si hay
+// un worktree registrado ahí, o "" si no hay. Parsea la salida de
+// `git worktree list --porcelain`. Normaliza paths con EvalSymlinks porque
+// en macOS los TMPDIR pueden venir con prefijo /private/var vs /var y git
+// imprime siempre la forma resuelta.
+func worktreeAt(repoRoot, path string) (string, error) {
+	out, err := exec.Command("git", "-C", repoRoot, "worktree", "list", "--porcelain").Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("git worktree list: %s", strings.TrimSpace(string(ee.Stderr)))
+		}
+		return "", err
+	}
+	target := canonicalPath(path)
+	var currentPath, currentBranch string
+	lines := strings.Split(string(out), "\n")
+	check := func() string {
+		if canonicalPath(currentPath) == target {
+			return currentBranch
+		}
+		return ""
+	}
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			if b := check(); currentPath != "" && canonicalPath(currentPath) == target {
+				return b, nil
+			}
+			currentPath, currentBranch = "", ""
+			continue
+		}
+		if strings.HasPrefix(trimmed, "worktree ") {
+			currentPath = strings.TrimPrefix(trimmed, "worktree ")
+		} else if strings.HasPrefix(trimmed, "branch ") {
+			currentBranch = strings.TrimPrefix(trimmed, "branch refs/heads/")
+		}
+	}
+	if b := check(); currentPath != "" && b != "" || canonicalPath(currentPath) == target {
+		return currentBranch, nil
+	}
+	return "", nil
+}
+
+// canonicalPath resuelve symlinks para comparar paths robustamente. Si el
+// path no existe (todavía no fue creado) cae a filepath.Clean.
+func canonicalPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	// Intenta resolver el padre si el path no existe, así matcheamos cuando
+	// comparamos la ruta a crear contra una ya creada con prefijo distinto.
+	dir, base := filepath.Split(p)
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		return filepath.Join(resolved, base)
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return filepath.Clean(p)
+	}
+	return abs
+}
+
+
+// branchExists devuelve true si la referencia local existe.
+func branchExists(repoRoot, branch string) (bool, error) {
+	cmd := exec.Command("git", "-C", repoRoot, "rev-parse", "--verify", "--quiet", "refs/heads/"+branch)
+	if err := cmd.Run(); err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			if ee.ExitCode() == 1 {
+				return false, nil
+			}
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// runGit corre `git -C repoRoot args...` y devuelve error con stderr si
+// falla. stdout no se captura — los comandos que usamos no lo necesitan.
+func runGit(repoRoot string, args ...string) error {
+	full := append([]string{"-C", repoRoot}, args...)
+	cmd := exec.Command("git", full...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git %s: %s", strings.Join(args, " "), strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/flow/execute/worktree_test.go
+++ b/internal/flow/execute/worktree_test.go
@@ -1,0 +1,142 @@
+package execute
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSlugify(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"Comando che execute con flujo tipo explore", "comando-che-execute-con-flujo-tipo-explo"}, // trim a 40 chars
+		{"  Hello  WORLD  ", "hello-world"},
+		{"a/b/c", "a-b-c"},
+		{"", "issue"},
+		{"---", "issue"},
+		{"con acentos: implementación", "con-acentos-implementaci-n"},
+		{strings.Repeat("a", 50), strings.Repeat("a", 40)},
+	}
+	for _, c := range cases {
+		if got := Slugify(c.in); got != c.want {
+			t.Errorf("Slugify(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// setupTempRepo inicializa un repo git vacío con un commit inicial en main y
+// un remote local que apunta al mismo repo, devolviendo la ruta raíz.
+func setupTempRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	runOrFail(t, root, "git", "init", "-q", "-b", "main")
+	runOrFail(t, root, "git", "config", "user.email", "test@example.com")
+	runOrFail(t, root, "git", "config", "user.name", "Test")
+	readme := filepath.Join(root, "README.md")
+	if err := os.WriteFile(readme, []byte("hello\n"), 0o644); err != nil {
+		t.Fatalf("write readme: %v", err)
+	}
+	runOrFail(t, root, "git", "add", "README.md")
+	runOrFail(t, root, "git", "commit", "-q", "-m", "initial")
+	return root
+}
+
+func runOrFail(t *testing.T, dir, bin string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(bin, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %v: %v\n%s", bin, args, err, out)
+	}
+}
+
+func TestCreateWorktree_GoldenPath(t *testing.T) {
+	root := setupTempRepo(t)
+	wt, err := CreateWorktree(WorktreeOpts{
+		RepoRoot: root, IssueNum: 42, Slug: "my-feature",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if wt.Branch != "exec/42-my-feature" {
+		t.Errorf("branch: got %q", wt.Branch)
+	}
+	expectedPath := filepath.Join(root, ".worktrees", "issue-42")
+	if wt.Path != expectedPath {
+		t.Errorf("path: got %q want %q", wt.Path, expectedPath)
+	}
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Errorf("worktree dir not created: %v", err)
+	}
+	// Cleanup lo deja sin worktree y sin branch.
+	if err := wt.Cleanup(root, false); err != nil {
+		t.Fatalf("cleanup: %v", err)
+	}
+	if _, err := os.Stat(expectedPath); !os.IsNotExist(err) {
+		t.Errorf("worktree dir still exists after cleanup: %v", err)
+	}
+}
+
+func TestCreateWorktree_ReusesExistingSameBranch(t *testing.T) {
+	root := setupTempRepo(t)
+	first, err := CreateWorktree(WorktreeOpts{RepoRoot: root, IssueNum: 7, Slug: "x"})
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	second, err := CreateWorktree(WorktreeOpts{RepoRoot: root, IssueNum: 7, Slug: "x"})
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+	if first.Path != second.Path || first.Branch != second.Branch {
+		t.Errorf("expected same worktree on reuse: first=%+v second=%+v", first, second)
+	}
+	// cleanup sólo una vez, no doble.
+	_ = first.Cleanup(root, false)
+}
+
+func TestCreateWorktree_RejectsDivergentBranch(t *testing.T) {
+	root := setupTempRepo(t)
+	// Armamos un worktree "a mano" apuntando a otra branch.
+	otherBranch := "exec/7-zzz"
+	otherPath := filepath.Join(root, ".worktrees", "issue-7")
+	runOrFail(t, root, "git", "worktree", "add", "-b", otherBranch, otherPath, "main")
+	_, err := CreateWorktree(WorktreeOpts{RepoRoot: root, IssueNum: 7, Slug: "aaa"})
+	if err == nil {
+		t.Fatalf("expected error when worktree exists with different branch")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("unexpected error msg: %v", err)
+	}
+}
+
+func TestCreateWorktree_ReusesExistingBranchWithoutWorktree(t *testing.T) {
+	root := setupTempRepo(t)
+	// Creamos la branch pero no el worktree.
+	runOrFail(t, root, "git", "branch", "exec/9-foo", "main")
+	wt, err := CreateWorktree(WorktreeOpts{RepoRoot: root, IssueNum: 9, Slug: "foo"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if wt.Branch != "exec/9-foo" {
+		t.Errorf("branch: got %q", wt.Branch)
+	}
+	_ = wt.Cleanup(root, false)
+}
+
+func TestCreateWorktree_InvalidInputs(t *testing.T) {
+	cases := []WorktreeOpts{
+		{RepoRoot: "/tmp", IssueNum: 0, Slug: "x"},
+		{RepoRoot: "/tmp", IssueNum: 1, Slug: ""},
+		{RepoRoot: "", IssueNum: 1, Slug: "x"},
+	}
+	for _, c := range cases {
+		if _, err := CreateWorktree(c); err == nil {
+			t.Errorf("expected error for %+v", c)
+		}
+	}
+}

--- a/internal/flow/execute/worktree_test.go
+++ b/internal/flow/execute/worktree_test.go
@@ -29,9 +29,11 @@ func TestSlugify(t *testing.T) {
 }
 
 // setupTempRepo inicializa un repo git vacío con un commit inicial en main y
-// un remote local que apunta al mismo repo, devolviendo la ruta raíz.
+// un remote local que apunta al mismo repo, devolviendo la ruta raíz. Setea
+// CHE_EXEC_SKIP_FETCH=1 porque estos tests no tienen origin configurado.
 func setupTempRepo(t *testing.T) string {
 	t.Helper()
+	t.Setenv("CHE_EXEC_SKIP_FETCH", "1")
 	root := t.TempDir()
 	runOrFail(t, root, "git", "init", "-q", "-b", "main")
 	runOrFail(t, root, "git", "config", "user.email", "test@example.com")
@@ -140,3 +142,87 @@ func TestCreateWorktree_InvalidInputs(t *testing.T) {
 		}
 	}
 }
+
+// TestCreateWorktree_FetchesOriginMainAndUsesRemoteRef: sin
+// CHE_EXEC_SKIP_FETCH, CreateWorktree debe hacer `git fetch origin main`
+// y crear la branch desde `origin/main` (no desde `main` local). Armamos
+// un setup con un bare remote local y un main remoto que tiene un commit
+// que no está en el main local — la branch nueva debería apuntar al head
+// remoto, no al local.
+func TestCreateWorktree_FetchesOriginMainAndUsesRemoteRef(t *testing.T) {
+	// No seteamos CHE_EXEC_SKIP_FETCH — queremos que el fetch ocurra.
+	// Unset defensivo por si el parent suite lo seteó.
+	t.Setenv("CHE_EXEC_SKIP_FETCH", "")
+
+	base := t.TempDir()
+	// Bare remote.
+	bare := filepath.Join(base, "origin.git")
+	runOrFail(t, "", "git", "init", "--bare", "-b", "main", "-q", bare)
+
+	// Clone A: inicializamos sin clone porque bare está vacío — usamos
+	// un repo standalone + remote add + push.
+	cloneA := filepath.Join(base, "a")
+	runOrFail(t, "", "git", "init", "-b", "main", "-q", cloneA)
+	runOrFail(t, cloneA, "git", "config", "user.email", "a@example.com")
+	runOrFail(t, cloneA, "git", "config", "user.name", "A")
+	runOrFail(t, cloneA, "git", "remote", "add", "origin", bare)
+	if err := os.WriteFile(filepath.Join(cloneA, "a.txt"), []byte("a1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runOrFail(t, cloneA, "git", "add", "a.txt")
+	runOrFail(t, cloneA, "git", "commit", "-q", "-m", "a1")
+	runOrFail(t, cloneA, "git", "push", "-q", "-u", "origin", "main")
+
+	// Repo bajo test: clone del bare, luego añadimos un commit remoto desde A
+	// que el repo local aún no ha fetcheado.
+	root := filepath.Join(base, "repo")
+	runOrFail(t, "", "git", "clone", "-q", bare, root)
+	runOrFail(t, root, "git", "config", "user.email", "test@example.com")
+	runOrFail(t, root, "git", "config", "user.name", "Test")
+
+	// Nuevo commit en A → push al bare. El repo local (root) aún no lo tiene.
+	if err := os.WriteFile(filepath.Join(cloneA, "a.txt"), []byte("a2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runOrFail(t, cloneA, "git", "commit", "-aq", "-m", "a2-remote")
+	runOrFail(t, cloneA, "git", "push", "-q", "origin", "main")
+
+	// Pre-check: el main local y el origin/main local (pre-fetch) apuntan
+	// al commit viejo (a1) — porque root fue clonado antes del segundo
+	// push desde A. El bare ya tiene a2.
+	localHead := mustRevParse(t, root, "HEAD")
+	remoteCommitInBare := mustRevParse(t, bare, "refs/heads/main")
+	if localHead == remoteCommitInBare {
+		t.Fatal("setup inválido: local y bare apuntan al mismo commit")
+	}
+
+	// CreateWorktree debe hacer fetch + usar origin/main (que ahora tiene a2).
+	wt, err := CreateWorktree(WorktreeOpts{
+		RepoRoot: root, IssueNum: 42, Slug: "fetch-test",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	defer wt.Cleanup(root, false)
+
+	// La branch debe apuntar al mismo commit que origin/main (el nuevo a2).
+	branchHead := mustRevParse(t, root, wt.Branch)
+	remoteHead := mustRevParse(t, root, "origin/main")
+	if branchHead != remoteHead {
+		t.Errorf("branch head %s != origin/main head %s — indicates the worktree was created from stale local main", branchHead, remoteHead)
+	}
+	if branchHead == localHead {
+		t.Errorf("branch head matches stale local main (a1) instead of origin/main (a2)")
+	}
+}
+
+func mustRevParse(t *testing.T, dir, ref string) string {
+	t.Helper()
+	cmd := exec.Command("git", "-C", dir, "rev-parse", ref)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("rev-parse %s: %v\n%s", ref, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -1,0 +1,142 @@
+// Package labels centraliza las constantes de los labels que che aplica sobre
+// issues de GitHub, y la máquina de transiciones entre estados. La idea es
+// tener un único lugar donde definir "qué es status:plan", "cómo se pasa de
+// status:plan a status:executing", etc., para que los distintos flows no
+// inventen strings distintas ni violen reglas de la máquina de estados.
+//
+// Coexiste con los helpers duplicados de `internal/flow/idea/idea.go` y
+// `internal/flow/explore/explore.go` durante la introducción de `execute`; la
+// deuda de extraer esos usos acá queda para un issue futuro (ver issue #6
+// "Fuera de alcance").
+package labels
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Status labels que la máquina de estados de che maneja sobre cada issue.
+// Estos son los labels "mutables": cambian a medida que el issue avanza por
+// el embudo idea → explore → execute → close.
+const (
+	StatusIdea          = "status:idea"
+	StatusPlan          = "status:plan"
+	StatusExecuting     = "status:executing"
+	StatusExecuted      = "status:executed"
+	StatusAwaitingHuman = "status:awaiting-human"
+)
+
+// Marker labels que no cambian con el estado — identifican el origen del
+// issue dentro del workflow de che.
+const (
+	CtPlan = "ct:plan"
+)
+
+// Transition representa un cambio de estado expresado como labels a remover
+// y labels a agregar. El orden no importa: `gh issue edit` aplica todo en
+// una sola llamada.
+type Transition struct {
+	Remove []string
+	Add    []string
+}
+
+// validTransitions define la máquina de estados de execute. Las transiciones
+// del resto de los flows (explore) no están acá todavía — cuando se extraiga
+// `internal/flow/common/` esos usos deberían migrar a este paquete.
+//
+// Claves: "from→to". Si el state de origen puede venir con o sin
+// awaiting-human, se acepta cualquiera de los dos (las transiciones quitan
+// awaiting-human explícitamente cuando corresponde).
+var validTransitions = map[string]Transition{
+	// execute arranca: plan → executing (lock). Si había awaiting-human (por
+	// alguna razón excepcional: p.ej. revisión humana del plan después de
+	// consolidar) también se lo quitamos — execute asume que el plan está
+	// listo para ejecutar.
+	StatusPlan + "→" + StatusExecuting: {
+		Remove: []string{StatusPlan, StatusAwaitingHuman},
+		Add:    []string{StatusExecuting},
+	},
+	// execute termina OK: executing → executed + awaiting-human.
+	StatusExecuting + "→" + StatusExecuted: {
+		Remove: []string{StatusExecuting},
+		Add:    []string{StatusExecuted, StatusAwaitingHuman},
+	},
+	// rollback: executing → plan (cualquier fallo post-lock).
+	StatusExecuting + "→" + StatusPlan: {
+		Remove: []string{StatusExecuting, StatusAwaitingHuman},
+		Add:    []string{StatusPlan},
+	},
+}
+
+// TransitionFor devuelve la Transition que corresponde a pasar de `from` a
+// `to`. Si el par no está registrado como transición válida, error.
+func TransitionFor(from, to string) (Transition, error) {
+	key := from + "→" + to
+	tr, ok := validTransitions[key]
+	if !ok {
+		return Transition{}, fmt.Errorf("invalid transition: %s → %s", from, to)
+	}
+	return tr, nil
+}
+
+// Apply ejecuta la transición en un issue concreto. `ref` es el identificador
+// del issue en el formato que acepta `gh issue edit` (número, URL, o
+// owner/repo#N). Asegura que todos los labels a agregar existan antes de
+// aplicar el edit.
+func Apply(ref, from, to string) error {
+	tr, err := TransitionFor(from, to)
+	if err != nil {
+		return err
+	}
+	for _, lbl := range tr.Add {
+		if err := Ensure(lbl); err != nil {
+			return err
+		}
+	}
+	return applyTransition(ref, tr)
+}
+
+// Ensure garantiza que un label exista en el repo antes de aplicarlo. Usa
+// `gh label create --force` que es idempotente.
+func Ensure(name string) error {
+	cmd := exec.Command("gh", "label", "create", name, "--force")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("ensuring label %s: %s", name, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// EnsureAll es `Ensure` en lote, útil cuando un flow sabe de antemano todos
+// los labels que va a aplicar durante su ejecución.
+func EnsureAll(names ...string) error {
+	for _, n := range names {
+		if err := Ensure(n); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// applyTransition ejecuta la llamada `gh issue edit` con los flags de
+// remove/add. Si una transición no tiene labels que tocar (no debería pasar
+// en una transición válida, pero defendemos), devolvemos nil sin llamar a gh.
+func applyTransition(ref string, tr Transition) error {
+	if len(tr.Remove) == 0 && len(tr.Add) == 0 {
+		return nil
+	}
+	args := []string{"issue", "edit", ref}
+	for _, l := range tr.Remove {
+		args = append(args, "--remove-label", l)
+	}
+	for _, l := range tr.Add {
+		args = append(args, "--add-label", l)
+	}
+	cmd := exec.Command("gh", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh issue edit: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/labels/labels_test.go
+++ b/internal/labels/labels_test.go
@@ -1,0 +1,89 @@
+package labels
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestTransitionFor_Valid(t *testing.T) {
+	cases := []struct {
+		from, to string
+		wantAdd  []string
+		wantRem  []string
+	}{
+		{
+			from:    StatusPlan,
+			to:      StatusExecuting,
+			wantAdd: []string{StatusExecuting},
+			wantRem: []string{StatusPlan, StatusAwaitingHuman},
+		},
+		{
+			from:    StatusExecuting,
+			to:      StatusExecuted,
+			wantAdd: []string{StatusExecuted, StatusAwaitingHuman},
+			wantRem: []string{StatusExecuting},
+		},
+		{
+			from:    StatusExecuting,
+			to:      StatusPlan,
+			wantAdd: []string{StatusPlan},
+			wantRem: []string{StatusExecuting, StatusAwaitingHuman},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.from+"→"+c.to, func(t *testing.T) {
+			tr, err := TransitionFor(c.from, c.to)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !equal(tr.Add, c.wantAdd) {
+				t.Errorf("Add: got %v, want %v", tr.Add, c.wantAdd)
+			}
+			if !equal(tr.Remove, c.wantRem) {
+				t.Errorf("Remove: got %v, want %v", tr.Remove, c.wantRem)
+			}
+		})
+	}
+}
+
+func TestTransitionFor_Invalid(t *testing.T) {
+	cases := []struct {
+		from, to string
+	}{
+		{StatusIdea, StatusExecuting},     // no se puede saltar explore
+		{StatusExecuted, StatusPlan},      // no hay vuelta atrás desde executed
+		{StatusAwaitingHuman, StatusPlan}, // awaiting-human no es un estado "desde"
+		{"", StatusExecuting},             // from vacío
+		{StatusPlan, ""},                  // to vacío
+		{StatusPlan, "status:ready-to-close"}, // estado no soportado todavía
+	}
+	for _, c := range cases {
+		t.Run(c.from+"→"+c.to, func(t *testing.T) {
+			if _, err := TransitionFor(c.from, c.to); err == nil {
+				t.Fatalf("expected error for %q → %q", c.from, c.to)
+			}
+		})
+	}
+}
+
+func TestTransitionFor_ErrorMessage(t *testing.T) {
+	_, err := TransitionFor("foo", "bar")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), "foo") || !strings.Contains(err.Error(), "bar") {
+		t.Errorf("error should mention both states: %v", err)
+	}
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/chichex/che/internal/flow/execute"
 	"github.com/chichex/che/internal/flow/explore"
 	"github.com/chichex/che/internal/flow/idea"
 )
@@ -30,6 +31,10 @@ const (
 	screenExploreAgent
 	screenExploreValidators
 	screenExploreRunning
+	screenExecuteLoading
+	screenExecuteSelect
+	screenExecuteAgent
+	screenExecuteRunning
 	screenResult
 )
 
@@ -57,7 +62,7 @@ type menuItem struct {
 var menuItems = []menuItem{
 	{label: "Idea nueva", key: "1", action: screenIdeaInput},
 	{label: "Explorar", key: "2", action: screenExploreLoading},
-	{label: "Ejecutar", key: "3", disabled: true},
+	{label: "Ejecutar", key: "3", action: screenExecuteLoading},
 	{label: "Cerrar", key: "4", disabled: true},
 	{label: "Eliminar", key: "5", disabled: true},
 }
@@ -94,6 +99,13 @@ type Model struct {
 	exploreChosenAgent     explore.Agent
 	exploreValidatorCursor int
 	exploreValidatorCount  map[explore.Agent]int
+
+	// selector de execute: lista de issues en status:plan.
+	executeCandidates []execute.Candidate
+	executeCursor     int
+	executeChosenRef  string
+	executeAgentIdx   int
+	executeChosenAgent execute.Agent
 
 	// resultado final
 	resultLines []string
@@ -163,6 +175,15 @@ type exploreCandidatesLoadedMsg struct {
 	resumeItems []explore.Candidate
 	err         error
 }
+type executeCandidatesLoadedMsg struct {
+	items []execute.Candidate
+	err   error
+}
+type executeDoneMsg struct {
+	code   execute.ExitCode
+	stdout string
+	stderr string
+}
 type resumeInspectedMsg struct {
 	ref        string
 	agent      explore.Agent
@@ -186,6 +207,30 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case exploreDoneMsg:
 		return m.finishRun(int(msg.code), msg.code == explore.ExitOK, msg.stdout, msg.stderr), nil
+
+	case executeDoneMsg:
+		return m.finishRun(int(msg.code), msg.code == execute.ExitOK, msg.stdout, msg.stderr), nil
+
+	case executeCandidatesLoadedMsg:
+		if msg.err != nil {
+			m.screen = screenResult
+			m.resultOK = false
+			m.resultLines = []string{"error: " + msg.err.Error()}
+			return m, nil
+		}
+		if len(msg.items) == 0 {
+			m.screen = screenResult
+			m.resultOK = false
+			m.resultLines = []string{
+				"No hay issues con label ct:plan + status:plan listos para ejecutar.",
+				"Primero corré `che explore <issue>` sobre un issue en status:idea.",
+			}
+			return m, nil
+		}
+		m.executeCandidates = msg.items
+		m.executeCursor = 0
+		m.screen = screenExecuteSelect
+		return m, nil
 
 	case resumeInspectedMsg:
 		if msg.err != nil {
@@ -229,7 +274,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tickMsg:
-		if m.screen == screenIdeaRunning || m.screen == screenExploreRunning {
+		if m.screen == screenIdeaRunning || m.screen == screenExploreRunning || m.screen == screenExecuteRunning {
 			return m, tickCmd()
 		}
 		return m, nil
@@ -260,7 +305,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleMenuKey(msg)
 	case screenIdeaInput:
 		return m.handleIdeaInputKey(msg)
-	case screenIdeaRunning, screenExploreRunning, screenExploreLoading:
+	case screenIdeaRunning, screenExploreRunning, screenExploreLoading, screenExecuteRunning, screenExecuteLoading:
 		if msg.String() == "ctrl+c" {
 			return m, tea.Quit
 		}
@@ -271,6 +316,10 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleExploreAgentKey(msg)
 	case screenExploreValidators:
 		return m.handleExploreValidatorsKey(msg)
+	case screenExecuteSelect:
+		return m.handleExecuteSelectKey(msg)
+	case screenExecuteAgent:
+		return m.handleExecuteAgentKey(msg)
 	case screenResult:
 		return m.handleResultKey(msg)
 	}
@@ -316,8 +365,108 @@ func (m Model) activateCurrent() (tea.Model, tea.Cmd) {
 		m.exploreCursor = 0
 		m.exploreLoadErr = nil
 		return m, loadExploreCandidatesCmd()
+	case screenExecuteLoading:
+		m.screen = screenExecuteLoading
+		m.executeCandidates = nil
+		m.executeCursor = 0
+		return m, loadExecuteCandidatesCmd()
 	}
 	return m, nil
+}
+
+func loadExecuteCandidatesCmd() tea.Cmd {
+	return func() tea.Msg {
+		items, err := execute.ListCandidates()
+		return executeCandidatesLoadedMsg{items: items, err: err}
+	}
+}
+
+func (m Model) handleExecuteSelectKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	k := msg.String()
+	total := len(m.executeCandidates)
+	switch k {
+	case "esc":
+		m.screen = screenMenu
+		m.executeCandidates = nil
+		return m, nil
+	case "ctrl+c":
+		return m, tea.Quit
+	case "up", "k":
+		if total == 0 {
+			return m, nil
+		}
+		m.executeCursor = (m.executeCursor - 1 + total) % total
+		return m, nil
+	case "down", "j":
+		if total == 0 {
+			return m, nil
+		}
+		m.executeCursor = (m.executeCursor + 1) % total
+		return m, nil
+	case "enter":
+		if total == 0 {
+			return m, nil
+		}
+		chosen := m.executeCandidates[m.executeCursor]
+		m.executeChosenRef = fmt.Sprint(chosen.Number)
+		m.executeAgentIdx = 0
+		m.screen = screenExecuteAgent
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m Model) handleExecuteAgentKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	k := msg.String()
+	switch k {
+	case "esc":
+		m.screen = screenExecuteSelect
+		return m, nil
+	case "ctrl+c":
+		return m, tea.Quit
+	case "up", "k":
+		m.executeAgentIdx = (m.executeAgentIdx - 1 + len(execute.ValidAgents)) % len(execute.ValidAgents)
+		return m, nil
+	case "down", "j":
+		m.executeAgentIdx = (m.executeAgentIdx + 1) % len(execute.ValidAgents)
+		return m, nil
+	case "enter":
+		m.executeChosenAgent = execute.ValidAgents[m.executeAgentIdx]
+		return m.startExecuteFlow(m.executeChosenRef, m.executeChosenAgent)
+	}
+	for i := range execute.ValidAgents {
+		if k == fmt.Sprint(i+1) {
+			m.executeChosenAgent = execute.ValidAgents[i]
+			return m.startExecuteFlow(m.executeChosenRef, m.executeChosenAgent)
+		}
+	}
+	return m, nil
+}
+
+// startExecuteFlow arranca execute.Run en background sobre el issue elegido
+// con el agente seleccionado y sin validadores (default 'none' en la TUI —
+// el usuario interactivo típicamente quiere ver el PR listo, los validadores
+// se pueden disparar después desde CLI si hace falta).
+func (m Model) startExecuteFlow(issueRef string, agent execute.Agent) (tea.Model, tea.Cmd) {
+	m.screen = screenExecuteRunning
+	m.runStart = time.Now()
+	m.runLog = []string{}
+	m.progressCh = make(chan tea.Msg, 64)
+
+	go func(ch chan<- tea.Msg) {
+		var stdout, stderr bytes.Buffer
+		code := execute.Run(issueRef, execute.Opts{
+			Stdout: &stdout,
+			Stderr: &stderr,
+			Agent:  agent,
+			OnProgress: func(line string) {
+				ch <- progressMsg{line: line}
+			},
+		})
+		ch <- executeDoneMsg{code: code, stdout: stdout.String(), stderr: stderr.String()}
+	}(m.progressCh)
+
+	return m, tea.Batch(waitForMsg(m.progressCh), tickCmd())
 }
 
 func loadExploreCandidatesCmd() tea.Cmd {
@@ -527,6 +676,7 @@ func (m Model) handleResultKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	m.runLog = nil
 	m.exploreNew = nil
 	m.exploreResume = nil
+	m.executeCandidates = nil
 	return m, nil
 }
 
@@ -638,10 +788,81 @@ func (m Model) View() string {
 		return renderExploreValidators(m)
 	case screenExploreRunning:
 		return renderRunning(m, "Explorando issue…", "Ctrl+C cancela")
+	case screenExecuteLoading:
+		return renderExecuteLoading(m)
+	case screenExecuteSelect:
+		return renderExecuteSelect(m)
+	case screenExecuteAgent:
+		return renderExecuteAgent(m)
+	case screenExecuteRunning:
+		return renderRunning(m, "Ejecutando issue…", "Ctrl+C cancela")
 	case screenResult:
 		return renderResult(m)
 	}
 	return ""
+}
+
+func renderExecuteLoading(m Model) string {
+	var sb strings.Builder
+	sb.WriteString(titleStyle.Render("Ejecutar un issue"))
+	sb.WriteString("\n")
+	sb.WriteString(subtitleStyle.Render("Buscando issues en status:plan…"))
+	sb.WriteString("\n")
+	sb.WriteString(hintStyle.Render("Ctrl+C cancela"))
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func renderExecuteSelect(m Model) string {
+	var sb strings.Builder
+	sb.WriteString(titleStyle.Render("Ejecutar"))
+	sb.WriteString("\n")
+	total := len(m.executeCandidates)
+	sb.WriteString(subtitleStyle.Render(fmt.Sprintf("%d issue(s) listos para ejecutar", total)))
+	sb.WriteString("\n\n")
+	if total == 0 {
+		sb.WriteString("  " + mutedBadge("(ninguno)") + "\n")
+	} else {
+		for i, c := range m.executeCandidates {
+			prefix := "  "
+			style := menuItemStyle
+			if i == m.executeCursor {
+				prefix = "▸ "
+				style = menuSelectedStyle
+			}
+			num := menuNumberStyle.Render(fmt.Sprintf("#%d", c.Number))
+			line := prefix + num + "  " + c.Title
+			sb.WriteString(style.Render(line) + "\n")
+		}
+	}
+	sb.WriteString("\n")
+	sb.WriteString(hintStyle.Render("↑/↓ navega · Enter elige · Esc vuelve · Ctrl+C sale"))
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func renderExecuteAgent(m Model) string {
+	var sb strings.Builder
+	sb.WriteString(titleStyle.Render("Elegí ejecutor"))
+	sb.WriteString("\n")
+	sb.WriteString(subtitleStyle.Render(fmt.Sprintf("Para ejecutar el issue #%s — ¿qué agente aplica el plan?", m.executeChosenRef)))
+	sb.WriteString("\n\n")
+	for i, a := range execute.ValidAgents {
+		prefix := "  "
+		style := menuItemStyle
+		if i == m.executeAgentIdx {
+			prefix = "▸ "
+			style = menuSelectedStyle
+		}
+		num := menuNumberStyle.Render(fmt.Sprintf("%d.", i+1))
+		name := strings.ToUpper(string(a)[:1]) + string(a)[1:]
+		line := prefix + num + " " + name
+		sb.WriteString(style.Render(line) + "\n")
+	}
+	sb.WriteString("\n")
+	sb.WriteString(hintStyle.Render("↑/↓ navega · 1-3 atajo · Enter elige · Esc vuelve · Ctrl+C sale"))
+	sb.WriteString("\n")
+	return sb.String()
 }
 
 func renderMenu(m Model) string {


### PR DESCRIPTION
## Summary
- Agrega `che execute`: lista issues en `status:plan`, ejecuta en worktree aislado (`.worktrees/issue-{n}` + branch `exec/{n}-{slug}`), aplica diff via claude CLI, crea/actualiza PR draft contra `main`, dispara validadores sobre el diff sin esperar, y transiciona el issue a `status:executed` + `awaiting-human`.
- Nuevo paquete `internal/labels` con la máquina `plan -> executing -> executed`; nuevo paquete `internal/flow/execute` con worktree helper, flow core, parser del body consolidado e idempotencia por head-branch.
- Des-disablea el slot "Ejecutar" en la TUI sin args y agrega las pantallas `screenExecute*`.

## Scope
- **Dentro**: subcomando cobra, TUI wiring, worktree obligatorio, PR draft idempotente, transiciones de labels, rollback en fallo, 10 tests e2e.
- **Fuera (deuda declarada)**: ciclo iter con scope-lock + hard-cap 3 (design.html L1257-1280), espera CI green, refactor a `internal/flow/common/`, signal handling SIGINT/SIGTERM explícito, UI de validators en TUI execute (default 'none' minimalista).

## Test plan
- [x] `go build ./...` limpio
- [x] `go vet ./...` limpio
- [x] `go test ./...` — 64 tests verdes (10 nuevos de execute + todos los preexistentes)
- [ ] Humano: probar el flow end-to-end contra un issue real en `status:plan`
- [ ] Humano: validar que el rollback deja el repo local limpio al cancelar con Ctrl+C

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)