### PR TITLE
feat(validate): mostrar issue relacionado (closes #N) en la lista de PRs

### DIFF
--- a/internal/flow/validate/validate.go
+++ b/internal/flow/validate/validate.go
@@ -159,15 +159,19 @@ type PullRequest struct {
 	Author     struct {
 		Login string `json:"login"`
 	} `json:"author"`
+	ClosingIssuesReferences []struct {
+		Number int `json:"number"`
+	} `json:"closingIssuesReferences"`
 }
 
 // Candidate es la vista mínima para la TUI al listar PRs abiertos.
 type Candidate struct {
-	Number  int
-	Title   string
-	URL     string
-	IsDraft bool
-	Author  string
+	Number         int
+	Title          string
+	URL            string
+	IsDraft        bool
+	Author         string
+	RelatedIssues  []int // issues referenciados via "Closes #N" / "Fixes #N" en el body del PR
 }
 
 // PRComment es un comment del PR; el body puede tener header de claude-cli al
@@ -371,7 +375,7 @@ func Run(prRef string, opts Opts) ExitCode {
 func ListOpenPRs() ([]Candidate, error) {
 	cmd := exec.Command("gh", "pr", "list",
 		"--state", "open",
-		"--json", "number,title,url,isDraft,author,headRefName",
+		"--json", "number,title,url,isDraft,author,headRefName,closingIssuesReferences",
 		"--limit", "50")
 	out, err := cmd.Output()
 	if err != nil {
@@ -386,12 +390,17 @@ func ListOpenPRs() ([]Candidate, error) {
 	}
 	res := make([]Candidate, 0, len(raw))
 	for _, p := range raw {
+		related := make([]int, 0, len(p.ClosingIssuesReferences))
+		for _, r := range p.ClosingIssuesReferences {
+			related = append(related, r.Number)
+		}
 		res = append(res, Candidate{
-			Number:  p.Number,
-			Title:   p.Title,
-			URL:     p.URL,
-			IsDraft: p.IsDraft,
-			Author:  p.Author.Login,
+			Number:        p.Number,
+			Title:         p.Title,
+			URL:           p.URL,
+			IsDraft:       p.IsDraft,
+			Author:        p.Author.Login,
+			RelatedIssues: related,
 		})
 	}
 	return res, nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1015,7 +1015,15 @@ func renderValidateSelect(m Model) string {
 			if c.IsDraft {
 				draft = " " + mutedBadge("draft")
 			}
-			line := prefix + num + "  " + c.Title + draft
+			rel := ""
+			if len(c.RelatedIssues) > 0 {
+				parts := make([]string, 0, len(c.RelatedIssues))
+				for _, n := range c.RelatedIssues {
+					parts = append(parts, fmt.Sprintf("#%d", n))
+				}
+				rel = " " + mutedBadge("closes "+strings.Join(parts, ", "))
+			}
+			line := prefix + num + "  " + c.Title + draft + rel
 			if c.Author != "" {
 				line += " " + comingSoonStyle.Render("— by @"+c.Author)
 			}


### PR DESCRIPTION
## Summary
En la pantalla \"Validar\" de la TUI, cada PR listado ahora muestra el issue vinculado como badge \`closes #N\` — viene del campo nativo \`closingIssuesReferences\` de GitHub (no parseamos el título).

## Test plan
- [x] \`go test ./...\` verde
- [ ] Humano: ver que el PR #17 aparezca como \"#17 ... closes #10\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)