### PR TITLE
fix(explore): excluir issues post-execute de las listas de la TUI

### DIFF
--- a/internal/flow/explore/explore.go
+++ b/internal/flow/explore/explore.go
@@ -787,9 +787,9 @@ type Candidate struct {
 
 // ListCandidates devuelve los issues abiertos con label ct:plan que todavía
 // no fueron explorados (sin status:plan) y que NO están esperando input
-// humano (sin status:awaiting-human). Limita a los 50 más recientes para
-// mantener la TUI manejable. Los awaiting-human se listan aparte con
-// ListAwaiting() — el usuario los reanuda desde otra sección de la TUI.
+// humano (sin status:awaiting-human). También excluye los que ya pasaron
+// por execute (status:executing | status:executed) — esos son de otro flow.
+// Limita a los 50 más recientes para mantener la TUI manejable.
 func ListCandidates() ([]Candidate, error) {
 	raw, err := listIssuesWithCtPlan()
 	if err != nil {
@@ -797,7 +797,8 @@ func ListCandidates() ([]Candidate, error) {
 	}
 	out := make([]Candidate, 0, len(raw))
 	for _, i := range raw {
-		if i.HasLabel("status:plan") || i.HasLabel("status:awaiting-human") {
+		if i.HasLabel("status:plan") || i.HasLabel("status:awaiting-human") ||
+			i.HasLabel("status:executing") || i.HasLabel("status:executed") {
 			continue
 		}
 		out = append(out, Candidate{Number: i.Number, Title: i.Title})
@@ -806,8 +807,10 @@ func ListCandidates() ([]Candidate, error) {
 }
 
 // ListAwaiting devuelve los issues con status:awaiting-human, candidatos a
-// reanudación. Son los que quedaron en pausa porque los validadores pidieron
-// input humano en una corrida anterior.
+// reanudación. Son los que quedaron en pausa porque los validadores de
+// explore pidieron input humano en una corrida anterior. Excluye los que
+// también tienen status:executed — esos vienen de execute (PR abierto
+// esperando review humano) y pertenecen al flow de validate, no de explore.
 func ListAwaiting() ([]Candidate, error) {
 	raw, err := listIssuesWithCtPlan()
 	if err != nil {
@@ -816,6 +819,9 @@ func ListAwaiting() ([]Candidate, error) {
 	out := make([]Candidate, 0, len(raw))
 	for _, i := range raw {
 		if !i.HasLabel("status:awaiting-human") {
+			continue
+		}
+		if i.HasLabel("status:executed") || i.HasLabel("status:executing") {
 			continue
 		}
 		out = append(out, Candidate{Number: i.Number, Title: i.Title})


### PR DESCRIPTION
## Summary
\`ListAwaiting\` listaba el issue #10 como "pausado para revalidar" aunque tenía \`status:executed\` + \`status:awaiting-human\` (quedó así post-\`che execute\`, esperando review humano del PR). Eso es flow de \`validate\`, no de \`explore\`.

Fix: ambas listas (\`ListCandidates\` y \`ListAwaiting\`) excluyen \`status:executing\` + \`status:executed\`.

## Test plan
- [x] \`go test ./...\` verde
- [ ] Humano: \`che explore\` en la TUI no debe listar el #10 (que tiene status:executed+awaiting-human)

🤖 Generated with [Claude Code](https://claude.com/claude-code)