### PR TITLE
feat(output): paquete internal/output unificado (logger + doctor)

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -2,10 +2,10 @@ package cmd
 
 import (
 	"fmt"
-	"io"
 	"os/exec"
 	"strings"
 
+	"github.com/chichex/che/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -17,7 +17,8 @@ estén instalados, que gh esté autenticado, y que el working dir sea un repo
 con remote a GitHub. Devuelve exit 0 si todo está OK, o 1 si falta algo
 mandatory.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runDoctor(cmd.OutOrStdout())
+		log := output.New(output.NewWriterSink(cmd.OutOrStdout()))
+		return runDoctor(log)
 	},
 }
 
@@ -32,7 +33,7 @@ type checkResult struct {
 	detail   string
 }
 
-func runDoctor(out io.Writer) error {
+func runDoctor(log *output.Logger) error {
 	results := []checkResult{
 		checkBinaryResponds("git", "git"),
 		checkGitHubRemote(),
@@ -45,20 +46,16 @@ func runDoctor(out io.Writer) error {
 
 	failed := 0
 	for _, r := range results {
-		symbol := "✓"
-		if !r.ok {
-			if r.optional {
-				symbol = "⚠"
-			} else {
-				symbol = "✗"
-				failed++
-			}
+		fields := output.F{Detail: r.detail}
+		switch {
+		case r.ok:
+			log.Success(r.label, fields)
+		case r.optional:
+			log.Warn(r.label, fields)
+		default:
+			log.Error(r.label, fields)
+			failed++
 		}
-		line := fmt.Sprintf("%s %s", symbol, r.label)
-		if r.detail != "" {
-			line += " — " + r.detail
-		}
-		fmt.Fprintln(out, line)
 	}
 
 	if failed > 0 {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/mattn/go-isatty v0.0.20
+	github.com/muesli/termenv v0.16.0
 	github.com/spf13/cobra v1.10.2
 )
 
@@ -22,12 +24,10 @@ require (
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/internal/output/event.go
+++ b/internal/output/event.go
@@ -1,0 +1,50 @@
+package output
+
+import "time"
+
+// Level es la severidad del evento.
+//
+// No hay verbosity flags en che (decision cerrada): el Level solo define
+// simbolo y color del render. Nada se filtra por nivel.
+type Level int
+
+const (
+	LevelInfo    Level = iota // paso del flow, sin valor de exito
+	LevelStep                 // sub-paso (dim) — reemplaza progress("…")
+	LevelSuccess              // creacion exitosa, transicion OK, merge
+	LevelWarn                 // best-effort failed, fallback aplicado
+	LevelError                // error fatal o semantico
+)
+
+// F es el bag de metadata estructurada adjunto a cada evento. Todos los
+// campos son opcionales; el renderer omite los vacios.
+//
+// Se llama F (no Fields) para que el call-site quede corto:
+//
+//	log.Success("creado", out.F{Issue: 47, Labels: []string{"type:feat"}})
+type F struct {
+	Issue     int      // renderiza "#47"
+	PR        int      // renderiza "PR #7"
+	Labels    []string // renderiza "[type:feat, ct:plan]"
+	URL       string   // renderiza " · https://…"
+	Agent     string   // renderiza "{opus}"
+	Iter      int      // renderiza "iter=2"
+	Verdict   string   // renderiza "verdict: approve"
+	Validator string   // renderiza "{codex#1}"
+	Attempt   int      // con Total, renderiza "(intento 2/3)"
+	Total     int
+	Cause     error  // renderiza " — error: <msg>"
+	Detail    string // detalle libre al final
+}
+
+// Event es la unidad serializable que fluye entre flow y Sink.
+//
+// El CLI la renderiza con output.Render a una linea ANSI; la TUI la
+// consume cruda y arma su propio render con lipgloss para integrarse
+// con sus estilos (padding, truncate, etc.).
+type Event struct {
+	Time    time.Time
+	Level   Level
+	Message string
+	Fields  F
+}

--- a/internal/output/logger.go
+++ b/internal/output/logger.go
@@ -1,0 +1,51 @@
+package output
+
+import "time"
+
+// Logger es la fachada que usan los flows. Wrapper fino sobre Sink.
+//
+// Se inyecta en Opts por parametro explicito (no context, no singleton):
+// coherente con el patron existente de pasar io.Writer a los flows, y
+// safe bajo t.Parallel en los tests e2e.
+type Logger struct {
+	sink Sink
+}
+
+// New construye un Logger sobre un sink. Si sink es nil, usa NopSink.
+//
+// Esto hace safe pasar Opts{Out: nil} desde call-sites legacy (y desde
+// tests que no quieran asertar sobre output).
+func New(sink Sink) *Logger {
+	if sink == nil {
+		sink = NopSink{}
+	}
+	return &Logger{sink: sink}
+}
+
+// Info emite un evento de nivel Info.
+func (l *Logger) Info(msg string, f ...F) { l.emit(LevelInfo, msg, f) }
+
+// Step emite un evento de nivel Step (sub-paso, dim).
+func (l *Logger) Step(msg string, f ...F) { l.emit(LevelStep, msg, f) }
+
+// Success emite un evento de nivel Success.
+func (l *Logger) Success(msg string, f ...F) { l.emit(LevelSuccess, msg, f) }
+
+// Warn emite un evento de nivel Warn.
+func (l *Logger) Warn(msg string, f ...F) { l.emit(LevelWarn, msg, f) }
+
+// Error emite un evento de nivel Error.
+func (l *Logger) Error(msg string, f ...F) { l.emit(LevelError, msg, f) }
+
+func (l *Logger) emit(lv Level, msg string, ff []F) {
+	var fields F
+	if len(ff) > 0 {
+		fields = ff[0]
+	}
+	l.sink.Emit(Event{
+		Time:    time.Now(),
+		Level:   lv,
+		Message: msg,
+		Fields:  fields,
+	})
+}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1,0 +1,200 @@
+package output_test
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/chichex/che/internal/output"
+)
+
+func TestLogger_NilSinkIsSafe(t *testing.T) {
+	log := output.New(nil)
+	// No debe panicar ni fallar.
+	log.Info("hola")
+	log.Success("ok", output.F{Issue: 1})
+	log.Error("boom", output.F{Cause: errors.New("x")})
+}
+
+func TestCapturingSink_CollectsEvents(t *testing.T) {
+	sink := &output.CapturingSink{}
+	log := output.New(sink)
+
+	log.Info("chequeando repo")
+	log.Success("creado", output.F{Issue: 47, URL: "https://example.test/issues/47"})
+	log.Warn("best-effort fallo", output.F{Detail: "retry=3"})
+	log.Error("boom", output.F{Cause: errors.New("db down")})
+
+	evs := sink.Events()
+	if got, want := len(evs), 4; got != want {
+		t.Fatalf("events len = %d, want %d", got, want)
+	}
+	if evs[0].Level != output.LevelInfo {
+		t.Errorf("ev[0].Level = %v, want LevelInfo", evs[0].Level)
+	}
+	if evs[1].Fields.Issue != 47 {
+		t.Errorf("ev[1].Fields.Issue = %d, want 47", evs[1].Fields.Issue)
+	}
+	if evs[2].Level != output.LevelWarn {
+		t.Errorf("ev[2].Level = %v, want LevelWarn", evs[2].Level)
+	}
+	if evs[3].Fields.Cause == nil || evs[3].Fields.Cause.Error() != "db down" {
+		t.Errorf("ev[3].Fields.Cause = %v, want db down", evs[3].Fields.Cause)
+	}
+}
+
+func TestCapturingSink_FindByMessage(t *testing.T) {
+	sink := &output.CapturingSink{}
+	log := output.New(sink)
+	log.Info("procesando items")
+	log.Success("creado")
+
+	ev, ok := sink.FindByMessage("procesando")
+	if !ok {
+		t.Fatal("FindByMessage no encontro 'procesando'")
+	}
+	if ev.Level != output.LevelInfo {
+		t.Errorf("nivel = %v, want Info", ev.Level)
+	}
+	if _, ok := sink.FindByMessage("no-existe"); ok {
+		t.Error("FindByMessage devolvio true para un substring que no existe")
+	}
+}
+
+func TestCapturingSink_CountByLevel(t *testing.T) {
+	sink := &output.CapturingSink{}
+	log := output.New(sink)
+	log.Info("a")
+	log.Info("b")
+	log.Warn("c")
+
+	if got := sink.CountByLevel(output.LevelInfo); got != 2 {
+		t.Errorf("CountByLevel(Info) = %d, want 2", got)
+	}
+	if got := sink.CountByLevel(output.LevelWarn); got != 1 {
+		t.Errorf("CountByLevel(Warn) = %d, want 1", got)
+	}
+}
+
+func TestWriterSink_NoColorWritesPlainText(t *testing.T) {
+	// bytes.Buffer no es *os.File → shouldColor devuelve false →
+	// NewWriterSink desactiva ANSI. Esto es lo que vamos a asertar en e2e
+	// tests (que corren con stderr redirigido a un pipe).
+	var buf bytes.Buffer
+	sink := output.NewWriterSink(&buf)
+	log := output.New(sink)
+
+	log.Success("creado", output.F{Issue: 47, Labels: []string{"type:feat", "ct:plan"}, URL: "https://example.test/47"})
+	log.Warn("problema", output.F{PR: 7})
+	log.Error("fallo", output.F{Cause: errors.New("timeout")})
+
+	got := buf.String()
+	// No debe haber ANSI escape codes.
+	if strings.Contains(got, "\x1b[") {
+		t.Errorf("output contiene ANSI escape codes en modo no-TTY:\n%s", got)
+	}
+	// Simbolos preservados.
+	for _, want := range []string{"✓", "⚠", "✗"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output no contiene simbolo %q:\n%s", want, got)
+		}
+	}
+	// Mensajes presentes sin prefijos verbales (los simbolos expresan severidad).
+	if !strings.Contains(got, "⚠ problema") {
+		t.Errorf("output no contiene '⚠ problema':\n%s", got)
+	}
+	if !strings.Contains(got, "✗ fallo") {
+		t.Errorf("output no contiene '✗ fallo':\n%s", got)
+	}
+	// Fields estructurados presentes.
+	if !strings.Contains(got, "#47") {
+		t.Errorf("output no contiene '#47':\n%s", got)
+	}
+	if !strings.Contains(got, "[type:feat, ct:plan]") {
+		t.Errorf("output no contiene labels con formato '[a, b]':\n%s", got)
+	}
+	if !strings.Contains(got, "https://example.test/47") {
+		t.Errorf("output no contiene la URL:\n%s", got)
+	}
+	if !strings.Contains(got, "PR") || !strings.Contains(got, "#7") {
+		t.Errorf("output no contiene 'PR #7':\n%s", got)
+	}
+	if !strings.Contains(got, "timeout") {
+		t.Errorf("output no contiene el Cause:\n%s", got)
+	}
+}
+
+func TestWriterSink_OneLinePerEmit(t *testing.T) {
+	var buf bytes.Buffer
+	log := output.New(output.NewWriterSink(&buf))
+
+	log.Info("a")
+	log.Info("b")
+	log.Info("c")
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if got, want := len(lines), 3; got != want {
+		t.Errorf("lines = %d, want %d:\n%s", got, want, buf.String())
+	}
+}
+
+func TestWriterSink_ConcurrentSafe(t *testing.T) {
+	// Simulamos el caso de execute: varias goroutines emiten en paralelo.
+	// Sin mutex se entrelazarian a media linea. Con mutex, cada linea
+	// queda entera.
+	var buf bytes.Buffer
+	log := output.New(output.NewWriterSink(&buf))
+
+	const goroutines = 16
+	const perGoroutine = 32
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < perGoroutine; i++ {
+				log.Info("paralelo", output.F{Issue: id*1000 + i})
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+	if got, want := len(lines), goroutines*perGoroutine; got != want {
+		t.Fatalf("lines = %d, want %d (hay entrelazado?)", got, want)
+	}
+	// Cada linea debe empezar con el simbolo de info.
+	for i, ln := range lines {
+		if !strings.HasPrefix(ln, "▸") {
+			t.Errorf("linea %d no empieza con simbolo de info (entrelazado?): %q", i, ln)
+			break
+		}
+	}
+}
+
+func TestNopSink_DoesNothing(t *testing.T) {
+	// Probamos que no panica y que no afecta al logger.
+	log := output.New(output.NopSink{})
+	log.Info("x")
+	log.Success("y")
+	log.Error("z", output.F{Cause: errors.New("e")})
+}
+
+func TestRender_FunctionReturnsString(t *testing.T) {
+	// Render() es util para la TUI que quiera pre-renderizar usando el
+	// mismo formato del CLI.
+	got := output.Render(output.Event{
+		Level:   output.LevelSuccess,
+		Message: "creado",
+		Fields:  output.F{Issue: 42},
+	})
+	if !strings.Contains(got, "creado") {
+		t.Errorf("Render no contiene el message: %q", got)
+	}
+	if !strings.Contains(got, "#42") {
+		t.Errorf("Render no contiene el issue: %q", got)
+	}
+}

--- a/internal/output/render.go
+++ b/internal/output/render.go
@@ -1,0 +1,160 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-isatty"
+	"github.com/muesli/termenv"
+)
+
+// writerSink renderiza Events a un io.Writer con ANSI opcional.
+//
+// Safe para uso concurrente: execute corre validadores async que pueden
+// emitir desde multiples goroutines. El mutex serializa writes para que
+// las lineas no se entrelacen a media salida.
+type writerSink struct {
+	w        io.Writer
+	mu       sync.Mutex
+	renderer *lipgloss.Renderer
+}
+
+// NewWriterSink construye un Sink que escribe a w.
+//
+// Auto-detecta TTY y respeta NO_COLOR/CI: si w no es terminal, o si
+// NO_COLOR/CI estan seteados, desactiva ANSI. Esto hace safe redirigir
+// a archivo o pipear sin ensuciar la salida con escape codes.
+func NewWriterSink(w io.Writer) Sink {
+	r := lipgloss.NewRenderer(w)
+	if !shouldColor(w) {
+		r.SetColorProfile(termenv.Ascii)
+	}
+	return &writerSink{w: w, renderer: r}
+}
+
+// Emit renderiza y escribe. Atomic via mutex (una linea por Emit).
+func (s *writerSink) Emit(ev Event) {
+	line := s.render(ev) + "\n"
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, _ = io.WriteString(s.w, line)
+}
+
+func (s *writerSink) render(ev Event) string {
+	sym := s.style(styleForLevel(ev.Level)).Render(symbolFor(ev.Level))
+	bodyColored := s.style(styleForLevel(ev.Level)).Render(ev.Message)
+
+	parts := []string{sym, bodyColored}
+
+	if suffix := s.renderFields(ev.Fields); suffix != "" {
+		parts = append(parts, suffix)
+	}
+	return strings.Join(parts, " ")
+}
+
+// renderFields compone los campos estructurados en un sufijo con orden
+// predecible. Cada campo vacio se omite. Si no hay ningun campo, devuelve
+// cadena vacia y el render no agrega espacio trailing.
+func (s *writerSink) renderFields(f F) string {
+	var out []string
+
+	if f.Issue > 0 {
+		out = append(out, s.style(styleNumber).Render(fmt.Sprintf("#%d", f.Issue)))
+	}
+	if f.PR > 0 {
+		out = append(out, s.style(styleMuted).Render("PR")+" "+s.style(styleNumber).Render(fmt.Sprintf("#%d", f.PR)))
+	}
+	if len(f.Labels) > 0 {
+		out = append(out, s.renderLabels(f.Labels))
+	}
+	if f.Iter > 0 {
+		out = append(out, s.style(styleMuted).Render(fmt.Sprintf("iter=%d", f.Iter)))
+	}
+	if f.Agent != "" {
+		out = append(out, s.style(styleAgent).Render("{"+f.Agent+"}"))
+	}
+	if f.Validator != "" {
+		out = append(out, s.style(styleAgent).Render("{"+f.Validator+"}"))
+	}
+	if f.Attempt > 0 && f.Total > 0 {
+		out = append(out, s.style(styleMuted).Render(fmt.Sprintf("(intento %d/%d)", f.Attempt, f.Total)))
+	}
+	if f.Verdict != "" {
+		out = append(out, s.renderVerdict(f.Verdict))
+	}
+	if f.Cause != nil {
+		out = append(out, s.style(styleMuted).Render("—")+" "+s.style(styleError).Render("error: "+f.Cause.Error()))
+	}
+	if f.Detail != "" {
+		out = append(out, s.style(styleMuted).Render("("+f.Detail+")"))
+	}
+	if f.URL != "" {
+		out = append(out, s.style(styleMuted).Render("·")+" "+s.style(styleURL).Render(f.URL))
+	}
+
+	return strings.Join(out, " ")
+}
+
+func (s *writerSink) renderLabels(labels []string) string {
+	colored := make([]string, len(labels))
+	for i, l := range labels {
+		colored[i] = s.style(styleLabels).Render(l)
+	}
+	sep := s.style(styleMuted).Render(", ")
+	open := s.style(styleMuted).Render("[")
+	close := s.style(styleMuted).Render("]")
+	return open + strings.Join(colored, sep) + close
+}
+
+func (s *writerSink) renderVerdict(v string) string {
+	label := s.style(styleMuted).Render("verdict:")
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "approve":
+		return label + " " + s.style(styleVerdictOK).Render(v)
+	case "changes_requested", "changes-requested", "needs_human", "needs-human":
+		return label + " " + s.style(styleVerdictKO).Render(v)
+	default:
+		return label + " " + s.style(styleMuted).Render(v)
+	}
+}
+
+// style asocia el renderer del sink al estilo recibido. Como Style es
+// value type, devuelve una copia con el renderer correcto (sin mutar el
+// global).
+func (s *writerSink) style(base lipgloss.Style) lipgloss.Style {
+	return base.Renderer(s.renderer)
+}
+
+// shouldColor decide si habilitar ANSI para el writer dado.
+//
+// Reglas: NO_COLOR wins (https://no-color.org), CI desactiva color por
+// convencion, y si w no es *os.File o no es TTY tampoco hay color.
+func shouldColor(w io.Writer) bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	if os.Getenv("CI") != "" {
+		return false
+	}
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	return isatty.IsTerminal(f.Fd())
+}
+
+// Render es la funcion utility para obtener el string renderizado de un
+// Event sin tener que construir un Sink. Utilizada por la TUI para reusar
+// exactamente el mismo formato que el CLI cuando le conviene (ej. log
+// line en runLog).
+//
+// El renderer asociado esta desacoplado de cualquier TTY: no escribe, y
+// deja los estilos con el default profile global de lipgloss.
+func Render(ev Event) string {
+	sink := &writerSink{renderer: lipgloss.DefaultRenderer()}
+	return sink.render(ev)
+}

--- a/internal/output/sink.go
+++ b/internal/output/sink.go
@@ -1,0 +1,21 @@
+package output
+
+// Sink es el destino final de eventos.
+//
+// Implementaciones:
+//   - writerSink: renderiza a un io.Writer con ANSI (CLI).
+//   - NopSink: descarta todo (tests, modo silencioso, fallback).
+//   - CapturingSink: colecciona eventos en memoria (tests).
+//   - eventSink (en internal/tui): empuja a un channel de tea.Msg.
+//
+// Las implementaciones DEBEN ser concurrency-safe: execute corre
+// validadores async que pueden emitir desde goroutines paralelas.
+type Sink interface {
+	Emit(Event)
+}
+
+// NopSink descarta todos los eventos. Safe por construccion.
+type NopSink struct{}
+
+// Emit descarta el evento.
+func (NopSink) Emit(Event) {}

--- a/internal/output/style.go
+++ b/internal/output/style.go
@@ -1,0 +1,80 @@
+package output
+
+import "github.com/charmbracelet/lipgloss"
+
+// Paleta Dracula.
+//
+// KEEP IN SYNC with internal/tui/styles.go. Se duplica aqui adrede para
+// evitar ciclo de imports (tui ya importa flow, y flow va a importar
+// internal/output).
+var (
+	colorPrimary = lipgloss.Color("#00D7FF") // cyan brillante
+	colorAccent  = lipgloss.Color("#FF79C6") // magenta — labels, numeros
+	colorSuccess = lipgloss.Color("#50FA7B") // verde — OK
+	colorError   = lipgloss.Color("#FF5555") // rojo — errores
+	colorMuted   = lipgloss.Color("#6272A4") // gris — hints, separadores
+	colorText    = lipgloss.Color("#F8F8F2") // off-white — texto normal
+	colorWarn    = lipgloss.Color("#F1FA8C") // amarillo Dracula — warnings
+)
+
+// Simbolos por Level. Matchean la convencion preexistente de doctor.go.
+const (
+	symInfo    = "▸"
+	symStep    = "·"
+	symSuccess = "✓"
+	symWarn    = "⚠"
+	symError   = "✗"
+)
+
+// Estilos lipgloss por componente. Se inicializan sin renderer asociado;
+// el writerSink los aplica con su propio renderer (que respeta TTY y
+// NO_COLOR).
+var (
+	styleInfo    = lipgloss.NewStyle().Foreground(colorText)
+	styleStep    = lipgloss.NewStyle().Foreground(colorMuted)
+	styleSuccess = lipgloss.NewStyle().Foreground(colorSuccess)
+	styleWarn    = lipgloss.NewStyle().Foreground(colorWarn)
+	styleError   = lipgloss.NewStyle().Foreground(colorError).Bold(true)
+
+	styleNumber    = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
+	styleLabels    = lipgloss.NewStyle().Foreground(colorAccent)
+	styleURL       = lipgloss.NewStyle().Foreground(colorMuted).Underline(true)
+	styleMuted     = lipgloss.NewStyle().Foreground(colorMuted)
+	styleAgent     = lipgloss.NewStyle().Foreground(colorPrimary).Bold(true)
+	styleVerdictOK = lipgloss.NewStyle().Foreground(colorSuccess).Bold(true)
+	styleVerdictKO = lipgloss.NewStyle().Foreground(colorError).Bold(true)
+)
+
+// symbolFor devuelve el simbolo del Level.
+func symbolFor(lv Level) string {
+	switch lv {
+	case LevelInfo:
+		return symInfo
+	case LevelStep:
+		return symStep
+	case LevelSuccess:
+		return symSuccess
+	case LevelWarn:
+		return symWarn
+	case LevelError:
+		return symError
+	}
+	return symInfo
+}
+
+// styleForLevel devuelve el estilo del texto base segun Level.
+func styleForLevel(lv Level) lipgloss.Style {
+	switch lv {
+	case LevelInfo:
+		return styleInfo
+	case LevelStep:
+		return styleStep
+	case LevelSuccess:
+		return styleSuccess
+	case LevelWarn:
+		return styleWarn
+	case LevelError:
+		return styleError
+	}
+	return styleInfo
+}

--- a/internal/output/testing.go
+++ b/internal/output/testing.go
@@ -1,0 +1,65 @@
+package output
+
+import (
+	"strings"
+	"sync"
+)
+
+// CapturingSink colecciona Events en memoria. Concurrency-safe.
+//
+// Pensado para tests unitarios de flows: despues de correr el flow con
+// un Logger sobre un CapturingSink, se puede asertar sobre los eventos
+// estructurados (sin tener que parsear ANSI).
+type CapturingSink struct {
+	mu     sync.Mutex
+	events []Event
+}
+
+// Emit colecciona el evento.
+func (s *CapturingSink) Emit(ev Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, ev)
+}
+
+// Events devuelve una copia de los eventos capturados hasta el momento.
+func (s *CapturingSink) Events() []Event {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]Event, len(s.events))
+	copy(out, s.events)
+	return out
+}
+
+// Reset vacia la lista de eventos. Util entre sub-tests.
+func (s *CapturingSink) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = nil
+}
+
+// FindByMessage devuelve el primer evento cuyo Message contenga substr.
+// El bool indica si se encontro.
+func (s *CapturingSink) FindByMessage(substr string) (Event, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, ev := range s.events {
+		if strings.Contains(ev.Message, substr) {
+			return ev, true
+		}
+	}
+	return Event{}, false
+}
+
+// CountByLevel devuelve cuantos eventos hay del nivel dado.
+func (s *CapturingSink) CountByLevel(lv Level) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, ev := range s.events {
+		if ev.Level == lv {
+			n++
+		}
+	}
+	return n
+}


### PR DESCRIPTION
## Summary

- Introduce `internal/output`: sistema unificado de logging para CLI y TUI. Logger con niveles `Info/Step/Success/Warn/Error`, eventos con campos estructurados (`F{Issue, PR, Labels, URL, Agent, Verdict, ...}`), símbolos `▸·✓⚠✗` y paleta Dracula (en sync con `internal/tui/styles.go`).
- `writerSink` concurrency-safe con mutex, auto-detección TTY + respeto a `NO_COLOR`/`CI`. `CapturingSink` para tests.
- Migra `cmd/doctor.go` como primer call-site. El formato `<sym> <label>` se preserva, tests e2e de doctor pasan sin cambios.

PR 1 de 2: acá va el paquete base + doctor. El PR 2 migrará el resto de los flows (`idea`, `close`, `validate`, `iterate`, `explore`, `execute`).

## Test plan

- [x] `go test ./...` verde local
- [x] `go test ./e2e/... -run Doctor` verde (7 tests)
- [x] Build limpio
- [ ] Probar visualmente `che doctor` en terminal con TTY (colores Dracula)
- [ ] CI verde

🤖 Generated with [Claude Code](https://claude.com/claude-code)