### PR TITLE
feat(validators): permitir 1 validador en explore (antes era 0 o 2-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ El diseño completo (flujos, diagramas, walkthrough punta a punta, observabilida
 | # | Comando | IA | Qué hace |
 |---|---------|----|----|
 | 01 | `che idea` | sí (Sonnet) | Anota idea, decide split, clasifica, crea issue(s) |
-| 02 | `che explore` | sí (Opus/Codex/Gemini + 2-3 validadores) | Convierte issue en plan, con iteración inline |
-| 03 | `che execute` | sí (Opus/Codex/Gemini + 2-3 validadores) | Implementa en worktree, abre PR, valida contra diff, CI como gate |
+| 02 | `che explore` | sí (Opus/Codex/Gemini + 1-3 validadores) | Convierte issue en plan, con iteración inline |
+| 03 | `che execute` | sí (Opus/Codex/Gemini + 1-3 validadores) | Implementa en worktree, abre PR, valida contra diff, CI como gate |
 | 04 | `che close` | no | Scoring humano + merge del PR + cleanup |
 | 05 | `che eliminar` | no | Descarta idea en cualquier estado |
 

--- a/cmd/explore.go
+++ b/cmd/explore.go
@@ -18,7 +18,7 @@ var exploreCmd = &cobra.Command{
 	Long: `explore toma la referencia a un issue creado por 'che idea' (con label
 ct:plan), lee su body, y profundiza con el agente elegido para devolver
 preguntas abiertas, riesgos y caminos de implementación posibles. El
-análisis se postea como comentario en el issue, 2-3 validadores lo
+análisis se postea como comentario en el issue, 1-3 validadores lo
 revisan en paralelo, y el label transiciona a status:plan (o
 status:awaiting-human si los validadores pidieron input humano).
 
@@ -28,7 +28,7 @@ Formatos aceptados para <issue-ref>:
   che explore owner/repo#42
 
 Agentes disponibles (--agent): opus (default, binario 'claude'), codex, gemini.
-Validadores (--validators): 2-3 separados por coma, pueden repetir tipo
+Validadores (--validators): 1-3 separados por coma, pueden repetir tipo
 (ej: 'codex,gemini' o 'codex,codex,gemini'). Usar 'none' para skipear
 validación (útil para CI/debug).
 
@@ -69,6 +69,6 @@ func init() {
 	exploreCmd.Flags().StringVar(&exploreAgentFlag, "agent", string(explore.DefaultAgent),
 		"ejecutor a usar: opus | codex | gemini")
 	exploreCmd.Flags().StringVar(&exploreValidatorsFlag, "validators", "codex,gemini",
-		"2-3 validadores separados por coma (opus|codex|gemini, pueden repetir), o 'none' para skipear")
+		"1-3 validadores separados por coma (opus|codex|gemini, pueden repetir), o 'none' para skipear")
 	rootCmd.AddCommand(exploreCmd)
 }

--- a/e2e/explore_test.go
+++ b/e2e/explore_test.go
@@ -548,23 +548,16 @@ func TestExplore_Validators_Invalid(t *testing.T) {
 	env.Invocations().AssertNotCalled(t, "gh")
 }
 
-// TestExplore_Validators_CountOutOfRange: 1 solo validator o 4 → exit 3 (el
-// design requiere 2-3 validadores).
+// TestExplore_Validators_CountOutOfRange: 4+ validadores → exit 3. Un solo
+// validador ahora es válido (1-3 items aceptados).
 func TestExplore_Validators_CountOutOfRange(t *testing.T) {
 	t.Parallel()
 	env := harness.New(t)
-	r := env.Run("explore", "--validators", "codex", "42")
+	r := env.Run("explore", "--validators", "codex,codex,codex,gemini", "42")
 	if r.ExitCode == 0 {
-		t.Fatalf("expected non-zero exit for single validator, got 0")
-	}
-	harness.AssertContains(t, r.Stderr, "2-3")
-
-	env2 := harness.New(t)
-	r2 := env2.Run("explore", "--validators", "codex,codex,codex,gemini", "42")
-	if r2.ExitCode == 0 {
 		t.Fatalf("expected non-zero exit for 4 validators, got 0")
 	}
-	harness.AssertContains(t, r2.Stderr, "2-3")
+	harness.AssertContains(t, r.Stderr, "1-3")
 }
 
 // TestExplore_Validators_InvalidResponse_Exit3: un validator devuelve un

--- a/internal/flow/explore/explore.go
+++ b/internal/flow/explore/explore.go
@@ -180,15 +180,15 @@ type Validator struct {
 
 // ParseValidators parsea una lista separada por coma ("codex,gemini",
 // "codex,codex,gemini"). Acepta "none" (o vacío) para desactivar validación.
-// Requiere 2-3 items cuando no es "none".
+// Requiere 1-3 items cuando no es "none".
 func ParseValidators(s string) ([]Validator, error) {
 	s = strings.TrimSpace(s)
 	if s == "" || strings.EqualFold(s, "none") {
 		return nil, nil
 	}
 	parts := strings.Split(s, ",")
-	if len(parts) < 2 || len(parts) > 3 {
-		return nil, fmt.Errorf("validators: need 2-3 items (or `none`), got %d", len(parts))
+	if len(parts) < 1 || len(parts) > 3 {
+		return nil, fmt.Errorf("validators: need 1-3 items (or `none`), got %d", len(parts))
 	}
 	counts := map[Agent]int{}
 	out := make([]Validator, 0, len(parts))

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -40,7 +40,7 @@ const (
 
 // maxValidatorsPerAgent define cuántas instancias del mismo agente se
 // pueden seleccionar. El design permite repetir tipo (ej: codex×2); le
-// ponemos tope 2 para mantener la suma razonable (2-3 validadores en total).
+// ponemos tope 2 para mantener la suma razonable (1-3 validadores en total).
 const maxValidatorsPerAgent = 2
 
 // validatorAgentDescriptions son los textos cortos que se muestran al lado
@@ -625,8 +625,8 @@ func (m Model) handleExploreValidatorsKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		validators := validatorsFromCounts(m.exploreValidatorCount)
 		total := len(validators)
-		// Reglas: 0 (skip), 2 o 3 son válidos; 1 y 4+ no.
-		if total != 0 && (total < 2 || total > 3) {
+		// Reglas: 0 (skip) o 1-3 son válidos; 4+ no.
+		if total > 3 {
 			return m, nil
 		}
 		return m.startExploreFlow(m.exploreChosenRef, m.exploreChosenAgent, validators)
@@ -1047,14 +1047,14 @@ func renderCheckbox(count int) string {
 }
 
 // renderValidatorTotal imprime el total con un marcador que indica si el
-// count es aceptable (0, 2 o 3) o inválido (1, 4+).
+// count es aceptable (0-3) o inválido (4+).
 func renderValidatorTotal(total int) string {
 	mark := "✓"
 	note := ""
-	valid := total == 0 || total == 2 || total == 3
+	valid := total >= 0 && total <= 3
 	if !valid {
 		mark = "✗"
-		note = "  (necesitás 0 para skipear, o 2-3 para validar)"
+		note = "  (máximo 3 validadores)"
 	} else if total == 0 {
 		note = "  (sin validadores — solo ejecutor)"
 	}


### PR DESCRIPTION
## Summary
- La regla anterior exigía 0 (skip) o 2-3 validadores en \`che explore\`. Un solo validador devolvía error. Ahora 0 o **1-3** son válidos.
- La rigidez rompía casos donde alcanza una sola mirada externa (ej: validar con Codex sin sumar Gemini para ahorrar tokens).
- \`che execute\` ya aceptaba 1-3 desde su introducción — sin cambios.

## Cambios
- \`internal/flow/explore/explore.go\`: \`ParseValidators\` min 1 en lugar de 2, mensaje "1-3"
- \`internal/tui/model.go\`: \`renderValidatorTotal\` acepta 0-3, hint "(máximo 3 validadores)"; \`handleExploreValidatorsKey\` Enter deja pasar 1
- \`cmd/explore.go\`: docstrings y \`--validators\` help "2-3" → "1-3"
- \`README.md\`: "2-3 validadores" → "1-3 validadores"
- \`e2e/explore_test.go\`: \`TestExplore_Validators_CountOutOfRange\` ahora solo chequea 4+ como inválido

## Test plan
- [x] \`go build ./...\` y \`go test ./...\` verdes
- [ ] Humano: probar desde la TUI elegir 1 validador y que Enter avance
- [ ] Humano: \`che explore --validators codex 42\` no devuelve error

🤖 Generated with [Claude Code](https://claude.com/claude-code)