### PR TITLE
feat(explore): clasificar questions en product/technical/documented y no escalar técnicas al humano

### DIFF
--- a/e2e/explore_test.go
+++ b/e2e/explore_test.go
@@ -473,6 +473,57 @@ func TestExplore_Validators_NeedsHuman_AwaitingLabel(t *testing.T) {
 	}
 }
 
+// TestExplore_Validators_TechnicalNeedsHuman_DoesNotPause: un validator
+// devuelve verdict=needs_human pero TODOS sus findings son kind=technical o
+// kind=documented (needs_human=false porque respetó la regla). El flow NO
+// debe pausar — transiciona a status:plan como si fuera changes_requested.
+// Esto bloquea el bug que motivó este feature: preguntas técnicas del
+// ejecutor siendo escaladas al humano.
+func TestExplore_Validators_TechnicalNeedsHuman_DoesNotPause(t *testing.T) {
+	t.Parallel()
+	env := harness.New(t)
+	scriptExplorePrechecks(env)
+	env.ExpectGh(`^issue view 42`).RespondStdoutFromFixture("explore/gh_issue_view_with_ctplan.json", 0)
+	env.ExpectAgent("claude").
+		WhenArgsMatch(`ingeniero senior`).
+		RespondStdoutFromFixture("explore/sonnet_explore_ok.json", 0)
+	env.ExpectAgent("codex").
+		WhenArgsMatch(`validador técnico`).
+		RespondStdoutFromFixture("explore/sonnet_validator_technical_needs_human.json", 0)
+	env.ExpectAgent("gemini").
+		WhenArgsMatch(`validador técnico`).
+		RespondStdoutFromFixture("explore/sonnet_validator_approve.json", 0)
+	// 3 comments esperados (executor + 2 validators). NO debe haber un
+	// 4to "human-request" porque los findings technical/documented no
+	// escalan al humano.
+	env.ExpectGh(`^issue comment 42`).Consumable().RespondStdout("url-e\n", 0)
+	env.ExpectGh(`^issue comment 42`).Consumable().RespondStdout("url-c\n", 0)
+	env.ExpectGh(`^issue comment 42`).Consumable().RespondStdout("url-g\n", 0)
+	env.ExpectGh(`^label create `).RespondStdout("ok\n", 0)
+	env.ExpectGh(`^issue edit 42 `).RespondStdout("ok\n", 0)
+
+	out := env.MustRun("explore", "42")
+	// Cierra en status:plan, no awaiting.
+	harness.AssertContains(t, out, "Explored")
+	if strings.Contains(out, "awaiting-human") {
+		t.Fatalf("flow should NOT pause when findings are technical/documented only; got: %s", out)
+	}
+
+	inv := env.Invocations()
+	// Exactamente 3 comments (executor + 2 validators), NO human-request.
+	if comments := inv.FindCalls("gh", "issue", "comment", "--body-file"); len(comments) != 3 {
+		t.Fatalf("expected 3 comments (executor + 2 validators, NO human-request), got %d", len(comments))
+	}
+	edits := inv.FindCalls("gh", "issue", "edit", "42")
+	if len(edits) != 1 {
+		t.Fatalf("expected 1 label edit (status:plan), got %d", len(edits))
+	}
+	edits[0].AssertArgsContain(t, "--add-label", "status:plan")
+	if strings.Contains(strings.Join(edits[0].Args, " "), "status:awaiting-human") {
+		t.Fatalf("status:awaiting-human should NOT be applied; got %v", edits[0].Args)
+	}
+}
+
 // TestExplore_Validators_Duplicate: codex,codex,gemini → 2 invocaciones a
 // codex (instance=1 e instance=2) + 1 a gemini. Verifica que el harness
 // soporta múltiples calls al mismo binario y que el flow distingue instancias.

--- a/e2e/testdata/explore/sonnet_validator_needs_human.json
+++ b/e2e/testdata/explore/sonnet_validator_needs_human.json
@@ -8,7 +8,8 @@
       "where": "alcance del flow",
       "issue": "¿El loop de corrección es bounded (máx 3 iteraciones) o el usuario siempre elige cuándo cortar?",
       "suggestion": "",
-      "needs_human": true
+      "needs_human": true,
+      "kind": "product"
     },
     {
       "severity": "blocker",
@@ -16,7 +17,8 @@
       "where": "escape humano",
       "issue": "¿Qué hacemos si el validador marca needs_human y el usuario no contesta en N días — timeout, skip, o queda pendiente para siempre?",
       "suggestion": "",
-      "needs_human": true
+      "needs_human": true,
+      "kind": "product"
     }
   ]
 }

--- a/e2e/testdata/explore/sonnet_validator_technical_needs_human.json
+++ b/e2e/testdata/explore/sonnet_validator_technical_needs_human.json
@@ -1,0 +1,24 @@
+{
+  "verdict": "needs_human",
+  "summary": "El plan tiene preguntas técnicas que el ejecutor debió decidir solo, no hay nada de producto que escalar.",
+  "findings": [
+    {
+      "severity": "minor",
+      "area": "questions",
+      "where": "questions[0]",
+      "issue": "La pregunta sobre preservar el callback progress(...) es una decisión técnica — el ejecutor debió tomarla con best practice, no escalarla.",
+      "suggestion": "El caller emite progreso antes de llamar a labels.Ensure; no cambia la firma del paquete.",
+      "needs_human": false,
+      "kind": "technical"
+    },
+    {
+      "severity": "minor",
+      "area": "questions",
+      "where": "questions[1]",
+      "issue": "La pregunta sobre migrar transitionLabels ya está resuelta en el body del issue (dice explícitamente 'migrar ensureLabel', no transiciones).",
+      "suggestion": "Leer el body del issue; esas funciones quedan fuera del alcance.",
+      "needs_human": false,
+      "kind": "documented"
+    }
+  ]
+}

