### PR TITLE
feat(#9): che execute: headers estructurados en PR comments de validadores

### DIFF
--- a/internal/comments/header.go
+++ b/internal/comments/header.go
@@ -1,0 +1,78 @@
+// Package comments centraliza el formato de los headers estructurados que che
+// embebe al inicio de cada comment (issue o PR) como HTML comment
+// `<!-- claude-cli: k=v ... -->`. El header permite al flow parsear comments
+// históricos y saber qué iteración / agente / rol los produjo — necesario, por
+// ejemplo, para el ciclo iter de execute con scope-lock (design.html L1257+).
+package comments
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Header es la metadata parseada del HTML comment de che al inicio del body.
+// Si Role es "" el body no tiene header (es del humano o de otra herramienta).
+type Header struct {
+	Flow     string
+	Iter     int
+	Agent    string
+	Instance int
+	Role     string
+}
+
+var headerRe = regexp.MustCompile(`^<!--\s*claude-cli:\s*(.+?)\s*-->`)
+var kvRe = regexp.MustCompile(`(\w+)=(\S+)`)
+
+// Parse lee la primera línea del body y, si es un HTML comment de che,
+// devuelve la metadata. Si no lo es, devuelve un Header vacío.
+func Parse(body string) Header {
+	m := headerRe.FindStringSubmatch(strings.TrimSpace(body))
+	if m == nil {
+		return Header{}
+	}
+	h := Header{}
+	for _, kv := range kvRe.FindAllStringSubmatch(m[1], -1) {
+		switch kv[1] {
+		case "flow":
+			h.Flow = kv[2]
+		case "iter":
+			if n, err := strconv.Atoi(kv[2]); err == nil {
+				h.Iter = n
+			}
+		case "agent":
+			h.Agent = kv[2]
+		case "instance":
+			if n, err := strconv.Atoi(kv[2]); err == nil {
+				h.Instance = n
+			}
+		case "role":
+			h.Role = kv[2]
+		}
+	}
+	return h
+}
+
+// Format devuelve el HTML comment serializado listo para prependerse al body
+// (sin newline final). Campos zero se omiten así el resultado no mete
+// `iter=0` ni `instance=0` cuando no aplican.
+func (h Header) Format() string {
+	var parts []string
+	if h.Flow != "" {
+		parts = append(parts, "flow="+h.Flow)
+	}
+	if h.Iter > 0 {
+		parts = append(parts, fmt.Sprintf("iter=%d", h.Iter))
+	}
+	if h.Agent != "" {
+		parts = append(parts, "agent="+h.Agent)
+	}
+	if h.Instance > 0 {
+		parts = append(parts, fmt.Sprintf("instance=%d", h.Instance))
+	}
+	if h.Role != "" {
+		parts = append(parts, "role="+h.Role)
+	}
+	return "<!-- claude-cli: " + strings.Join(parts, " ") + " -->"
+}

--- a/internal/comments/header_test.go
+++ b/internal/comments/header_test.go
@@ -1,0 +1,117 @@
+package comments
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseValidatorHeader(t *testing.T) {
+	body := "<!-- claude-cli: flow=execute iter=1 agent=opus instance=1 role=validator -->\nfindings..."
+	h := Parse(body)
+	if h.Flow != "execute" || h.Iter != 1 || h.Agent != "opus" || h.Instance != 1 || h.Role != "validator" {
+		t.Fatalf("unexpected header: %+v", h)
+	}
+}
+
+func TestParseExecutorHeader(t *testing.T) {
+	body := "<!-- claude-cli: flow=explore iter=2 agent=opus role=executor -->\nplan..."
+	h := Parse(body)
+	if h.Flow != "explore" || h.Iter != 2 || h.Agent != "opus" || h.Role != "executor" {
+		t.Fatalf("unexpected header: %+v", h)
+	}
+	if h.Instance != 0 {
+		t.Fatalf("Instance should be zero when omitted, got %d", h.Instance)
+	}
+}
+
+func TestParseHumanRequestHeader(t *testing.T) {
+	body := "<!-- claude-cli: flow=explore iter=1 role=human-request -->\npreguntas..."
+	h := Parse(body)
+	if h.Flow != "explore" || h.Iter != 1 || h.Role != "human-request" {
+		t.Fatalf("unexpected header: %+v", h)
+	}
+	if h.Agent != "" {
+		t.Fatalf("Agent should be empty, got %q", h.Agent)
+	}
+}
+
+func TestParseNoHeader(t *testing.T) {
+	h := Parse("hola humano aquí")
+	if (h != Header{}) {
+		t.Fatalf("expected empty header, got %+v", h)
+	}
+}
+
+func TestParseMalformedFieldsSkipped(t *testing.T) {
+	// iter no numérico debe quedar en 0, el resto se respeta.
+	body := "<!-- claude-cli: flow=execute iter=abc agent=codex instance=xx role=validator -->"
+	h := Parse(body)
+	if h.Flow != "execute" || h.Agent != "codex" || h.Role != "validator" {
+		t.Fatalf("unexpected header: %+v", h)
+	}
+	if h.Iter != 0 || h.Instance != 0 {
+		t.Fatalf("expected iter/instance zeroed, got iter=%d instance=%d", h.Iter, h.Instance)
+	}
+}
+
+func TestFormatValidator(t *testing.T) {
+	h := Header{Flow: "execute", Iter: 1, Agent: "opus", Instance: 1, Role: "validator"}
+	got := h.Format()
+	want := "<!-- claude-cli: flow=execute iter=1 agent=opus instance=1 role=validator -->"
+	if got != want {
+		t.Fatalf("Format:\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestFormatOmitsZeroFields(t *testing.T) {
+	h := Header{Flow: "explore", Iter: 1, Role: "human-request"}
+	got := h.Format()
+	want := "<!-- claude-cli: flow=explore iter=1 role=human-request -->"
+	if got != want {
+		t.Fatalf("Format:\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestRoundTrip(t *testing.T) {
+	cases := []Header{
+		{Flow: "execute", Iter: 1, Agent: "opus", Instance: 1, Role: "validator"},
+		{Flow: "execute", Iter: 3, Agent: "codex", Instance: 2, Role: "validator"},
+		{Flow: "execute", Iter: 1, Agent: "gemini", Instance: 1, Role: "validator"},
+		{Flow: "explore", Iter: 2, Agent: "opus", Role: "executor"},
+		{Flow: "explore", Iter: 1, Role: "human-request"},
+	}
+	for _, h := range cases {
+		body := h.Format() + "\nbody text"
+		got := Parse(body)
+		if got != h {
+			t.Errorf("round-trip failed:\n orig %+v\n got  %+v\n wire %q", h, got, h.Format())
+		}
+	}
+}
+
+func TestParseIgnoresLeadingWhitespace(t *testing.T) {
+	body := "   \n<!-- claude-cli: flow=execute iter=1 agent=opus instance=1 role=validator -->\n"
+	h := Parse(body)
+	if h.Role != "validator" {
+		t.Fatalf("expected validator role, got %+v", h)
+	}
+}
+
+// TestHeaderIsFirstLine documenta que el header debe estar al principio del
+// body: si hay texto antes, Parse no lo detecta. Esto matchea el contrato de
+// explore.ParseCommentHeader y evita que texto libre del humano dispare un
+// falso match del regex.
+func TestHeaderIsFirstLine(t *testing.T) {
+	body := "texto libre\n<!-- claude-cli: flow=execute iter=1 agent=opus role=validator -->"
+	h := Parse(body)
+	if (h != Header{}) {
+		t.Fatalf("expected empty header when not at start, got %+v", h)
+	}
+}
+
+func TestFormatResultStartsWithMarker(t *testing.T) {
+	h := Header{Flow: "execute", Iter: 1, Agent: "opus", Instance: 1, Role: "validator"}
+	if !strings.HasPrefix(h.Format(), "<!-- claude-cli:") {
+		t.Fatalf("Format must start with claude-cli marker: %q", h.Format())
+	}
+}

--- a/internal/flow/execute/execute.go
+++ b/internal/flow/execute/execute.go
@@ -31,11 +31,10 @@ import (
 	"github.com/chichex/che/internal/labels"
 )
 
-// validatorCommentIter es el iter que estampan los headers de los PR comments
-// de validadores. Hoy siempre 1 porque execute no tiene ciclo iter aún — el
-// formato queda listo para cuando se implemente el ciclo con scope-lock
-// (design.html L1257+). Cuando exista, este valor lo resuelve el caller.
-const validatorCommentIter = 1
+// validatorRole es el valor del campo `role` en el header claude-cli de los
+// comments de validadores que postea execute. Lo usa nextValidatorIter para
+// filtrar los comments de tandas anteriores al calcular el iter.
+const validatorRole = "validator"
 
 // ExitCode es el código de salida semántico para el caller.
 type ExitCode int
@@ -549,8 +548,18 @@ func Run(issueRef string, opts Opts) ExitCode {
 	validatorsCtx, validatorsCancel := context.WithCancel(ctx)
 	defer validatorsCancel()
 	if !opts.SkipValidators && len(opts.Validators) > 0 {
-		progress(fmt.Sprintf("disparando %d validador(es) sobre el PR…", len(opts.Validators)))
-		validatorsDone = fireValidators(validatorsCtx, prURL, issue, plan, opts.Validators)
+		// Cuando reusamos un PR existente puede haber comments de tandas
+		// previas; leemos sus headers para numerar esta tanda con el próximo
+		// iter. Si la lectura falla o no hay comments previos, caemos a 1 —
+		// un iter mal numerado no justifica abortar el run.
+		iter := 1
+		if existing, err := fetchPRComments(ctx, prURL); err == nil {
+			iter = nextValidatorIter(existing)
+		} else {
+			fmt.Fprintf(stderr, "warning: no pude leer comments previos del PR para numerar iter (%v); usando iter=1\n", err)
+		}
+		progress(fmt.Sprintf("disparando %d validador(es) sobre el PR (iter=%d)…", len(opts.Validators), iter))
+		validatorsDone = fireValidators(validatorsCtx, prURL, issue, plan, opts.Validators, iter)
 		validatorsTotal = len(opts.Validators)
 	}
 
@@ -1316,10 +1325,14 @@ func createDraftPR(ctx context.Context, wtPath, branch string, issue *Issue) (st
 // señales y aplicar su propio timeout. El canal tiene buffer = len(validators)
 // así las goroutines nunca se bloquean si el caller deja de drenarlo.
 //
+// iter es el número de tanda que se estampa en el header — el caller lo
+// resuelve con nextValidatorIter sobre los comments previos del PR; sin eso,
+// al reusar un PR en un segundo run quedarían comments indistinguibles.
+//
 // parent es el context del flow; cualquier cancelación (señal o timeout del
 // wait superior) mata los subprocesos de validación con SIGTERM al process
 // group y permite a las goroutines retornar sin colgarse.
-func fireValidators(parent context.Context, prURL string, issue *Issue, plan *ConsolidatedPlan, validators []Validator) <-chan int {
+func fireValidators(parent context.Context, prURL string, issue *Issue, plan *ConsolidatedPlan, validators []Validator, iter int) <-chan int {
 	done := make(chan int, len(validators))
 	for i, v := range validators {
 		i, v := i, v
@@ -1354,18 +1367,70 @@ func fireValidators(parent context.Context, prURL string, issue *Issue, plan *Co
 			if parent.Err() != nil {
 				return
 			}
-			header := comments.Header{
-				Flow:     "execute",
-				Iter:     validatorCommentIter,
-				Agent:    string(v.Agent),
-				Instance: v.Instance,
-				Role:     "validator",
-			}.Format()
-			body := fmt.Sprintf("%s\n## Validator %s#%d\n\n%s\n", header, v.Agent, v.Instance, strings.TrimSpace(string(out)))
-			_ = postPRComment(parent, prURL, body)
+			_ = postPRComment(parent, prURL, renderValidatorComment(iter, v, string(out)))
 		}()
 	}
 	return done
+}
+
+// renderValidatorComment arma el body del PR comment de un validator con el
+// header estructurado al principio. Pura y sin side-effects: así un test
+// puede assertarlo sin disparar goroutines ni ejecutar gh.
+func renderValidatorComment(iter int, v Validator, agentOut string) string {
+	header := comments.Header{
+		Flow:     "execute",
+		Iter:     iter,
+		Agent:    string(v.Agent),
+		Instance: v.Instance,
+		Role:     validatorRole,
+	}.Format()
+	return fmt.Sprintf("%s\n## Validator %s#%d\n\n%s\n", header, v.Agent, v.Instance, strings.TrimSpace(agentOut))
+}
+
+// PRComment es un comment del PR con el subset mínimo que nos interesa para
+// calcular iter. Coincide con lo que devuelve `gh pr view --json comments`.
+type PRComment struct {
+	Body      string    `json:"body"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+// nextValidatorIter devuelve el próximo iter a usar para los comments de
+// validadores en el PR. Es max(iter) + 1 mirando sólo los comments de che
+// con flow=execute y role=validator; si no hay, devuelve 1. Así una segunda
+// corrida sobre el mismo PR queda separada de la primera.
+func nextValidatorIter(existing []PRComment) int {
+	max := 0
+	for _, c := range existing {
+		h := comments.Parse(c.Body)
+		if h.Flow != "execute" || h.Role != validatorRole {
+			continue
+		}
+		if h.Iter > max {
+			max = h.Iter
+		}
+	}
+	return max + 1
+}
+
+// fetchPRComments lee los comments actuales del PR. Usa `gh pr view --json
+// comments` (misma forma que validate.FetchPRComments). El ctx permite
+// cancelarlo rápido si entra una señal.
+func fetchPRComments(ctx context.Context, prURL string) ([]PRComment, error) {
+	cmd := exec.CommandContext(ctx, "gh", "pr", "view", prURL, "--json", "comments")
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("gh pr view comments: %s", strings.TrimSpace(string(ee.Stderr)))
+		}
+		return nil, err
+	}
+	var wrap struct {
+		Comments []PRComment `json:"comments"`
+	}
+	if err := json.Unmarshal(out, &wrap); err != nil {
+		return nil, fmt.Errorf("parse gh pr view comments: %w", err)
+	}
+	return wrap.Comments, nil
 }
 
 func buildValidatorPrompt(issue *Issue, plan *ConsolidatedPlan) string {

--- a/internal/flow/execute/execute.go
+++ b/internal/flow/execute/execute.go
@@ -27,8 +27,15 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/chichex/che/internal/comments"
 	"github.com/chichex/che/internal/labels"
 )
+
+// validatorCommentIter es el iter que estampan los headers de los PR comments
+// de validadores. Hoy siempre 1 porque execute no tiene ciclo iter aún — el
+// formato queda listo para cuando se implemente el ciclo con scope-lock
+// (design.html L1257+). Cuando exista, este valor lo resuelve el caller.
+const validatorCommentIter = 1
 
 // ExitCode es el código de salida semántico para el caller.
 type ExitCode int
@@ -1347,7 +1354,14 @@ func fireValidators(parent context.Context, prURL string, issue *Issue, plan *Co
 			if parent.Err() != nil {
 				return
 			}
-			body := fmt.Sprintf("## Validator %s#%d\n\n%s\n", v.Agent, v.Instance, strings.TrimSpace(string(out)))
+			header := comments.Header{
+				Flow:     "execute",
+				Iter:     validatorCommentIter,
+				Agent:    string(v.Agent),
+				Instance: v.Instance,
+				Role:     "validator",
+			}.Format()
+			body := fmt.Sprintf("%s\n## Validator %s#%d\n\n%s\n", header, v.Agent, v.Instance, strings.TrimSpace(string(out)))
 			_ = postPRComment(parent, prURL, body)
 		}()
 	}

--- a/internal/flow/execute/execute_test.go
+++ b/internal/flow/execute/execute_test.go
@@ -3,6 +3,7 @@ package execute
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -576,5 +577,85 @@ func TestWaitValidators_Timeout(t *testing.T) {
 	}
 	if !strings.Contains(out, "1/2") {
 		t.Errorf("expected 1/2 completaron, got:\n%s", out)
+	}
+}
+
+// TestRenderValidatorComment_HeaderPrefix protege el wiring: el body del PR
+// comment que postea execute tiene que empezar con el HTML comment de che
+// (flow=execute, iter=N, agent=..., instance=..., role=validator) seguido del
+// cuerpo. Si alguien rompe el Sprintf o cambia el orden, este test lo
+// atrapa sin tocar la red ni el agente.
+func TestRenderValidatorComment_HeaderPrefix(t *testing.T) {
+	v := Validator{Agent: AgentOpus, Instance: 1}
+	got := renderValidatorComment(2, v, "findings del agente\n")
+
+	wantPrefix := "<!-- claude-cli: flow=execute iter=2 agent=opus instance=1 role=validator -->\n"
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("body no arranca con el header esperado\n got:  %q\n want: prefix %q", got, wantPrefix)
+	}
+	if !strings.Contains(got, "## Validator opus#1") {
+		t.Errorf("falta el sub-header del validator en el body:\n%s", got)
+	}
+	if !strings.Contains(got, "findings del agente") {
+		t.Errorf("falta el output del agente en el body:\n%s", got)
+	}
+}
+
+// TestRenderValidatorComment_IterPropagated asegura que el iter que recibe
+// renderValidatorComment es el que termina en el header — Codex marcó este
+// punto: cuando execute reusa un PR existente, el iter tiene que numerar la
+// nueva tanda, no quedar fijo en 1.
+func TestRenderValidatorComment_IterPropagated(t *testing.T) {
+	for _, iter := range []int{1, 2, 7} {
+		got := renderValidatorComment(iter, Validator{Agent: AgentCodex, Instance: 2}, "x")
+		want := fmt.Sprintf("iter=%d", iter)
+		if !strings.Contains(got, want) {
+			t.Errorf("iter=%d no aparece en el header:\n%s", iter, got)
+		}
+	}
+}
+
+// TestNextValidatorIter_Empty y sus hermanos cubren la lógica del selector
+// de iter que corre en el caller antes de fireValidators. Sin estos tests,
+// la fix del hardcoded iter=1 queda sin cobertura y puede regresar.
+func TestNextValidatorIter_Empty(t *testing.T) {
+	if got := nextValidatorIter(nil); got != 1 {
+		t.Errorf("sin comments previos, iter debe ser 1; got %d", got)
+	}
+	if got := nextValidatorIter([]PRComment{}); got != 1 {
+		t.Errorf("con slice vacío, iter debe ser 1; got %d", got)
+	}
+}
+
+func TestNextValidatorIter_IgnoraComentariosAjenos(t *testing.T) {
+	cs := []PRComment{
+		{Body: "hola humano aquí, sin header"},
+		{Body: "<!-- claude-cli: flow=explore iter=3 role=executor -->\nplan"},
+		{Body: "<!-- claude-cli: flow=execute iter=4 role=pr-link -->\ncomment al issue"},
+	}
+	if got := nextValidatorIter(cs); got != 1 {
+		t.Errorf("comments de otros flows/roles no deben contar; got %d", got)
+	}
+}
+
+func TestNextValidatorIter_MaxPlusOne(t *testing.T) {
+	cs := []PRComment{
+		{Body: renderValidatorComment(1, Validator{Agent: AgentOpus, Instance: 1}, "a")},
+		{Body: renderValidatorComment(1, Validator{Agent: AgentCodex, Instance: 1}, "b")},
+		{Body: renderValidatorComment(2, Validator{Agent: AgentOpus, Instance: 1}, "c")},
+	}
+	if got := nextValidatorIter(cs); got != 3 {
+		t.Errorf("max(iter)=2 → next=3; got %d", got)
+	}
+}
+
+// TestNextValidatorIter_ReusaRealRoundTrip arma un body como el que postearía
+// execute (via renderValidatorComment) y verifica que nextValidatorIter lo
+// parsea correctamente. Esto ata los dos extremos del contrato: lo que
+// escribimos es lo que después sabemos leer.
+func TestNextValidatorIter_ReusaRealRoundTrip(t *testing.T) {
+	body := renderValidatorComment(5, Validator{Agent: AgentGemini, Instance: 1}, "findings\n")
+	if got := nextValidatorIter([]PRComment{{Body: body}}); got != 6 {
+		t.Errorf("round-trip: iter posteado=5, siguiente debería ser 6; got %d", got)
 	}
 }

--- a/internal/flow/explore/explore.go
+++ b/internal/flow/explore/explore.go
@@ -258,10 +258,13 @@ type CommentHeader struct {
 
 // ParseCommentHeader lee la primera línea del body y, si es un HTML comment
 // de che, devuelve la metadata. Si no lo es, devuelve un CommentHeader vacío.
-// Delega el parseo al helper compartido internal/comments.
+// Delega el parseo al helper compartido internal/comments: si comments.Parse
+// devuelve el zero value (no hay header o está malformado), acá también
+// devolvemos el zero value — así no dependemos de qué campos puntuales
+// considera "marcadores" el helper.
 func ParseCommentHeader(body string) CommentHeader {
 	h := comments.Parse(body)
-	if h.Role == "" && h.Flow == "" {
+	if h == (comments.Header{}) {
 		return CommentHeader{}
 	}
 	return CommentHeader{

--- a/internal/flow/explore/explore.go
+++ b/internal/flow/explore/explore.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/chichex/che/internal/comments"
 	"github.com/chichex/che/internal/labels"
 )
 
@@ -255,34 +256,21 @@ type CommentHeader struct {
 	Role     string // "executor", "validator", "human-request"
 }
 
-// headerRe matchea el HTML comment de che al principio del body. Captura
-// flow, iter, agent, instance, role como key=value dentro del comment.
-var headerRe = regexp.MustCompile(`^<!--\s*claude-cli:\s*(.+?)\s*-->`)
-var kvRe = regexp.MustCompile(`(\w+)=(\S+)`)
-
 // ParseCommentHeader lee la primera línea del body y, si es un HTML comment
 // de che, devuelve la metadata. Si no lo es, devuelve un CommentHeader vacío.
+// Delega el parseo al helper compartido internal/comments.
 func ParseCommentHeader(body string) CommentHeader {
-	m := headerRe.FindStringSubmatch(strings.TrimSpace(body))
-	if m == nil {
+	h := comments.Parse(body)
+	if h.Role == "" && h.Flow == "" {
 		return CommentHeader{}
 	}
-	h := CommentHeader{}
-	for _, kv := range kvRe.FindAllStringSubmatch(m[1], -1) {
-		switch kv[1] {
-		case "flow":
-			h.Flow = kv[2]
-		case "iter":
-			fmt.Sscanf(kv[2], "%d", &h.Iter)
-		case "agent":
-			h.Agent = Agent(kv[2])
-		case "instance":
-			fmt.Sscanf(kv[2], "%d", &h.Instance)
-		case "role":
-			h.Role = kv[2]
-		}
+	return CommentHeader{
+		Flow:     h.Flow,
+		Iter:     h.Iter,
+		Agent:    Agent(h.Agent),
+		Instance: h.Instance,
+		Role:     h.Role,
 	}
-	return h
 }
 
 // IsHuman devuelve true cuando el comment NO tiene header de che — asumimos
@@ -1092,7 +1080,7 @@ func validate(r *Response) error {
 // continuar la conversación sin perder estructura.
 func renderComment(r *Response, agent Agent, iter int) string {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("<!-- claude-cli: flow=explore iter=%d agent=%s role=executor -->\n", iter, agent))
+	sb.WriteString(comments.Header{Flow: "explore", Iter: iter, Agent: string(agent), Role: "executor"}.Format() + "\n")
 	sb.WriteString(fmt.Sprintf("## [executor:%s · iter:%d]\n\n", agent, iter))
 
 	sb.WriteString("**Resumen:** ")
@@ -1431,8 +1419,9 @@ Plan del ejecutor:
 func renderValidatorComment(r validatorResult, iter int) string {
 	v := r.Validator
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("<!-- claude-cli: flow=explore iter=%d agent=%s instance=%d role=validator -->\n",
-		iter, v.Agent, v.Instance))
+	sb.WriteString(comments.Header{
+		Flow: "explore", Iter: iter, Agent: string(v.Agent), Instance: v.Instance, Role: "validator",
+	}.Format() + "\n")
 
 	if r.Err != nil || r.Response == nil {
 		sb.WriteString(fmt.Sprintf("## [validator:%s#%d · iter:%d · ERROR]\n\n", v.Agent, v.Instance, iter))
@@ -1490,7 +1479,7 @@ func renderValidatorComment(r validatorResult, iter int) string {
 // needs_human=true de los validadores que no dupliquen preguntas del plan.
 func renderHumanRequest(issueNumber int, plan *Response, results []validatorResult, iter int) string {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("<!-- claude-cli: flow=explore iter=%d role=human-request -->\n", iter))
+	sb.WriteString(comments.Header{Flow: "explore", Iter: iter, Role: "human-request"}.Format() + "\n")
 	sb.WriteString("## 🧑 Necesito tu input para seguir\n\n")
 
 	planQs := collectPlanBlockers(plan)


### PR DESCRIPTION
Implementa el plan consolidado de #9.

Closes #9