--- a/internal/flow/explore/explore.go
+++ b/internal/flow/explore/explore.go
@@ -952,22 +952,41 @@ func buildPrompt(issue *Issue) string {
 
 Te voy a pasar un issue de GitHub ya clasificado (type, size, criterios iniciales). Tu tarea NO es implementar ni planear al detalle — es abrir el espacio de diseño:
 1. Parafrasear el issue para confirmar entendimiento.
-2. Listar las preguntas abiertas que hay que responder antes de ejecutar.
-3. Identificar riesgos con likelihood e impact.
-4. Proponer 2-4 caminos de implementación distintos con pros, cons y effort estimado.
-5. Marcar EXACTAMENTE UN camino como recomendado.
-6. Indicar el próximo paso concreto.
+2. Tomar decisiones técnicas por tu cuenta y declararlas como assumptions.
+3. Listar las preguntas abiertas que SOLO el humano puede contestar.
+4. Identificar riesgos con likelihood e impact.
+5. Proponer 2-4 caminos de implementación distintos con pros, cons y effort estimado.
+6. Marcar EXACTAMENTE UN camino como recomendado.
+7. Indicar el próximo paso concreto.
+
+IMPORTANTE — Clasificá todo lo que no sabés antes de decidir si preguntar:
+
+- kind="product": ambigüedad IRREDUCIBLE del dominio o del producto. Política del proyecto, trade-off de UX/negocio, alcance opinado. El código y el body del issue no la resuelven. SOLO estas van como "question" y pausan el flow.
+- kind="technical": decisión de ingeniería (API shape, orden de refactor, naming de helpers, trade-off de implementación, preservar vs extender un callback, alcance de un refactor mecánico). NO es una question. Tomá vos la decisión y anotala como "assumption" con una justificación de 1-2 líneas.
+- kind="documented": la respuesta ya está en el body del issue, en el código del repo, en design docs, memory, README o criterios de aceptación. Si te descubrís por preguntar algo documentado, LEELO y resolvé; no generes ni question ni assumption para esto.
+
+Regla práctica: si alguien con contexto del proyecto podría contestar con un grep, leyendo el body del issue, o aplicando best practice razonable, NO es una "question". Es una decisión tuya que va como "assumption" (o ni siquiera — no todo vale la pena declarar).
+
+No escales al humano cosas como:
+  * "¿preservamos este callback al migrar?" (technical — decidilo con best practice)
+  * "¿el test va con go-parser o grep en CI?" (technical — elegí una)
+  * "¿migramos también la función X que el issue no pide?" (documented — si no lo pide, no lo hacés)
+  * "¿las 3 implementaciones pasan los mismos args?" (documented — hacé grep y resolvé)
 
 Valores válidos:
 - likelihood/impact: low, medium, high
 - effort: XS (minutos), S (horas), M (1-2 días), L (1 semana), XL (varias semanas)
+- kind: product, technical, documented
 
 Devolvé EXCLUSIVAMENTE un objeto JSON con este shape — sin texto antes ni después, sin markdown code fences:
 
 {
   "summary": "Paráfrasis accionable del issue en 1-2 oraciones",
   "questions": [
-    {"q": "Pregunta abierta concreta", "why": "Por qué importa para el diseño", "blocker": true}
+    {"q": "Pregunta abierta concreta para el humano", "why": "Por qué NO puede responderse con código ni con el body", "blocker": true, "kind": "product"}
+  ],
+  "assumptions": [
+    {"what": "Decisión técnica que tomaste", "why": "Justificación breve (código leído, best practice, precedente del repo)"}
   ],
   "risks": [
     {"risk": "Descripción del riesgo", "likelihood": "medium", "impact": "high", "mitigation": "Cómo evitarlo"}
@@ -979,7 +998,9 @@ Devolvé EXCLUSIVAMENTE un objeto JSON con este shape — sin texto antes ni des
 }
 
 Reglas:
-- questions[] tiene al menos 1 item. Si no se te ocurre ninguna, el análisis es superficial — forzate a pensar.
+- questions[] puede estar vacío si no hay ambigüedad de producto real. Un array vacío es preferible a rellenar con preguntas técnicas inventadas.
+- assumptions[] idealmente tiene 2-5 items si tomaste decisiones técnicas. Cero assumptions con cero questions es sospechoso: o el issue es trivial, o no estás mirando lo suficiente.
+- Toda question DEBE tener kind="product". Si te sale kind="technical" o "documented", MOVELA a assumptions (o descartala si ya está documentada).
 - risks[] tiene al menos 1 item.
 - paths[] tiene entre 2 y 4 items. Un solo camino = no estás explorando, solo planeando.
 - EXACTAMENTE UN path con "recommended": true. Los otros con false.
@@ -1000,11 +1021,29 @@ func validate(r *Response) error {
 	if strings.TrimSpace(r.Summary) == "" {
 		return fmt.Errorf("summary is empty")
 	}
-	if len(r.Questions) == 0 {
-		return fmt.Errorf("questions[] is empty")
-	}
+	// questions[] puede estar vacío: con el prompt de clasificación
+	// (product/technical/documented) es legítimo que el ejecutor cierre
+	// todo como assumptions y no escale nada al humano.
 	if len(r.Risks) == 0 {
 		return fmt.Errorf("risks[] is empty")
+	}
+	for i, q := range r.Questions {
+		if strings.TrimSpace(q.Q) == "" {
+			return fmt.Errorf("question %d: q is empty", i)
+		}
+		if k := normalizeKind(q.Kind); k != "" && k != KindProduct {
+			// El ejecutor clasificó una question como technical/documented
+			// pero la dejó en questions[]. Esto es inconsistente con el
+			// prompt — las que no son product deben ir como assumption o
+			// ser descartadas. Rechazamos para que el ejecutor se corrija
+			// en vez de filtrar silenciosamente.
+			return fmt.Errorf("question %d: kind=%q en questions[] — mover a assumptions[] o remover (solo product va acá)", i, q.Kind)
+		}
+	}
+	for i, a := range r.Assumptions {
+		if strings.TrimSpace(a.What) == "" {
+			return fmt.Errorf("assumption %d: what is empty", i)
+		}
 	}
 	if len(r.Paths) < 2 || len(r.Paths) > 4 {
 		return fmt.Errorf("paths[] must have 2-4 items, got %d", len(r.Paths))
@@ -1052,7 +1091,19 @@ func renderComment(r *Response, agent Agent, iter int) string {
 	sb.WriteString(r.Summary)
 	sb.WriteString("\n\n")
 
+	if len(r.Assumptions) > 0 {
+		sb.WriteString("### Decisiones técnicas tomadas\n")
+		sb.WriteString("_El ejecutor resolvió esto por su cuenta (decisión de ingeniería, no de producto). Si alguna no te cuadra, marcala en un comment y re-corré._\n\n")
+		for _, a := range r.Assumptions {
+			sb.WriteString(fmt.Sprintf("- **%s** — %s\n", a.What, a.Why))
+		}
+		sb.WriteString("\n")
+	}
+
 	sb.WriteString("### Preguntas abiertas\n")
+	if len(r.Questions) == 0 {
+		sb.WriteString("_Sin ambigüedades de producto irreducibles; el ejecutor no necesita input humano para arrancar._\n")
+	}
 	for _, q := range r.Questions {
 		marker := "-"
 		if q.Blocker {
@@ -1299,15 +1350,38 @@ func buildValidatorPrompt(issue *Issue, execResp *Response) string {
 
 Chequeá específicamente:
 1. ¿Faltan riesgos relevantes? (scope creep, acoplamiento, rollback, UX, testing)
-2. ¿Faltan preguntas abiertas importantes? (decisiones no tomadas)
-3. ¿Los paths son arquitectónicamente distintos o son variantes del mismo tema?
-4. ¿Los pros/cons de cada path son realistas? ¿el recommended tiene justificación?
-5. ¿Algún punto requiere decisión de PRODUCTO del humano (no técnica)? Marcalo con needs_human=true.
+2. ¿Las preguntas del ejecutor son realmente para el humano, o debió decidirlas él?
+3. ¿Las assumptions del ejecutor son razonables o alguna está mal justificada?
+4. ¿Los paths son arquitectónicamente distintos o son variantes del mismo tema?
+5. ¿Los pros/cons de cada path son realistas? ¿el recommended tiene justificación?
+6. ¿Hay algo genuinamente irreducible que requiera decisión de PRODUCTO del humano?
+
+IMPORTANTE — Clasificación de questions del ejecutor:
+
+Para cada pregunta en questions[] del plan, clasificala en tu review:
+
+- Si kind="product" y la pregunta es legítima (ambigüedad de dominio/UX/negocio que ni el código ni el body resuelven): aceptala. Opcionalmente marcá needs_human=true en un finding si pensás que quedó mal formulada.
+- Si kind="technical" o kind="documented" (o sin kind pero claramente cae en una de esas dos categorías): ES UN BUG DEL EJECUTOR. Generá un finding con:
+    * severity="minor"
+    * area="questions"
+    * kind="technical" o "documented" según corresponda
+    * needs_human=false (NUNCA true — no escales al humano por decisiones técnicas)
+    * issue: "la pregunta X debió decidirse por el ejecutor porque <la respuesta está en <archivo/body>|es best practice <Y>|es decisión de ingeniería>"
+    * suggestion: la respuesta concreta o el path donde está la info.
+
+NO propongas agregar más preguntas al humano por decisiones técnicas. Si el ejecutor no decidió algo que debería haber decidido, la respuesta es "decidilo vos o el ejecutor", no "pidámosle al humano".
+
+Clasificación de tus propios findings:
+
+- kind="product": gap real de producto. Puede ir con needs_human=true.
+- kind="technical": gap técnico (falta manejo de error, path no compila, riesgo no cubierto). needs_human=false. Es feedback para el ejecutor.
+- kind="documented": el ejecutor ignoró algo que está en el body/código/docs. needs_human=false. Es bug del plan.
 
 Valores válidos:
-- verdict: "approve" (plan suficiente), "changes_requested" (hay que corregir cosas técnicas), "needs_human" (hay preguntas de producto que ni vos ni el ejecutor pueden contestar)
+- verdict: "approve" (plan suficiente), "changes_requested" (hay que corregir cosas técnicas), "needs_human" (hay preguntas de producto irreducibles)
 - severity: "blocker", "major", "minor"
-- area: "questions", "risks", "paths", "summary", "other"
+- area: "questions", "assumptions", "risks", "paths", "summary", "other"
+- kind: "product", "technical", "documented"
 
 Devolvé EXCLUSIVAMENTE un objeto JSON con este shape — sin texto antes ni después, sin markdown code fences:
 
@@ -1321,16 +1395,18 @@ Devolvé EXCLUSIVAMENTE un objeto JSON con este shape — sin texto antes ni des
       "where": "risks[]",
       "issue": "Descripción concreta del gap",
       "suggestion": "Cómo arreglarlo (opcional)",
-      "needs_human": false
+      "needs_human": false,
+      "kind": "technical"
     }
   ]
 }
 
 Reglas:
 - Si el plan está bien, verdict=approve y findings=[].
-- needs_human=true SOLO cuando la respuesta depende de una decisión del dueño del producto (ej: "¿idempotente o no?", "¿timeout o esperar para siempre?"). Cosas técnicas (falta manejo de error, el path no compila) van con needs_human=false.
-- Un finding con needs_human=true debería escalar el verdict global a "needs_human" si es blocker.
+- needs_human=true requiere kind=product Y que la respuesta dependa de decisión del dueño del producto (ej: "¿idempotente o no?", "¿timeout o esperar para siempre?"). Cualquier otro caso debe ir con needs_human=false.
+- Un finding kind=product needs_human=true escala el verdict global a "needs_human". Un finding technical o documented NUNCA escala a "needs_human" aunque sea blocker.
 - No inventes gaps — si el plan cubre un riesgo aunque sea brevemente, no lo marques como faltante.
+- Si el ejecutor NO listó questions y sus assumptions cubren las decisiones técnicas con justificación razonable, eso no es un gap: es lo correcto.
 
 Issue #` + fmt.Sprint(issue.Number) + `:
 Título: ` + issue.Title + `
@@ -1377,10 +1453,18 @@ func renderValidatorComment(r validatorResult, iter int) string {
 	sb.WriteString("### Findings\n")
 	for _, f := range resp.Findings {
 		marker := "-"
-		if f.NeedsHuman {
+		// Solo marcamos con 🧑 los findings que realmente pausan el flow
+		// (kind=product + needs_human). Un finding technical/documented con
+		// needs_human=true es inconsistente: lo mostramos como aviso pero
+		// sin el icono de "espera al humano" para no confundir.
+		if f.escalatesToHuman() {
 			marker = "- 🧑"
 		}
-		sb.WriteString(fmt.Sprintf("%s **[%s · %s]** %s", marker, f.Severity, f.Area, f.Issue))
+		kindTag := ""
+		if k := f.FindingKind(); k != KindProduct {
+			kindTag = " · " + k
+		}
+		sb.WriteString(fmt.Sprintf("%s **[%s · %s%s]** %s", marker, f.Severity, f.Area, kindTag, f.Issue))
 		if f.Where != "" {
 			sb.WriteString(" _(en: " + f.Where + ")_")
 		}
@@ -1915,12 +1999,13 @@ func buildValidatorResumePrompt(issue *Issue, state conversationState) string {
 	return `Sos un validador técnico senior. En una iteración anterior, otros validadores (incluido vos posiblemente) marcaron que el plan necesitaba input humano para ciertas preguntas de producto. El humano contestó. Tu tarea ahora es verificar si las respuestas cubren los gaps, y si queda algo sin responder.
 
 Reglas de esta iteración:
-1. Si las respuestas humanas cubren todas las preguntas que tenían needs_human=true en iter anterior, devolvé verdict=approve.
-2. Si quedan gaps técnicos menores (no bloqueantes ni de producto), devolvé verdict=changes_requested con findings específicos. Esto NO bloquea convergencia.
-3. Si las respuestas son ambiguas, parciales o contradicen algo del plan, devolvé verdict=needs_human con un finding needs_human=true explicando QUÉ falta responder — NO repitas las preguntas si ya fueron contestadas.
-4. Sé riguroso pero no inventes gaps — si la respuesta humana es clara aunque breve, aceptala.
+1. Si las respuestas humanas cubren todas las preguntas kind=product que tenían needs_human=true en iter anterior, devolvé verdict=approve.
+2. Si quedan gaps técnicos menores (no bloqueantes ni de producto), devolvé verdict=changes_requested con findings kind=technical. Esto NO bloquea convergencia.
+3. Si las respuestas son ambiguas, parciales o contradicen algo del plan Y la ambigüedad es de producto, devolvé verdict=needs_human con un finding kind=product needs_human=true explicando QUÉ falta responder — NO repitas las preguntas si ya fueron contestadas.
+4. NO pidas más input humano por decisiones técnicas. Si detectás algo que el ejecutor debería resolver (API shape, orden de implementación, naming), marcalo con kind=technical needs_human=false.
+5. Sé riguroso pero no inventes gaps — si la respuesta humana es clara aunque breve, aceptala.
 
-Valores válidos: mismo enum que antes (verdict, severity, area).
+Valores válidos: mismo enum que antes (verdict, severity, area) + kind=product|technical|documented.
 
 Devolvé EXCLUSIVAMENTE un objeto JSON con el shape:
 
@@ -1928,7 +2013,7 @@ Devolvé EXCLUSIVAMENTE un objeto JSON con el shape:
   "verdict": "approve",
   "summary": "Tu opinión global en 1-2 oraciones",
   "findings": [
-    {"severity": "minor", "area": "paths", "where": "...", "issue": "...", "suggestion": "...", "needs_human": false}
+    {"severity": "minor", "area": "paths", "where": "...", "issue": "...", "suggestion": "...", "needs_human": false, "kind": "technical"}
   ]
 }
 
@@ -2026,7 +2111,8 @@ func buildConsolidationPrompt(issue *Issue, state conversationState, finalResult
 
 Reglas:
 - Incorporá las respuestas del humano como DECISIONES firmes (no como "a definir").
-- Los findings de los validadores son cosas a cubrir: los blockers/majors van como steps o acceptance_criteria, los minors van como risks_to_mitigate.
+- Incorporá las assumptions del plan original como decisiones tomadas (salvo que el humano o un validador las contradiga explícitamente).
+- Los findings de los validadores son cosas a cubrir: blockers/majors van como steps o acceptance_criteria, minors van como risks_to_mitigate. Los findings con kind=technical y kind=documented son feedback del ejecutor — incorporá la corrección; no los arrastres como preguntas abiertas.
 - Elegí UN approach (el recommended del plan original ajustado por las decisiones del humano si cambió algo).
 - Sé concreto: si el humano dijo "no aplica X", sacá X del alcance; si dijo "preferimos A sobre B", elegí A y descartá B.
 - No incluyas preguntas abiertas ni ambigüedades — si algo quedó gris, elegí la opción más conservadora y anotá en risks_to_mitigate.

--- a/internal/flow/explore/explore.go
+++ b/internal/flow/explore/explore.go
@@ -315,18 +315,49 @@ func (i *Issue) LabelNames() []string {
 }
 
 // Response es lo que claude devuelve después de analizar el issue.
+//
+// Assumptions son decisiones técnicas que el ejecutor tomó por su cuenta
+// (aspecto de API, orden de refactor, helper naming, trade-offs que no
+// requieren voto humano). Las listamos en el comment del executor para que
+// el dueño tenga visibilidad sin interrumpirle. Si un validador difiere, lo
+// marca como finding technical — no escala al humano.
 type Response struct {
-	Summary   string     `json:"summary"`
-	Questions []Question `json:"questions"`
-	Risks     []Risk     `json:"risks"`
-	Paths     []Path     `json:"paths"`
-	NextStep  string     `json:"next_step"`
+	Summary     string       `json:"summary"`
+	Questions   []Question   `json:"questions"`
+	Assumptions []Assumption `json:"assumptions,omitempty"`
+	Risks       []Risk       `json:"risks"`
+	Paths       []Path       `json:"paths"`
+	NextStep    string       `json:"next_step"`
 }
 
+// Question es una pregunta abierta del ejecutor.
+//
+// Kind clasifica la pregunta para que el flow decida si realmente
+// corresponde interrumpir al humano:
+//   - "product": ambigüedad de dominio/producto irreducible que ni el código
+//     ni el body del issue resuelven. Solo estas van al human-request.
+//   - "technical": decisión de ingeniería (API shape, orden de refactor,
+//     naming). El ejecutor debería tomarla por su cuenta; si aparece como
+//     question es un bug del ejecutor y el validador la marca como tal.
+//   - "documented": la respuesta ya está en el body del issue, en el código,
+//     o en artefactos del repo. Bug del ejecutor: debió leer, no preguntar.
+//
+// Si Kind está vacío (fixtures viejas / modelos que no emiten el campo),
+// asumimos "product" — comportamiento conservador compatible con el shape
+// anterior, donde toda question blocker iba al humano.
 type Question struct {
 	Q       string `json:"q"`
 	Why     string `json:"why"`
 	Blocker bool   `json:"blocker"`
+	Kind    string `json:"kind,omitempty"`
+}
+
+// Assumption es una decisión técnica que el ejecutor tomó sin consultar al
+// humano. Se renderiza en el comment del executor como rastro de decisión
+// (no bloquea el flow ni requiere respuesta).
+type Assumption struct {
+	What string `json:"what"`
+	Why  string `json:"why"`
 }
 
 type Risk struct {
@@ -353,6 +384,60 @@ var (
 	validSeverities = map[string]bool{"blocker": true, "major": true, "minor": true}
 )
 
+// Valores válidos de Kind para Question/Finding. "product" es el único que
+// habilita escape humano; los otros dos son feedback interno del loop.
+const (
+	KindProduct    = "product"
+	KindTechnical  = "technical"
+	KindDocumented = "documented"
+)
+
+// validKinds es la allowlist de Kind explícitos. No usamos el helper en
+// validación estricta (aceptamos missing) pero sirve para normalizar inputs
+// que vengan con mayúsculas o variantes.
+var validKinds = map[string]bool{
+	KindProduct:    true,
+	KindTechnical:  true,
+	KindDocumented: true,
+}
+
+// normalizeKind baja a lowercase y si el valor no está en la allowlist lo
+// trata como vacío (→ default "product" arriba). Así absorbemos variantes
+// del LLM sin romper, pero tampoco propagamos etiquetas fantasía.
+func normalizeKind(k string) string {
+	k = strings.ToLower(strings.TrimSpace(k))
+	if validKinds[k] {
+		return k
+	}
+	return ""
+}
+
+// kindOrDefault devuelve el Kind efectivo, aplicando el default "product"
+// cuando el campo viene vacío. Centralizar esta lógica evita que un caller
+// olvide el fallback y trate una question sin Kind como technical por error.
+func kindOrDefault(k string) string {
+	if n := normalizeKind(k); n != "" {
+		return n
+	}
+	return KindProduct
+}
+
+// QuestionKind expone el Kind efectivo de una Question — default "product"
+// para compat con fixtures/modelos que no emiten el campo.
+func (q Question) QuestionKind() string { return kindOrDefault(q.Kind) }
+
+// FindingKind expone el Kind efectivo de un Finding — default "product".
+func (f Finding) FindingKind() string { return kindOrDefault(f.Kind) }
+
+// escalatesToHuman devuelve true cuando un finding realmente debe pausar el
+// flow esperando respuesta del humano. Combina needs_human + kind==product:
+// si el validador emite needs_human=true con kind=technical/documented, es
+// un bug del validador (o del shape anterior al kind) y lo ignoramos para
+// no reintroducir la paranoia que este flow busca quitar.
+func (f Finding) escalatesToHuman() bool {
+	return f.NeedsHuman && f.FindingKind() == KindProduct
+}
+
 // ValidatorResponse es el output estructurado que devuelve cada validador
 // después de leer el plan del ejecutor.
 type ValidatorResponse struct {
@@ -363,7 +448,19 @@ type ValidatorResponse struct {
 
 // Finding es una observación concreta que un validador encontró sobre el plan.
 // NeedsHuman indica que requiere decisión de producto del humano, no de otro
-// agente — dispara el escape humano que pausa el flow.
+// agente — dispara el escape humano que pausa el flow SIEMPRE Y CUANDO el
+// Kind sea "product" (ver QuestionKindProduct).
+//
+// Kind clasifica el finding para decidir si realmente escala al humano:
+//   - "product": decisión de producto/dominio irreducible. Es el único caso
+//     donde NeedsHuman=true realmente pausa el flow.
+//   - "technical": decisión de ingeniería. Si el validador difiere del
+//     ejecutor, lo deja como feedback — NO escala. NeedsHuman debe ser false.
+//   - "documented": la respuesta ya está en el body/código/docs. Bug del
+//     ejecutor o del validador anterior. NO escala.
+//
+// Si Kind está vacío (fixtures viejas), se asume "product" — backwards
+// compat con el shape pre-clasificación.
 type Finding struct {
 	Severity   string `json:"severity"`
 	Area       string `json:"area"`
@@ -371,6 +468,7 @@ type Finding struct {
 	Issue      string `json:"issue"`
 	Suggestion string `json:"suggestion,omitempty"`
 	NeedsHuman bool   `json:"needs_human"`
+	Kind       string `json:"kind,omitempty"`
 }
 
 // validatorResult agrupa qué validador corrió, qué devolvió y si falló.
@@ -381,17 +479,23 @@ type validatorResult struct {
 }
 
 // hasHumanGaps revisa si alguno de los validators pidió input humano, ya sea
-// vía verdict=needs_human o vía un finding con needs_human=true.
+// vía verdict=needs_human o vía un finding con needs_human=true. Solo cuenta
+// findings con Kind=product — un validador que emite needs_human=true sobre
+// algo technical/documented es inconsistente y lo ignoramos (ese finding se
+// ve en el comment, pero no para de pausar al humano).
+//
+// El verdict=needs_human también requiere acompañamiento de al menos un
+// finding que realmente escale. Si el validador dijo needs_human pero todos
+// los findings son technical o documented, se trata como changes_requested
+// de facto. Eso previene el patrón "verdict needs_human con preguntas
+// técnicas" que vimos en issue #10.
 func hasHumanGaps(results []validatorResult) bool {
 	for _, r := range results {
 		if r.Response == nil {
 			continue
 		}
-		if r.Response.Verdict == "needs_human" {
-			return true
-		}
 		for _, f := range r.Response.Findings {
-			if f.NeedsHuman {
+			if f.escalatesToHuman() {
 				return true
 			}
 		}
@@ -1349,16 +1453,24 @@ func renderHumanRequest(issueNumber int, plan *Response, results []validatorResu
 }
 
 // collectPlanBlockers devuelve las preguntas del plan marcadas como
-// blocker=true; son las principales a contestar.
+// blocker=true y clasificadas como "product" (o sin Kind, que por default
+// se trata como product — back-compat con fixtures/modelos viejos). Las
+// preguntas con Kind=technical o documented NO entran al human-request
+// aunque estén marcadas como blocker: son decisiones que el ejecutor
+// debería haber tomado por su cuenta.
 func collectPlanBlockers(plan *Response) []Question {
 	if plan == nil {
 		return nil
 	}
 	var out []Question
 	for _, q := range plan.Questions {
-		if q.Blocker && strings.TrimSpace(q.Q) != "" {
-			out = append(out, q)
+		if !q.Blocker || strings.TrimSpace(q.Q) == "" {
+			continue
 		}
+		if q.QuestionKind() != KindProduct {
+			continue
+		}
+		out = append(out, q)
 	}
 	return out
 }
@@ -1386,7 +1498,10 @@ func collectValidatorQuestions(results []validatorResult, planQs []Question) []e
 		}
 		label := fmt.Sprintf("%s#%d", r.Validator.Agent, r.Validator.Instance)
 		for _, f := range r.Response.Findings {
-			if !f.NeedsHuman {
+			// Solo escalan los findings que realmente necesitan humano Y son
+			// de producto. Technical/documented se ven en el comment del
+			// validador pero no obligan al humano a contestarlas.
+			if !f.escalatesToHuman() {
 				continue
 			}
 			if isMetaFinding(f.Issue) {

--- a/internal/flow/explore/explore_test.go
+++ b/internal/flow/explore/explore_test.go
@@ -121,3 +121,190 @@ func TestCollectValidatorQuestions_KeepsGenuine(t *testing.T) {
 		t.Fatalf("expected source=gemini#1, got %s", extras[0].source)
 	}
 }
+
+// TestCollectPlanBlockers_FiltersNonProductKinds: preguntas blocker con
+// kind=technical o kind=documented NO entran al human-request. Solo las
+// kind=product (o sin kind, back-compat) se listan.
+func TestCollectPlanBlockers_FiltersNonProductKinds(t *testing.T) {
+	plan := &Response{
+		Questions: []Question{
+			{Q: "¿Política de reintentos? Si falla, ¿retry silencioso o aborto?", Blocker: true, Kind: KindProduct},
+			{Q: "¿Migramos también transitionLabels? (alcance del refactor)", Blocker: true, Kind: KindTechnical},
+			{Q: "¿Preservamos el callback progress() al migrar a labels.Ensure?", Blocker: true, Kind: KindTechnical},
+			{Q: "¿El issue ya pide cerrar este punto? Lo dice el body.", Blocker: true, Kind: KindDocumented},
+			{Q: "Pregunta legacy sin kind (compat backwards)", Blocker: true},
+		},
+	}
+
+	got := collectPlanBlockers(plan)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 blockers (1 product explícito + 1 legacy sin kind = product default), got %d: %+v", len(got), got)
+	}
+	for _, q := range got {
+		if q.QuestionKind() != KindProduct {
+			t.Fatalf("expected only kind=product blockers, got %q for %q", q.QuestionKind(), q.Q)
+		}
+	}
+}
+
+// TestHasHumanGaps_IgnoresNonProductFindings: un validator con verdict
+// needs_human pero findings kind=technical NO debe pausar el flow.
+func TestHasHumanGaps_IgnoresNonProductFindings(t *testing.T) {
+	results := []validatorResult{
+		{
+			Validator: Validator{Agent: AgentCodex, Instance: 1},
+			Response: &ValidatorResponse{
+				Verdict: "needs_human",
+				Findings: []Finding{
+					{Severity: "blocker", Area: "questions", NeedsHuman: true, Kind: KindTechnical,
+						Issue: "El ejecutor debió decidir si preservar el callback progress()."},
+					{Severity: "minor", Area: "questions", NeedsHuman: true, Kind: KindDocumented,
+						Issue: "La respuesta está en el body del issue."},
+				},
+			},
+		},
+	}
+	if hasHumanGaps(results) {
+		t.Fatalf("expected hasHumanGaps=false cuando todos los findings son technical/documented")
+	}
+}
+
+// TestHasHumanGaps_TrueOnProductFinding: un solo finding kind=product con
+// needs_human=true sí debe escalar.
+func TestHasHumanGaps_TrueOnProductFinding(t *testing.T) {
+	results := []validatorResult{
+		{
+			Validator: Validator{Agent: AgentGemini, Instance: 1},
+			Response: &ValidatorResponse{
+				Verdict: "needs_human",
+				Findings: []Finding{
+					{Severity: "blocker", Area: "questions", NeedsHuman: true, Kind: KindProduct,
+						Issue: "¿Política de retención tras N días sin respuesta?"},
+					{Severity: "minor", Area: "questions", NeedsHuman: true, Kind: KindTechnical,
+						Issue: "Naming del helper (no escala pero se reporta)."},
+				},
+			},
+		},
+	}
+	if !hasHumanGaps(results) {
+		t.Fatalf("expected hasHumanGaps=true cuando hay al menos un finding product needs_human")
+	}
+}
+
+// TestHasHumanGaps_BackwardsCompat_MissingKind: findings viejos sin kind
+// deben tratarse como product para no romper fixtures previas.
+func TestHasHumanGaps_BackwardsCompat_MissingKind(t *testing.T) {
+	results := []validatorResult{
+		{
+			Validator: Validator{Agent: AgentOpus, Instance: 1},
+			Response: &ValidatorResponse{
+				Verdict: "needs_human",
+				Findings: []Finding{
+					{Severity: "blocker", Area: "questions", NeedsHuman: true,
+						Issue: "¿Cuándo cortamos el loop si no converge?"},
+				},
+			},
+		},
+	}
+	if !hasHumanGaps(results) {
+		t.Fatalf("expected hasHumanGaps=true para findings sin kind (default=product, compat)")
+	}
+}
+
+// TestCollectValidatorQuestions_DropsNonProductFindings: un finding
+// technical con needs_human=true (inconsistente) no debería aparecer en
+// las "observaciones adicionales" del human-request.
+func TestCollectValidatorQuestions_DropsNonProductFindings(t *testing.T) {
+	planQs := []Question{
+		{Q: "¿Política de rollback?", Blocker: true, Kind: KindProduct},
+	}
+	results := []validatorResult{
+		{
+			Validator: Validator{Agent: AgentCodex, Instance: 1},
+			Response: &ValidatorResponse{
+				Verdict: "changes_requested",
+				Findings: []Finding{
+					{Severity: "minor", Area: "questions", NeedsHuman: true, Kind: KindTechnical,
+						Issue: "La decisión sobre naming del helper es técnica, no de producto."},
+					{Severity: "major", Area: "questions", NeedsHuman: true, Kind: KindDocumented,
+						Issue: "Esto ya está resuelto en el body del issue."},
+				},
+			},
+		},
+	}
+
+	extras := collectValidatorQuestions(results, planQs)
+	if len(extras) != 0 {
+		t.Fatalf("expected 0 extras (technical + documented no escalan), got %d: %+v", len(extras), extras)
+	}
+}
+
+// TestValidateResponse_RejectsNonProductQuestion: el ejecutor que deja una
+// question con kind=technical en questions[] debe fallar la validación (es
+// un bug del ejecutor, no lo filtramos silencioso).
+func TestValidateResponse_RejectsNonProductQuestion(t *testing.T) {
+	r := &Response{
+		Summary: "Ok",
+		Questions: []Question{
+			{Q: "¿Decisión técnica que debería ser assumption?", Blocker: true, Kind: KindTechnical},
+		},
+		Risks: []Risk{{Risk: "x", Likelihood: "low", Impact: "low", Mitigation: "y"}},
+		Paths: []Path{
+			{Title: "A", Sketch: "x", Pros: []string{"p"}, Cons: []string{"c"}, Effort: "S", Recommended: true},
+			{Title: "B", Sketch: "x", Pros: []string{"p"}, Cons: []string{"c"}, Effort: "S", Recommended: false},
+		},
+		NextStep: "paso",
+	}
+	if err := validate(r); err == nil {
+		t.Fatalf("expected validate() to reject question with kind=technical; got nil")
+	}
+}
+
+// TestValidateResponse_AcceptsEmptyQuestions: con el prompt nuevo es válido
+// devolver questions=[] si el ejecutor cerró todo como assumptions.
+func TestValidateResponse_AcceptsEmptyQuestions(t *testing.T) {
+	r := &Response{
+		Summary:     "Ok",
+		Questions:   nil,
+		Assumptions: []Assumption{{What: "Usamos labels.Ensure directo", Why: "Best practice existente"}},
+		Risks:       []Risk{{Risk: "x", Likelihood: "low", Impact: "low", Mitigation: "y"}},
+		Paths: []Path{
+			{Title: "A", Sketch: "x", Pros: []string{"p"}, Cons: []string{"c"}, Effort: "S", Recommended: true},
+			{Title: "B", Sketch: "x", Pros: []string{"p"}, Cons: []string{"c"}, Effort: "S", Recommended: false},
+		},
+		NextStep: "paso",
+	}
+	if err := validate(r); err != nil {
+		t.Fatalf("expected validate() to accept empty questions[], got: %v", err)
+	}
+}
+
+// TestNormalizeKind_UnknownKindTreatedAsEmpty: un LLM que devuelve "prod" o
+// "tecnico" (variante) debe quedar como "" → default "product" al aplicar
+// kindOrDefault. Así no propagamos etiquetas fantasía que podrían romper
+// los filtros.
+func TestNormalizeKind_UnknownKindTreatedAsEmpty(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"product", "product"},
+		{"PRODUCT", "product"},
+		{"  technical ", "technical"},
+		{"documented", "documented"},
+		{"prod", ""},
+		{"tecnico", ""},
+		{"business", ""},
+	}
+	for _, c := range cases {
+		got := normalizeKind(c.in)
+		if got != c.want {
+			t.Errorf("normalizeKind(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+	// kindOrDefault cierra la compat: cualquier cosa no válida se trata
+	// como product (el default conservador).
+	if got := kindOrDefault("prod"); got != KindProduct {
+		t.Errorf("kindOrDefault(\"prod\") = %q, want %q", got, KindProduct)
+	}
+}


### PR DESCRIPTION
## Summary
- Los validadores de \`che explore\` estaban escalando al humano preguntas técnicas (\"¿preservamos este callback?\") o ya documentadas en el body/código. Issue #10 fue el caso concreto.
- Nuevo schema: \`Question.Kind\` = \`product | technical | documented\` + \`Assumptions\` al plan.
- Prompt del ejecutor: por default **decide y anota como assumption**; solo \`product\` genera \`question\`.
- Prompt del validador: si ve una question \`technical/documented\`, la marca como bug del ejecutor (\`needs_human: false\`) con la respuesta concreta — NUNCA re-escala.

## Defensas extra
- \`validate()\` rechaza con exit 3 si el ejecutor emite \`question\` con \`kind != product\` → fuerza retry del LLM en vez de filtrar silenciosamente.
- \`hasHumanGaps()\` ignora el \`verdict\` global del validador, solo mira findings individuales con \`escalatesToHuman()\`. Un \`verdict=needs_human\` con findings técnicos no pausa el flow.
- Default \`kindOrDefault(\"\")\` → \`\"product\"\` para backward compat con fixtures existentes.

## Test plan
- [x] \`go build ./...\` y \`go test ./...\` verdes
- [x] 7 tests unitarios nuevos + 1 e2e (\`TestExplore_Validator_Technical_DoesNotEscalate\`)
- [ ] Humano: probar con un issue real post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)