### PR TITLE
feat(output): migrar los 6 flows al logger unificado + eventSink de TUI

### DIFF
--- a/cmd/close.go
+++ b/cmd/close.go
@@ -5,6 +5,7 @@ import (
 
 	closing "github.com/chichex/che/internal/flow/close"
 	"github.com/chichex/che/internal/flow/validate"
+	"github.com/chichex/che/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +49,7 @@ No hay flag --agent: close usa opus (claude) por diseño.`,
 		}
 		code := closing.Run(args[0], closing.Opts{
 			Stdout:     cmd.OutOrStdout(),
-			Stderr:     cmd.ErrOrStderr(),
+			Out:        output.New(output.NewWriterSink(cmd.ErrOrStderr())),
 			KeepBranch: closeKeepBranch,
 		})
 		if code != closing.ExitOK {

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 
 	"github.com/chichex/che/internal/flow/execute"
+	"github.com/chichex/che/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -63,7 +64,7 @@ Este subcomando es la ruta no-interactiva (scripting/CI). La TUI de che
 
 		code := execute.Run(args[0], execute.Opts{
 			Stdout:     cmd.OutOrStdout(),
-			Stderr:     cmd.ErrOrStderr(),
+			Out:        output.New(output.NewWriterSink(cmd.ErrOrStderr())),
 			Agent:      agent,
 			Validators: validators,
 			Ctx:        ctx,

--- a/cmd/explore.go
+++ b/cmd/explore.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/chichex/che/internal/flow/explore"
+	"github.com/chichex/che/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -52,7 +53,7 @@ Este subcomando es la ruta no-interactiva (scripting/CI). La TUI de che
 		}
 		code := explore.Run(args[0], explore.Opts{
 			Stdout:     cmd.OutOrStdout(),
-			Stderr:     cmd.ErrOrStderr(),
+			Out:        output.New(output.NewWriterSink(cmd.ErrOrStderr())),
 			Agent:      agent,
 			Validators: validators,
 		})

--- a/cmd/idea.go
+++ b/cmd/idea.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/chichex/che/internal/flow/idea"
+	"github.com/chichex/che/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +35,7 @@ Este subcomando es la ruta no-interactiva (scripting/CI). La TUI de che
 		}
 		code := idea.Run(text, idea.Opts{
 			Stdout: cmd.OutOrStdout(),
-			Stderr: cmd.ErrOrStderr(),
+			Out:    output.New(output.NewWriterSink(cmd.ErrOrStderr())),
 		})
 		if code != idea.ExitOK {
 			os.Exit(int(code))

--- a/cmd/iterate.go
+++ b/cmd/iterate.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/chichex/che/internal/flow/iterate"
 	"github.com/chichex/che/internal/flow/validate"
+	"github.com/chichex/che/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -45,7 +46,7 @@ No hay flag --agent: iterate usa opus (claude) por diseño.`,
 		}
 		code := iterate.Run(args[0], iterate.Opts{
 			Stdout: cmd.OutOrStdout(),
-			Stderr: cmd.ErrOrStderr(),
+			Out:    output.New(output.NewWriterSink(cmd.ErrOrStderr())),
 		})
 		if code != iterate.ExitOK {
 			cmd.SilenceUsage = true

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/chichex/che/internal/flow/validate"
+	"github.com/chichex/che/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -50,7 +51,7 @@ abrir el HTML.`,
 		}
 		code := validate.Run(args[0], validate.Opts{
 			Stdout:     cmd.OutOrStdout(),
-			Stderr:     cmd.ErrOrStderr(),
+			Out:        output.New(output.NewWriterSink(cmd.ErrOrStderr())),
 			Validators: validators,
 		})
 		if code != validate.ExitOK {

--- a/internal/flow/close/closing.go
+++ b/internal/flow/close/closing.go
@@ -30,6 +30,7 @@ import (
 	"github.com/chichex/che/internal/flow/execute"
 	"github.com/chichex/che/internal/flow/validate"
 	"github.com/chichex/che/internal/labels"
+	"github.com/chichex/che/internal/output"
 )
 
 // ExitCode es el código de salida semántico para el caller.
@@ -86,11 +87,11 @@ var CIPollInterval = func() time.Duration {
 	return 15 * time.Second
 }()
 
-// Opts agrupa los writers y la callback de progreso.
+// Opts agrupa el writer de stdout (payload) y el logger estructurado
+// (progress + errors). Si Out es nil, el flow corre silencioso.
 type Opts struct {
-	Stdout     io.Writer
-	Stderr     io.Writer
-	OnProgress func(string)
+	Stdout io.Writer
+	Out    *output.Logger
 	// KeepBranch omite el --delete-branch del merge y el cleanup del
 	// worktree asociado. Default false: tras mergear, che close borra la
 	// branch remota/local y remueve el worktree para dejar el repo limpio.
@@ -302,58 +303,61 @@ func hasBlockingLabel(p validate.PullRequest) bool {
 //     · failure path: limpia solo si el worktree es propio del run, para no
 //       borrar trabajo del usuario en worktrees reusados.
 func Run(prRef string, opts Opts) ExitCode {
-	stdout, stderr := opts.Stdout, opts.Stderr
-	keepBranch := opts.KeepBranch
-	progress := opts.OnProgress
-	if progress == nil {
-		progress = func(string) {}
+	stdout := opts.Stdout
+	if stdout == nil {
+		stdout = io.Discard
 	}
+	log := opts.Out
+	if log == nil {
+		log = output.New(nil)
+	}
+	keepBranch := opts.KeepBranch
 
 	prRef = strings.TrimSpace(prRef)
 	if prRef == "" {
-		fmt.Fprintln(stderr, "error: pr ref is empty")
+		log.Error("pr ref is empty")
 		return ExitSemantic
 	}
 	if _, err := validate.ParsePRRef(prRef); err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("pr ref invalido", output.F{Cause: err})
 		return ExitSemantic
 	}
 
-	progress("chequeando repo git y auth de GitHub…")
+	log.Info("chequeando repo git y auth de GitHub")
 	repoRoot, err := repoToplevel()
 	if err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("git repo invalido", output.F{Cause: err})
 		return ExitRetry
 	}
 	if err := precheckGitHubRemote(); err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("github remote invalido", output.F{Cause: err})
 		return ExitRetry
 	}
 	if err := precheckGhAuth(); err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("gh auth fallo", output.F{Cause: err})
 		return ExitRetry
 	}
 
-	progress("obteniendo PR desde GitHub…")
+	log.Info("obteniendo PR desde GitHub")
 	pr, err := FetchPR(prRef)
 	if err != nil {
-		fmt.Fprintf(stderr, "error: fetching PR: %v\n", err)
+		log.Error("fetching PR failed", output.F{Cause: err})
 		return ExitRetry
 	}
 	if pr.State != "OPEN" {
-		fmt.Fprintf(stderr, "error: PR #%d is not OPEN (state=%s)\n", pr.Number, pr.State)
+		log.Error(fmt.Sprintf("PR #%d is not OPEN (state=%s)", pr.Number, pr.State))
 		return ExitSemantic
 	}
 
 	if blocking := BlockingVerdict(pr); blocking != "" {
-		fmt.Fprintf(stderr, "⚠ warning: PR #%d tiene label %s — procedo igual porque así lo pediste.\n",
-			pr.Number, blocking)
+		log.Warn(fmt.Sprintf("warning: PR #%d tiene verdict bloqueante — procedo igual porque así lo pediste", pr.Number),
+			output.F{Labels: []string{blocking}})
 	}
 
 	if pr.IsDraft {
-		progress(fmt.Sprintf("PR #%d está en draft — pasándolo a ready for review…", pr.Number))
+		log.Step(fmt.Sprintf("PR #%d está en draft — pasando a ready for review", pr.Number))
 		if err := prReady(prRef); err != nil {
-			fmt.Fprintf(stderr, "error: %v\n", err)
+			log.Error("gh pr ready fallo", output.F{PR: pr.Number, Cause: err})
 			return ExitRetry
 		}
 	}
@@ -381,7 +385,7 @@ func Run(prRef string, opts Opts) ExitCode {
 		}
 		wtCtx, wtCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer wtCancel()
-		cleanupWorktree(wtCtx, stderr, repoRoot, wt)
+		cleanupWorktree(wtCtx, log, repoRoot, wt)
 	}()
 
 	issueNum := firstClosingIssue(pr)
@@ -389,17 +393,17 @@ func Run(prRef string, opts Opts) ExitCode {
 	for attempt := 1; attempt <= MaxFixAttempts+1; attempt++ {
 		// Refrescar estado del PR (mergeable puede venir UNKNOWN en la
 		// primera vista; github lo computa lazy).
-		progress(fmt.Sprintf("chequeando estado del PR (intento %d/%d)…", attempt, MaxFixAttempts+1))
+		log.Step("chequeando estado del PR", output.F{Attempt: attempt, Total: MaxFixAttempts + 1, PR: pr.Number})
 		freshPR, err := FetchPR(prRef)
 		if err != nil {
-			fmt.Fprintf(stderr, "error: %v\n", err)
+			log.Error("fetching PR failed", output.F{Cause: err})
 			return ExitRetry
 		}
 		pr = freshPR
 
 		checks, err := FetchChecks(prRef)
 		if err != nil {
-			fmt.Fprintf(stderr, "error: %v\n", err)
+			log.Error("fetching checks failed", output.F{Cause: err})
 			return ExitRetry
 		}
 
@@ -409,22 +413,24 @@ func Run(prRef string, opts Opts) ExitCode {
 		lastProblems = problems
 
 		if len(problems) == 0 {
-			progress("PR mergeable y CI verde — procediendo al merge")
+			log.Success("PR mergeable y CI verde", output.F{PR: pr.Number})
 			break
 		}
 
 		if attempt > MaxFixAttempts {
-			fmt.Fprintf(stderr, "error: agotados %d intentos de fix; problemas restantes: %s\n",
-				MaxFixAttempts, strings.Join(problems, ", "))
+			log.Error(fmt.Sprintf("agotados %d intentos de fix; problemas restantes: %s",
+				MaxFixAttempts, strings.Join(problems, ", ")),
+				output.F{PR: pr.Number})
 			return ExitRetry
 		}
 
-		progress(fmt.Sprintf("problemas detectados: %s — intentando fix con opus", strings.Join(problems, ", ")))
+		log.Warn(fmt.Sprintf("problemas detectados: %s — intentando fix con opus", strings.Join(problems, ", ")),
+			output.F{PR: pr.Number, Agent: "opus"})
 
 		if wt == nil {
 			w, owned, err := resolveWorktree(repoRoot, issueNum, pr.HeadBranch)
 			if err != nil {
-				fmt.Fprintf(stderr, "error: %v\n", err)
+				log.Error("resolver worktree fallo", output.F{Cause: err})
 				return ExitRetry
 			}
 			wt = w
@@ -432,16 +438,16 @@ func Run(prRef string, opts Opts) ExitCode {
 		}
 
 		prompt := buildFixPrompt(pr, conflict, failingChecks(checks))
-		if err := runAgent(wt.Path, prompt, progress); err != nil {
-			fmt.Fprintf(stderr, "error: agente falló: %v\n", err)
+		if err := runAgent(wt.Path, prompt, log); err != nil {
+			log.Error("agente falló", output.F{Agent: "opus", Cause: err})
 			return ExitRetry
 		}
 
-		progress("esperando que CI re-evalúe tras el push del agente…")
-		if err := waitCIStable(prRef, progress); err != nil {
+		log.Step("esperando que CI re-evalúe tras el push del agente")
+		if err := waitCIStable(prRef, log); err != nil {
 			// waitCIStable no retorna error fatal si vencía el timeout —
 			// solo si gh explotó. En timeout seguimos al próximo intento.
-			fmt.Fprintf(stderr, "warning: %v\n", err)
+			log.Warn(fmt.Sprintf("warning: %v", err))
 		}
 	}
 
@@ -469,9 +475,9 @@ func Run(prRef string, opts Opts) ExitCode {
 		preRemoteKnown = known
 	}
 
-	progress(fmt.Sprintf("mergeando PR #%d con merge commit…", pr.Number))
+	log.Step(fmt.Sprintf("mergeando PR #%d con merge commit", pr.Number))
 	if err := mergePR(prRef, keepBranch); err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("gh pr merge fallo", output.F{PR: pr.Number, Cause: err})
 		return ExitRetry
 	}
 	mergedOK = true
@@ -482,8 +488,9 @@ func Run(prRef string, opts Opts) ExitCode {
 	// en el body del PR quedan OPEN un tiempo hasta que github procesa el
 	// auto-close; hacemos un close explícito para no depender de eso y para
 	// aplicar la transición de labels atómicamente con el cierre.
-	closedIssues := closeAssociatedIssues(pr, stderr, progress)
+	closedIssues := closeAssociatedIssues(pr, log)
 
+	log.Success("merged PR", output.F{PR: pr.Number, URL: pr.URL})
 	fmt.Fprintf(stdout, "Closed PR %s\n", pr.URL)
 	if len(closedIssues) > 0 {
 		fmt.Fprintf(stdout, "Cerrado(s) issue(s): %s\n", joinInts(closedIssues))
@@ -529,7 +536,7 @@ func firstClosingIssue(pr *PullRequest) int {
 // (status:executed → status:closed). Errores no fatales (log + seguir).
 // Devuelve la lista de números de issues que se cerraron efectivamente
 // (para reporte en stdout).
-func closeAssociatedIssues(pr *PullRequest, stderr io.Writer, progress func(string)) []int {
+func closeAssociatedIssues(pr *PullRequest, log *output.Logger) []int {
 	var closed []int
 	for _, ref := range pr.ClosingIssuesReferences {
 		if ref.Number == 0 {
@@ -539,17 +546,19 @@ func closeAssociatedIssues(pr *PullRequest, stderr io.Writer, progress func(stri
 		// Si github ya lo cerró por el merge auto, el issueClose es
 		// idempotente (devuelve error que ignoramos) pero la transición de
 		// labels sí queremos aplicarla igual.
-		progress(fmt.Sprintf("cerrando issue #%d…", ref.Number))
+		log.Step("cerrando issue", output.F{Issue: ref.Number})
 		if err := issueClose(refStr); err != nil {
-			fmt.Fprintf(stderr, "warning: no se pudo cerrar issue #%d: %v\n", ref.Number, err)
+			log.Warn(fmt.Sprintf("warning: no se pudo cerrar issue #%d", ref.Number),
+				output.F{Issue: ref.Number, Cause: err})
 		} else {
 			closed = append(closed, ref.Number)
+			log.Success("issue cerrado", output.F{Issue: ref.Number, Labels: []string{labels.StatusClosed}})
 		}
 		// Transición de labels. Best-effort: si el issue no estaba en
 		// status:executed, la transición falla — lo logueamos y seguimos.
 		if err := labels.Apply(refStr, labels.StatusExecuted, labels.StatusClosed); err != nil {
-			fmt.Fprintf(stderr, "warning: labels del issue #%d no transicionaron a status:closed: %v\n",
-				ref.Number, err)
+			log.Warn(fmt.Sprintf("warning: labels del issue #%d no transicionaron a status:closed", ref.Number),
+				output.F{Issue: ref.Number, Cause: err})
 		}
 	}
 	return closed
@@ -841,7 +850,7 @@ func buildFixPrompt(pr *PullRequest, conflicts bool, failingChecks []Check) stri
 // en el worktree para que los tool use (Edit, Bash) afecten esa copia del
 // repo. Usa stream-json + formatOpusLine para que los eventos aparezcan en
 // el progress. Mismo patrón que execute.runAgent.
-func runAgent(cwd, prompt string, progress func(string)) error {
+func runAgent(cwd, prompt string, log *output.Logger) error {
 	ctx, cancel := context.WithTimeout(context.Background(), AgentTimeout)
 	defer cancel()
 
@@ -864,8 +873,8 @@ func runAgent(cwd, prompt string, progress func(string)) error {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	var stderrBuf strings.Builder
-	go streamPipe(&wg, stdoutPipe, nil, progress, "opus: ", formatOpusLine)
-	go streamPipe(&wg, stderrPipe, &stderrBuf, progress, "opus stderr: ", nil)
+	go streamPipe(&wg, stdoutPipe, nil, log, "opus: ", formatOpusLine)
+	go streamPipe(&wg, stderrPipe, &stderrBuf, log, "opus stderr: ", nil)
 	wg.Wait()
 
 	waitErr := cmd.Wait()
@@ -886,7 +895,7 @@ func runAgent(cwd, prompt string, progress func(string)) error {
 
 // streamPipe lee un pipe y reenvía las líneas al progress. Si format no
 // es nil, cada línea se pasa por él. Igual patrón que execute.
-func streamPipe(wg *sync.WaitGroup, r io.Reader, acc *strings.Builder, progress func(string), prefix string, format func(string) (string, bool)) {
+func streamPipe(wg *sync.WaitGroup, r io.Reader, acc *strings.Builder, log *output.Logger, prefix string, format func(string) (string, bool)) {
 	defer wg.Done()
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
@@ -903,8 +912,8 @@ func streamPipe(wg *sync.WaitGroup, r io.Reader, acc *strings.Builder, progress 
 			}
 			out = msg
 		}
-		if strings.TrimSpace(out) != "" && progress != nil {
-			progress(prefix + out)
+		if strings.TrimSpace(out) != "" && log != nil {
+			log.Step(prefix + out)
 		}
 	}
 }
@@ -1167,20 +1176,20 @@ func runGit(repoRoot string, args ...string) error {
 // worktree creado por el usuario fuera de ese prefijo, NO lo tocamos —
 // avisamos por stderr para que el humano decida. Hacerlo gratis sería un
 // side effect no anunciado del `che close`.
-func cleanupWorktree(ctx context.Context, stderr io.Writer, repoRoot string, wt *execute.Worktree) {
+func cleanupWorktree(ctx context.Context, log *output.Logger, repoRoot string, wt *execute.Worktree) {
 	if wt == nil {
 		return
 	}
 	if samePath(repoRoot, wt.Path) {
-		fmt.Fprintf(stderr, "warning: la branch del PR estaba checkouteada en el worktree principal (%s) — che close no modifica el cwd del usuario. La branch remota fue borrada por `gh pr merge --delete-branch`; la local queda hasta que la elimines con `git branch -D %s`.\n", wt.Path, wt.Branch)
+		log.Warn(fmt.Sprintf("warning: la branch del PR estaba checkouteada en el worktree principal (%s) — che close no modifica el cwd del usuario. La branch remota fue borrada por gh pr merge --delete-branch; la local queda hasta que la elimines con git branch -D %s", wt.Path, wt.Branch))
 		return
 	}
 	if !isCheManagedWorktree(repoRoot, wt.Path) {
-		fmt.Fprintf(stderr, "warning: la branch del PR estaba checkouteada en un worktree fuera de `.worktrees/` (%s) — che close no toca worktrees que no creó. Limpialo a mano si querés con `git worktree remove %s`.\n", wt.Path, wt.Path)
+		log.Warn(fmt.Sprintf("warning: la branch del PR estaba checkouteada en un worktree fuera de .worktrees/ (%s) — che close no toca worktrees que no creó. Limpialo a mano con git worktree remove %s", wt.Path, wt.Path))
 		return
 	}
 	if err := wt.Cleanup(ctx, repoRoot, false); err != nil {
-		fmt.Fprintf(stderr, "warning: cleanup local parcial: %v — revisá `git worktree list` y `git branch` para limpiar a mano\n", err)
+		log.Warn("cleanup local parcial — revisá git worktree list y git branch para limpiar a mano", output.F{Cause: err})
 	}
 }
 
@@ -1271,7 +1280,7 @@ func remoteBranchExists(repoRoot, branch string) (exists bool, known bool) {
 // waitCIStable pollea `gh pr checks` hasta que el CI deje de estar pending
 // o venza CIPollTimeout. No retorna error de timeout — solo de gh roto.
 // El Run evalúa el CI final en la siguiente iteración del loop.
-func waitCIStable(ref string, progress func(string)) error {
+func waitCIStable(ref string, log *output.Logger) error {
 	deadline := time.Now().Add(CIPollTimeout)
 	for {
 		checks, err := FetchChecks(ref)
@@ -1285,7 +1294,7 @@ func waitCIStable(ref string, progress func(string)) error {
 		if time.Now().After(deadline) {
 			return fmt.Errorf("CI sigue pending tras %s — próximo intento va a re-chequear", CIPollTimeout)
 		}
-		progress(fmt.Sprintf("CI corriendo (%d checks)… próximo poll en %s", len(checks), CIPollInterval))
+		log.Step(fmt.Sprintf("CI corriendo (%d checks) — próximo poll en %s", len(checks), CIPollInterval))
 		time.Sleep(CIPollInterval)
 	}
 }

--- a/internal/flow/execute/execute.go
+++ b/internal/flow/execute/execute.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/chichex/che/internal/comments"
 	"github.com/chichex/che/internal/labels"
+	"github.com/chichex/che/internal/output"
 	planpkg "github.com/chichex/che/internal/plan"
 )
 
@@ -138,12 +139,12 @@ var ValidatorsWaitTimeout = func() time.Duration {
 	return 10 * time.Minute
 }()
 
-// Opts agrupa los writers, la callback de progreso y el agente ejecutor.
+// Opts agrupa el writer de stdout (payload: "Executed ...", "PR: ..."),
+// el logger estructurado (progress + errors) y el agente ejecutor.
 type Opts struct {
-	Stdout     io.Writer
-	Stderr     io.Writer
-	OnProgress func(string)
-	Agent      Agent
+	Stdout io.Writer
+	Out    *output.Logger
+	Agent  Agent
 	// Validators son los agentes que postean findings en el PR después de
 	// crearlo. execute NO espera por ellos (fire-and-forget).
 	Validators []Validator
@@ -285,11 +286,21 @@ func preparePlan(body string) (*ConsolidatedPlan, error) {
 //   - Rollback: si algo falla después del lock, revertir a status:plan y
 //     limpiar worktree.
 func Run(issueRef string, opts Opts) ExitCode {
-	stdout, stderr := opts.Stdout, opts.Stderr
-	progress := opts.OnProgress
-	if progress == nil {
-		progress = func(string) {}
+	stdout := opts.Stdout
+	if stdout == nil {
+		stdout = io.Discard
 	}
+	log := opts.Out
+	if log == nil {
+		log = output.New(nil)
+	}
+	// stderr + progress adapters: permiten reusar helpers legacy sin
+	// tocar sus firmas. Cada línea al stderr se emite como log.Warn
+	// (en execute, los fmt.Fprintf(stderr, ...) son mayoría warnings
+	// best-effort + errors; usar Warn evita ruido cuando el flow continúa).
+	stderr := log.AsWriter(output.LevelWarn)
+	progress := func(s string) { log.Step(s) }
+	_ = stderr // puede no usarse si todos los call-sites ya usan log directo
 
 	// Instalar signal handling si el caller no pasó un context. cmd/execute.go
 	// instala el suyo (para mapear SIGINT → exit 130 explícito); la TUI pasa

--- a/internal/flow/explore/explore.go
+++ b/internal/flow/explore/explore.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/chichex/che/internal/comments"
 	"github.com/chichex/che/internal/labels"
+	"github.com/chichex/che/internal/output"
 	"github.com/chichex/che/internal/plan"
 )
 
@@ -207,15 +208,16 @@ func ParseValidators(s string) ([]Validator, error) {
 	return out, nil
 }
 
-// Opts agrupa los writers, la callback de progreso, el agente ejecutor y la
-// lista de validadores. Si OnProgress es nil, el flow corre silencioso. Si
-// Agent es "", se usa DefaultAgent. Si Validators es nil, no se corre la
-// etapa de validación (comportamiento v0.0.11).
+// Opts agrupa el writer de stdout (payload: "Explored ...", "Paused ...",
+// "Resumed and consolidated ..." + validation report), el logger
+// estructurado (progress + errors), el agente ejecutor y la lista de
+// validadores. Si Out es nil el flow corre silencioso. Si Agent es "",
+// se usa DefaultAgent. Si Validators es nil, no se corre la etapa de
+// validación.
 type Opts struct {
-	Stdout     io.Writer
-	Stderr     io.Writer
-	OnProgress func(string)
-	Agent      Agent
+	Stdout io.Writer
+	Out    *output.Logger
+	Agent  Agent
 	Validators []Validator
 }
 
@@ -505,37 +507,45 @@ const MaxIterations = 3
 // issue: status:awaiting-human dispara reanudación, el resto es exploración
 // nueva. status:plan sin awaiting significa "ya explorado" y corta.
 func Run(issueRef string, opts Opts) ExitCode {
-	stdout, stderr := opts.Stdout, opts.Stderr
-	progress := opts.OnProgress
-	if progress == nil {
-		progress = func(string) {}
+	stdout := opts.Stdout
+	if stdout == nil {
+		stdout = io.Discard
 	}
+	log := opts.Out
+	if log == nil {
+		log = output.New(nil)
+	}
+	// stderr + progress adapters: permiten reusar helpers legacy
+	// (que reciben io.Writer + func(string)) sin tocar sus firmas. Cada
+	// linea al stderr se emite como log.Error; cada progress como log.Step.
+	stderr := log.AsWriter(output.LevelError)
+	progress := func(s string) { log.Step(s) }
 
 	issueRef = strings.TrimSpace(issueRef)
 	if issueRef == "" {
-		fmt.Fprintln(stderr, "error: issue ref is empty")
+		log.Error("issue ref is empty")
 		return ExitSemantic
 	}
 
-	progress("chequeando repo git y auth de GitHub…")
+	log.Info("chequeando repo git y auth de GitHub")
 	if err := precheckGitHubRemote(); err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("github remote invalido", output.F{Cause: err})
 		return ExitRetry
 	}
 	if err := precheckGhAuth(); err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("gh auth fallo", output.F{Cause: err})
 		return ExitRetry
 	}
 
-	progress("obteniendo issue desde GitHub…")
+	log.Info("obteniendo issue desde GitHub")
 	issue, err := fetchIssue(issueRef)
 	if err != nil {
-		fmt.Fprintf(stderr, "error: fetching issue: %v\n", err)
+		log.Error("fetching issue failed", output.F{Cause: err})
 		return ExitRetry
 	}
 
 	if err := gateBasic(issue); err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("gate failed", output.F{Issue: issue.Number, Cause: err})
 		return ExitSemantic
 	}
 
@@ -545,7 +555,8 @@ func Run(issueRef string, opts Opts) ExitCode {
 		return runResume(issueRef, issue, opts, progress, stdout, stderr)
 	}
 	if issue.HasLabel(labels.StatusPlan) {
-		fmt.Fprintf(stderr, "error: issue #%d was already explored (status:plan present)\n", issue.Number)
+		log.Error(fmt.Sprintf("issue #%d was already explored (status:plan present)", issue.Number),
+			output.F{Issue: issue.Number, Labels: []string{labels.StatusPlan}})
 		return ExitSemantic
 	}
 	return runNew(issueRef, issue, opts, progress, stdout, stderr)

--- a/internal/flow/idea/idea.go
+++ b/internal/flow/idea/idea.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/chichex/che/internal/labels"
+	"github.com/chichex/che/internal/output"
 )
 
 // Response es lo que esperamos que devuelva el agente de clasificación.
@@ -44,12 +45,12 @@ const (
 	ExitSemantic ExitCode = 3 // entrada vacía, JSON inválido, enums fuera de rango
 )
 
-// Opts agrupa los writers y la callback de progreso. Si OnProgress es nil,
-// el flow corre silencioso (modo CI).
+// Opts agrupa el writer de stdout (payload estable: URLs creadas,
+// "Done.") y el logger estructurado (progress + errores). Si Out es nil,
+// el flow corre silencioso (NopSink).
 type Opts struct {
-	Stdout     io.Writer
-	Stderr     io.Writer
-	OnProgress func(string) // invocado por cada línea de output de los subprocesses
+	Stdout io.Writer
+	Out    *output.Logger
 }
 
 var (
@@ -57,64 +58,72 @@ var (
 	validSizes = map[string]bool{"XS": true, "S": true, "M": true, "L": true, "XL": true}
 )
 
-// Run ejecuta el flow completo. Los writers de opts son el stdout/stderr
-// "final" (URLs creadas, errores). OnProgress recibe las líneas que van
-// saliendo de claude mientras corre — el caller decide qué hacer con ellas
-// (mostrarlas en vivo en la TUI, escribirlas a log, o nada).
+// Run ejecuta el flow completo.
 func Run(text string, opts Opts) ExitCode {
-	stdout, stderr := opts.Stdout, opts.Stderr
-	progress := opts.OnProgress
-	if progress == nil {
-		progress = func(string) {}
+	stdout := opts.Stdout
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	log := opts.Out
+	if log == nil {
+		log = output.New(nil)
 	}
 
 	text = strings.TrimSpace(text)
 	if text == "" {
-		fmt.Fprintln(stderr, "error: idea text is empty")
+		log.Error("idea text is empty")
 		return ExitSemantic
 	}
 
-	progress("chequeando repo git y auth de GitHub…")
+	log.Info("chequeando repo git y auth de GitHub")
 	if err := precheckGitHubRemote(); err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("github remote invalido", output.F{Cause: err})
 		return ExitRetry
 	}
 	if err := precheckGhAuth(); err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("gh auth fallo", output.F{Cause: err})
 		return ExitRetry
 	}
 
-	progress("consultando a claude…")
-	resp, err := callClaude(text, progress)
+	log.Step("consultando a claude")
+	resp, err := callClaude(text, log)
 	if err != nil {
-		fmt.Fprintf(stderr, "error: calling claude: %v\n", err)
+		log.Error("calling claude failed", output.F{Agent: "claude", Cause: err})
 		return ExitRetry
 	}
 
 	if err := validate(resp); err != nil {
-		fmt.Fprintf(stderr, "error: claude response: %v\n", err)
+		log.Error("claude response invalid", output.F{Cause: err})
 		return ExitSemantic
 	}
 
-	progress(fmt.Sprintf("claude clasificó %d idea(s); preparando labels…", len(resp.Items)))
-	if err := ensureLabels(resp.Items, progress); err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+	log.Success("idea clasificada", output.F{Detail: fmt.Sprintf("%d item(s)", len(resp.Items))})
+	if err := ensureLabels(resp.Items, log); err != nil {
+		log.Error("no se pudieron asegurar labels", output.F{Cause: err})
 		return ExitRetry
 	}
 
-	progress("creando issues…")
 	fmt.Fprintf(stdout, "Creating %d issue(s)…\n", len(resp.Items))
 
 	created := []string{}
 	for i, item := range resp.Items {
-		progress(fmt.Sprintf("creando issue %d/%d: %s", i+1, len(resp.Items), item.Title))
+		log.Step(fmt.Sprintf("creating issue %d/%d", i+1, len(resp.Items)), output.F{Detail: item.Title})
 		url, err := createIssue(item)
 		if err != nil {
-			fmt.Fprintf(stderr, "error: creating issue %d/%d: %v\n", i+1, len(resp.Items), err)
-			rollback(created, stderr, progress)
+			log.Error(fmt.Sprintf("creating issue %d/%d failed", i+1, len(resp.Items)), output.F{Cause: err})
+			rollback(created, log)
 			return ExitRetry
 		}
 		created = append(created, url)
+		log.Success("issue creado", output.F{
+			URL: url,
+			Labels: []string{
+				"type:" + item.Type,
+				"size:" + strings.ToLower(item.Size),
+				labels.StatusIdea,
+				labels.CtPlan,
+			},
+		})
 		fmt.Fprintf(stdout, "Created %s\n", url)
 	}
 
@@ -142,7 +151,7 @@ func precheckGhAuth() error {
 	return nil
 }
 
-func callClaude(userText string, progress func(string)) (*Response, error) {
+func callClaude(userText string, log *output.Logger) (*Response, error) {
 	prompt := buildPrompt(userText)
 	cmd := exec.Command("claude", "-p", prompt, "--output-format", "text")
 	stdout, err := cmd.StdoutPipe()
@@ -163,7 +172,7 @@ func callClaude(userText string, progress func(string)) (*Response, error) {
 		line := scanner.Text()
 		fullOutput.WriteString(line + "\n")
 		if strings.TrimSpace(line) != "" {
-			progress("claude: " + line)
+			log.Step("claude: " + line)
 		}
 	}
 
@@ -281,7 +290,7 @@ func validate(r *Response) error {
 
 // ensureLabels garantiza que los labels type:*, size:* y status:idea que se
 // van a aplicar existan en el repo. Delega en labels.Ensure (idempotente).
-func ensureLabels(items []Item, progress func(string)) error {
+func ensureLabels(items []Item, log *output.Logger) error {
 	seen := map[string]bool{}
 	var names []string
 	for _, it := range items {
@@ -298,7 +307,7 @@ func ensureLabels(items []Item, progress func(string)) error {
 		}
 	}
 	for _, lbl := range names {
-		progress("asegurando label " + lbl)
+		log.Step("asegurando label", output.F{Labels: []string{lbl}})
 		if err := labels.Ensure(lbl); err != nil {
 			return err
 		}
@@ -378,20 +387,20 @@ func renderBody(it Item) string {
 	return sb.String()
 }
 
-func rollback(created []string, stderr io.Writer, progress func(string)) {
+func rollback(created []string, log *output.Logger) {
 	var orphans []string
 	for i := len(created) - 1; i >= 0; i-- {
 		url := created[i]
-		progress("rollback: cerrando " + url)
+		log.Step("rollback: cerrando", output.F{URL: url})
 		if err := exec.Command("gh", "issue", "close", url).Run(); err != nil {
 			orphans = append(orphans, url)
 		}
 	}
 	if len(orphans) > 0 {
-		fmt.Fprintf(stderr, "warning: could not close %d issue(s) created before failure:\n", len(orphans))
+		log.Warn(fmt.Sprintf("could not close %d issue(s) created before failure", len(orphans)))
 		for _, u := range orphans {
-			fmt.Fprintf(stderr, "  - %s\n", u)
+			log.Warn("orphan", output.F{URL: u})
 		}
-		fmt.Fprintln(stderr, "close them manually (`gh issue close <url>`) before re-running")
+		log.Info("close them manually (`gh issue close <url>`) before re-running")
 	}
 }

--- a/internal/flow/iterate/iterate.go
+++ b/internal/flow/iterate/iterate.go
@@ -38,6 +38,7 @@ import (
 	"github.com/chichex/che/internal/flow/execute"
 	"github.com/chichex/che/internal/flow/validate"
 	"github.com/chichex/che/internal/labels"
+	"github.com/chichex/che/internal/output"
 )
 
 // ExitCode es el código de salida semántico.
@@ -63,11 +64,11 @@ var AgentTimeout = func() time.Duration {
 	return 30 * time.Minute
 }()
 
-// Opts agrupa writers y callback de progreso.
+// Opts agrupa el writer de stdout (payload: "Iterated PR ...", "Done.")
+// y el logger estructurado (progress + errors).
 type Opts struct {
-	Stdout     io.Writer
-	Stderr     io.Writer
-	OnProgress func(string)
+	Stdout io.Writer
+	Out    *output.Logger
 }
 
 // ListIterable devuelve los PRs abiertos del repo que piden iteración,
@@ -107,81 +108,84 @@ func hasChangesRequested(p validate.PullRequest) bool {
 
 // Run ejecuta el flow completo sobre un PR.
 func Run(prRef string, opts Opts) ExitCode {
-	stdout, stderr := opts.Stdout, opts.Stderr
-	progress := opts.OnProgress
-	if progress == nil {
-		progress = func(string) {}
+	stdout := opts.Stdout
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	log := opts.Out
+	if log == nil {
+		log = output.New(nil)
 	}
 
 	prRef = strings.TrimSpace(prRef)
 	if prRef == "" {
-		fmt.Fprintln(stderr, "error: pr ref is empty")
+		log.Error("pr ref is empty")
 		return ExitSemantic
 	}
 	if _, err := validate.ParsePRRef(prRef); err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("pr ref invalido", output.F{Cause: err})
 		return ExitSemantic
 	}
 
-	progress("chequeando repo git y auth de GitHub…")
+	log.Info("chequeando repo git y auth de GitHub")
 	repoRoot, err := repoToplevel()
 	if err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("git repo invalido", output.F{Cause: err})
 		return ExitRetry
 	}
 	if err := precheckGitHubRemote(); err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("github remote invalido", output.F{Cause: err})
 		return ExitRetry
 	}
 	if err := precheckGhAuth(); err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("gh auth fallo", output.F{Cause: err})
 		return ExitRetry
 	}
 
-	progress("obteniendo PR desde GitHub…")
+	log.Info("obteniendo PR desde GitHub")
 	pr, err := validate.FetchPR(prRef)
 	if err != nil {
-		fmt.Fprintf(stderr, "error: fetching PR: %v\n", err)
+		log.Error("fetching PR failed", output.F{Cause: err})
 		return ExitRetry
 	}
 	if pr.State != "OPEN" {
-		fmt.Fprintf(stderr, "error: PR #%d is not OPEN (state=%s)\n", pr.Number, pr.State)
+		log.Error(fmt.Sprintf("PR #%d is not OPEN (state=%s)", pr.Number, pr.State))
 		return ExitSemantic
 	}
 	if strings.TrimSpace(pr.HeadBranch) == "" {
-		fmt.Fprintf(stderr, "error: PR #%d no tiene head branch (¿fork?) — iterate no soporta ese caso\n", pr.Number)
+		log.Error(fmt.Sprintf("PR #%d no tiene head branch (¿fork?) — iterate no soporta ese caso", pr.Number))
 		return ExitSemantic
 	}
 
-	progress("leyendo comments previos para buscar findings…")
+	log.Step("leyendo comments previos para buscar findings")
 	comments, err := validate.FetchPRComments(prRef)
 	if err != nil {
-		fmt.Fprintf(stderr, "error: fetching comments: %v\n", err)
+		log.Error("fetching comments failed", output.F{Cause: err})
 		return ExitRetry
 	}
 
 	findingsBlocks := LatestValidateFindings(comments)
 	if len(findingsBlocks) == 0 {
-		fmt.Fprintf(stderr, "error: PR #%d no tiene findings de che validate — no hay nada que iterar. Corré `che validate %d` antes.\n",
-			pr.Number, pr.Number)
+		log.Error(fmt.Sprintf("PR #%d no tiene findings de che validate — no hay nada que iterar. Corré `che validate %d` antes.", pr.Number, pr.Number))
 		return ExitSemantic
 	}
 
 	iter := DetermineIterateIter(comments)
+	log.Success("encontré findings del último run de validate", output.F{PR: pr.Number, Iter: iter, Detail: fmt.Sprintf("%d validators", len(findingsBlocks))})
 
 	issueNum := firstClosingIssue(pr)
 
-	progress(fmt.Sprintf("resolviendo worktree (issue=%d, branch=%s)…", issueNum, pr.HeadBranch))
+	log.Step(fmt.Sprintf("resolviendo worktree (issue=%d, branch=%s)", issueNum, pr.HeadBranch))
 	wt, wtOwned, err := resolveWorktree(repoRoot, issueNum, pr.HeadBranch)
 	if err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("resolver worktree fallo", output.F{Cause: err})
 		return ExitRetry
 	}
 	defer func() {
 		if wt != nil && wtOwned {
 			wtCtx, wtCancel := context.WithTimeout(context.Background(), 30*time.Second)
 			if err := wt.Cleanup(wtCtx, repoRoot, false); err != nil {
-				fmt.Fprintf(stderr, "warning: cleanup local parcial: %v — revisá `git worktree list` y `git branch` para limpiar a mano\n", err)
+				log.Warn("cleanup local parcial — revisá git worktree list y git branch para limpiar a mano", output.F{Cause: err})
 			}
 			wtCancel()
 		}
@@ -189,55 +193,48 @@ func Run(prRef string, opts Opts) ExitCode {
 
 	prompt := BuildIteratePrompt(pr, iter, findingsBlocks)
 
-	// Snapshot del HEAD antes de invocar al agente. La detección de
-	// "¿opus produjo commits?" compara HEAD before/after en vez del
-	// tracking ref origin/<branch>: opus normalmente pushea por su
-	// cuenta (el prompt se lo pide), lo que avanza origin/<branch> y
-	// hace que HEAD..origin dé vacío, falseando el chequeo.
 	beforeHEAD, err := gitRevParse(wt.Path, "HEAD")
 	if err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("git rev-parse HEAD fallo", output.F{Cause: err})
 		return ExitRetry
 	}
 
-	progress("invocando a opus para que aplique los cambios…")
-	if err := runAgent(wt.Path, prompt, progress); err != nil {
-		fmt.Fprintf(stderr, "error: opus falló: %v\n", err)
+	log.Step("invocando a opus para aplicar los cambios", output.F{Agent: "opus", Detail: wt.Path})
+	if err := runAgent(wt.Path, prompt, log); err != nil {
+		log.Error("opus falló", output.F{Agent: "opus", Cause: err})
 		return ExitRetry
 	}
 
-	progress("chequeando si el worktree quedó con cambios…")
+	log.Step("chequeando si el worktree quedó con cambios")
 	hasChanges, err := worktreeHasChanges(wt.Path)
 	if err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("git status fallo", output.F{Cause: err})
 		return ExitRetry
 	}
 
-	pushed, newCommits, err := commitAndPushIfChanged(wt.Path, pr.HeadBranch, beforeHEAD, hasChanges, progress)
+	pushed, newCommits, err := commitAndPushIfChanged(wt.Path, pr.HeadBranch, beforeHEAD, hasChanges, log)
 	if err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("commit/push fallo", output.F{Cause: err})
 		return ExitRetry
 	}
 
 	if !pushed {
-		// No hubo cambios reales. Dejamos todo como estaba (incluyendo
-		// label validated:changes-requested) y salimos con retry para
-		// que el usuario sepa que hay que mirar por qué opus no arregló.
-		fmt.Fprintf(stderr, "error: opus no produjo cambios commiteables para el PR #%d — revisá los findings a mano o reintentá.\n", pr.Number)
+		log.Error(fmt.Sprintf("opus no produjo cambios commiteables para el PR #%d — revisá los findings a mano o reintentá", pr.Number))
 		return ExitRetry
 	}
 
-	progress("posteando comment de iterate en el PR…")
+	log.Step("posteando comment de iterate en el PR")
 	body := RenderIterateComment(iter, newCommits)
 	if err := postPRComment(prRef, body); err != nil {
-		fmt.Fprintf(stderr, "warning: no se pudo postear comment de iterate: %v — sigo igual\n", err)
+		log.Warn("warning: no se pudo postear comment de iterate — sigo igual", output.F{Cause: err})
 	}
 
-	progress("removiendo label validated:changes-requested del PR…")
+	log.Step("removiendo label validated:changes-requested del PR")
 	if err := removeLabel(prRef, labels.ValidatedChangesRequested); err != nil {
-		fmt.Fprintf(stderr, "warning: no se pudo remover label: %v — removelo a mano\n", err)
+		log.Warn("warning: no se pudo remover label — removelo a mano", output.F{Cause: err})
 	}
 
+	log.Success("iterated PR", output.F{PR: pr.Number, URL: pr.URL, Detail: fmt.Sprintf("%d nuevos commits", len(newCommits))})
 	fmt.Fprintf(stdout, "Iterated PR %s\n", pr.URL)
 	fmt.Fprintf(stdout, "Nuevos commits: %d\n", len(newCommits))
 	fmt.Fprintln(stdout, "Done. Re-corré `che validate` para obtener un verdict nuevo.")
@@ -376,7 +373,7 @@ func RenderIterateComment(iter int, commitSubjects []string) string {
 
 // ---- agent invocation (copy-adapted del patrón de close/execute) ----
 
-func runAgent(cwd, prompt string, progress func(string)) error {
+func runAgent(cwd, prompt string, log *output.Logger) error {
 	ctx, cancel := context.WithTimeout(context.Background(), AgentTimeout)
 	defer cancel()
 
@@ -399,8 +396,8 @@ func runAgent(cwd, prompt string, progress func(string)) error {
 	var wg sync.WaitGroup
 	wg.Add(2)
 	var stderrBuf strings.Builder
-	go streamPipe(&wg, stdoutPipe, nil, progress, "opus: ", formatOpusLine)
-	go streamPipe(&wg, stderrPipe, &stderrBuf, progress, "opus stderr: ", nil)
+	go streamPipe(&wg, stdoutPipe, nil, log, "opus: ", formatOpusLine)
+	go streamPipe(&wg, stderrPipe, &stderrBuf, log, "opus stderr: ", nil)
 	wg.Wait()
 
 	waitErr := cmd.Wait()
@@ -419,7 +416,7 @@ func runAgent(cwd, prompt string, progress func(string)) error {
 	return nil
 }
 
-func streamPipe(wg *sync.WaitGroup, r io.Reader, acc *strings.Builder, progress func(string), prefix string, format func(string) (string, bool)) {
+func streamPipe(wg *sync.WaitGroup, r io.Reader, acc *strings.Builder, log *output.Logger, prefix string, format func(string) (string, bool)) {
 	defer wg.Done()
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
@@ -436,8 +433,8 @@ func streamPipe(wg *sync.WaitGroup, r io.Reader, acc *strings.Builder, progress 
 			}
 			out = msg
 		}
-		if strings.TrimSpace(out) != "" && progress != nil {
-			progress(prefix + out)
+		if strings.TrimSpace(out) != "" && log != nil {
+			log.Step(prefix + out)
 		}
 	}
 }
@@ -782,9 +779,9 @@ func worktreeHasChanges(wtPath string) (bool, error) {
 //
 // El push final es idempotente: si opus ya pusheó, `git push origin <branch>`
 // es no-op.
-func commitAndPushIfChanged(wtPath, branch, beforeHEAD string, hasDirty bool, progress func(string)) (bool, []string, error) {
+func commitAndPushIfChanged(wtPath, branch, beforeHEAD string, hasDirty bool, log *output.Logger) (bool, []string, error) {
 	if hasDirty {
-		progress("commiteando cambios no-commiteados que dejó opus…")
+		log.Step("commiteando cambios no-commiteados que dejó opus")
 		if err := runGitIn(wtPath, "add", "-A"); err != nil {
 			return false, nil, err
 		}
@@ -806,7 +803,7 @@ func commitAndPushIfChanged(wtPath, branch, beforeHEAD string, hasDirty bool, pr
 		return false, nil, err
 	}
 
-	progress(fmt.Sprintf("pusheando a origin/%s (idempotente si opus ya pusheó)…", branch))
+	log.Step(fmt.Sprintf("pusheando a origin/%s (idempotente si opus ya pusheó)", branch))
 	if err := runGitIn(wtPath, "push", "origin", branch); err != nil {
 		return false, nil, err
 	}

--- a/internal/flow/validate/validate.go
+++ b/internal/flow/validate/validate.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/chichex/che/internal/labels"
+	"github.com/chichex/che/internal/output"
 )
 
 // ExitCode es el código de salida semántico para el caller.
@@ -140,11 +141,11 @@ func ParseValidators(s string) ([]Validator, error) {
 	return out, nil
 }
 
-// Opts agrupa los writers y la lista de validadores.
+// Opts agrupa el writer de stdout (payload: reporte final) y el logger
+// estructurado (progress + errors), más la lista de validadores.
 type Opts struct {
 	Stdout     io.Writer
-	Stderr     io.Writer
-	OnProgress func(string)
+	Out        *output.Logger
 	Validators []Validator
 }
 
@@ -301,88 +302,101 @@ type validatorResult struct {
 //     final con tabla.
 //   - Stdout: reporte resumido (verdict + findings count por validador).
 func Run(prRef string, opts Opts) ExitCode {
-	stdout, stderr := opts.Stdout, opts.Stderr
-	progress := opts.OnProgress
-	if progress == nil {
-		progress = func(string) {}
+	stdout := opts.Stdout
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	log := opts.Out
+	if log == nil {
+		log = output.New(nil)
 	}
 
 	prRef = strings.TrimSpace(prRef)
 	if prRef == "" {
-		fmt.Fprintln(stderr, "error: pr ref is empty")
+		log.Error("pr ref is empty")
 		return ExitSemantic
 	}
 
 	if len(opts.Validators) == 0 {
-		fmt.Fprintln(stderr, "error: at least 1 validator is required")
+		log.Error("at least 1 validator is required")
 		return ExitSemantic
 	}
 
-	progress("chequeando auth de GitHub…")
+	log.Info("chequeando auth de GitHub")
 	if err := precheckGitHubRemote(); err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("github remote invalido", output.F{Cause: err})
 		return ExitRetry
 	}
 	if err := precheckGhAuth(); err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+		log.Error("gh auth fallo", output.F{Cause: err})
 		return ExitRetry
 	}
 
-	progress("obteniendo PR desde GitHub…")
+	log.Info("obteniendo PR desde GitHub")
 	pr, err := FetchPR(prRef)
 	if err != nil {
-		fmt.Fprintf(stderr, "error: fetching PR: %v\n", err)
+		log.Error("fetching PR failed", output.F{Cause: err})
 		return ExitRetry
 	}
 	if pr.State != "OPEN" {
-		fmt.Fprintf(stderr, "error: PR #%d is not OPEN (state=%s)\n", pr.Number, pr.State)
+		log.Error(fmt.Sprintf("PR #%d is not OPEN (state=%s)", pr.Number, pr.State))
 		return ExitSemantic
 	}
 
-	progress("descargando diff del PR…")
+	log.Step("descargando diff del PR", output.F{PR: pr.Number})
 	diff, err := FetchDiff(prRef)
 	if err != nil {
-		fmt.Fprintf(stderr, "error: fetching diff: %v\n", err)
+		log.Error("fetching diff failed", output.F{Cause: err})
 		return ExitRetry
 	}
 	if strings.TrimSpace(diff) == "" {
-		fmt.Fprintf(stderr, "error: diff del PR #%d está vacío — ¿está mergeado o no tiene cambios?\n", pr.Number)
+		log.Error(fmt.Sprintf("diff del PR #%d está vacío — ¿está mergeado o no tiene cambios?", pr.Number))
 		return ExitSemantic
 	}
 
-	progress("leyendo comments previos para calcular iter…")
+	log.Step("leyendo comments previos para calcular iter")
 	comments, err := FetchPRComments(prRef)
 	if err != nil {
-		fmt.Fprintf(stderr, "error: fetching comments: %v\n", err)
+		log.Error("fetching comments failed", output.F{Cause: err})
 		return ExitRetry
 	}
 	iter := DetermineIter(comments)
 
-	progress(fmt.Sprintf("corriendo %d validador(es) en paralelo (iter=%d)…", len(opts.Validators), iter))
-	results := runValidatorsParallel(pr, diff, opts.Validators, progress)
+	log.Info(fmt.Sprintf("corriendo %d validador(es) en paralelo", len(opts.Validators)), output.F{Iter: iter, PR: pr.Number})
+	results := runValidatorsParallel(pr, diff, opts.Validators, log)
 
-	progress("posteando comments de validadores…")
+	log.Step("posteando comments de validadores")
 	for _, r := range results {
 		body := renderValidatorComment(r, iter)
 		if err := postPRComment(prRef, body); err != nil {
-			fmt.Fprintf(stderr, "error: posting %s#%d comment: %v\n",
-				r.Validator.Agent, r.Validator.Instance, err)
+			log.Error(fmt.Sprintf("posting %s#%d comment failed", r.Validator.Agent, r.Validator.Instance),
+				output.F{Validator: fmt.Sprintf("%s#%d", r.Validator.Agent, r.Validator.Instance), Cause: err})
 			return ExitRetry
 		}
+		verdict := ""
+		if r.Response != nil {
+			verdict = r.Response.Verdict
+		}
+		log.Success("comment posteado",
+			output.F{Validator: fmt.Sprintf("%s#%d", r.Validator.Agent, r.Validator.Instance), Verdict: verdict})
 	}
 
-	progress("posteando comment resumen…")
+	log.Step("posteando comment resumen")
 	summary := renderSummaryComment(results, iter)
 	if err := postPRComment(prRef, summary); err != nil {
-		fmt.Fprintf(stderr, "error: posting summary comment: %v\n", err)
+		log.Error("posting summary comment failed", output.F{Cause: err})
 		return ExitRetry
 	}
 
 	if verdict := consolidateVerdict(results); verdict != "" {
 		target := verdictToLabel(verdict)
-		progress("aplicando label " + target + " al PR…")
+		log.Step("aplicando label al PR", output.F{Labels: []string{target}, PR: pr.Number})
 		if err := applyValidatedLabel(prRef, pr, target); err != nil {
-			fmt.Fprintf(stderr, "warning: no pude aplicar label %s al PR: %v\n", target, err)
+			log.Warn("warning: no pude aplicar label al PR",
+				output.F{Labels: []string{target}, PR: pr.Number, Cause: err})
+		} else {
+			log.Success("verdict consolidado",
+				output.F{PR: pr.Number, Verdict: verdict, Labels: []string{target}})
 		}
 	}
 
@@ -649,7 +663,7 @@ func FetchPRComments(ref string) ([]PRComment, error) {
 // devuelve el slice alineado con el input. Ninguno cancela a los otros — los
 // errores quedan en el validatorResult individual y se reportan como "ERROR"
 // en el comment correspondiente.
-func runValidatorsParallel(pr *PullRequest, diff string, validators []Validator, progress func(string)) []validatorResult {
+func runValidatorsParallel(pr *PullRequest, diff string, validators []Validator, log *output.Logger) []validatorResult {
 	results := make([]validatorResult, len(validators))
 	var wg sync.WaitGroup
 	for i, v := range validators {
@@ -657,10 +671,8 @@ func runValidatorsParallel(pr *PullRequest, diff string, validators []Validator,
 		go func(i int, v Validator) {
 			defer wg.Done()
 			label := fmt.Sprintf("%s#%d", v.Agent, v.Instance)
-			progress(label + ": consultando…")
-			resp, err := callValidator(v, pr, diff, func(line string) {
-				progress(label + ": " + line)
-			})
+			log.Step(label + ": consultando")
+			resp, err := callValidator(v, pr, diff, log, label)
 			results[i] = validatorResult{Validator: v, Response: resp, Err: err}
 		}(i, v)
 	}
@@ -670,9 +682,9 @@ func runValidatorsParallel(pr *PullRequest, diff string, validators []Validator,
 
 // callValidator invoca al binario del agente validador con el prompt del PR
 // diff y parsea la respuesta.
-func callValidator(v Validator, pr *PullRequest, diff string, progress func(string)) (*Response, error) {
+func callValidator(v Validator, pr *PullRequest, diff string, log *output.Logger, label string) (*Response, error) {
 	prompt := buildValidatorPrompt(pr, diff)
-	out, err := runAgentCmd(v.Agent, prompt, progress, "")
+	out, err := runAgentCmd(v.Agent, prompt, log, label+": ")
 	if err != nil {
 		return nil, err
 	}
@@ -680,8 +692,8 @@ func callValidator(v Validator, pr *PullRequest, diff string, progress func(stri
 }
 
 // runAgentCmd invoca al binario del agente con el prompt construido. Streamea
-// stdout/stderr en vivo al progress y aplica AgentTimeout con context.
-func runAgentCmd(agent Agent, prompt string, progress func(string), progressPrefix string) (string, error) {
+// stdout/stderr en vivo al log y aplica AgentTimeout con context.
+func runAgentCmd(agent Agent, prompt string, log *output.Logger, progressPrefix string) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), AgentTimeout)
 	defer cancel()
 
@@ -702,8 +714,8 @@ func runAgentCmd(agent Agent, prompt string, progress func(string), progressPref
 	var fullStdout, fullStderr strings.Builder
 	var wg sync.WaitGroup
 	wg.Add(2)
-	go streamPipe(&wg, stdoutPipe, &fullStdout, progress, progressPrefix)
-	go streamPipe(&wg, stderrPipe, &fullStderr, progress, progressPrefix+"stderr: ")
+	go streamPipe(&wg, stdoutPipe, &fullStdout, log, progressPrefix)
+	go streamPipe(&wg, stderrPipe, &fullStderr, log, progressPrefix+"stderr: ")
 
 	wg.Wait()
 	waitErr := cmd.Wait()
@@ -722,15 +734,15 @@ func runAgentCmd(agent Agent, prompt string, progress func(string), progressPref
 	return fullStdout.String(), nil
 }
 
-func streamPipe(wg *sync.WaitGroup, r io.Reader, full *strings.Builder, progress func(string), prefix string) {
+func streamPipe(wg *sync.WaitGroup, r io.Reader, full *strings.Builder, log *output.Logger, prefix string) {
 	defer wg.Done()
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		full.WriteString(line + "\n")
-		if strings.TrimSpace(line) != "" && progress != nil {
-			progress(prefix + line)
+		if strings.TrimSpace(line) != "" && log != nil {
+			log.Step(prefix + line)
 		}
 	}
 }

--- a/internal/output/logger.go
+++ b/internal/output/logger.go
@@ -1,6 +1,10 @@
 package output
 
-import "time"
+import (
+	"bytes"
+	"sync"
+	"time"
+)
 
 // Logger es la fachada que usan los flows. Wrapper fino sobre Sink.
 //
@@ -48,4 +52,43 @@ func (l *Logger) emit(lv Level, msg string, ff []F) {
 		Message: msg,
 		Fields:  fields,
 	})
+}
+
+// AsWriter devuelve un io.Writer que bufferiza hasta un newline y emite
+// cada linea completa como un evento del nivel indicado. Util como
+// adapter para helpers legacy que reciben io.Writer (ej. stderr) sin
+// reescribir su firma: pasar log.AsWriter(LevelError) y cada línea se
+// loguea como error estructurado.
+func (l *Logger) AsWriter(lv Level) *LineWriter {
+	return &LineWriter{logger: l, level: lv}
+}
+
+// LineWriter adapta un Logger a io.Writer. Concurrency-safe: mutex
+// interno serializa los flushes de líneas.
+type LineWriter struct {
+	logger *Logger
+	level  Level
+	mu     sync.Mutex
+	buf    bytes.Buffer
+}
+
+// Write bufferiza hasta newline y emite un evento por cada línea completa.
+func (w *LineWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.buf.Write(p)
+	for {
+		data := w.buf.Bytes()
+		nl := bytes.IndexByte(data, '\n')
+		if nl < 0 {
+			break
+		}
+		line := string(data[:nl])
+		w.buf.Next(nl + 1)
+		if line == "" {
+			continue
+		}
+		w.logger.emit(w.level, line, nil)
+	}
+	return len(p), nil
 }

--- a/internal/tui/event_render.go
+++ b/internal/tui/event_render.go
@@ -1,0 +1,114 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/chichex/che/internal/output"
+)
+
+// renderEventLine convierte un Event del logger a una linea estilizada
+// para el runLog de la TUI.
+//
+// Reusa la paleta de styles.go (colorSuccess, colorError, colorAccent,
+// colorMuted, colorPrimary) para quedar visualmente consistente con el
+// resto de la TUI. El simbolo y los fields se alinean igual que el CLI.
+func renderEventLine(ev output.Event) string {
+	sym := symbolForLevel(ev.Level)
+	symStyle := levelStyle(ev.Level)
+	body := symStyle.Render(sym) + " " + symStyle.Render(ev.Message)
+
+	if suffix := renderEventFields(ev.Fields); suffix != "" {
+		body += " " + suffix
+	}
+	return body
+}
+
+func symbolForLevel(lv output.Level) string {
+	switch lv {
+	case output.LevelInfo:
+		return "▸"
+	case output.LevelStep:
+		return "·"
+	case output.LevelSuccess:
+		return "✓"
+	case output.LevelWarn:
+		return "⚠"
+	case output.LevelError:
+		return "✗"
+	}
+	return "▸"
+}
+
+func levelStyle(lv output.Level) lipgloss.Style {
+	switch lv {
+	case output.LevelInfo:
+		return lipgloss.NewStyle().Foreground(colorText)
+	case output.LevelStep:
+		return logLineStyle
+	case output.LevelSuccess:
+		return successStyle
+	case output.LevelWarn:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("#F1FA8C"))
+	case output.LevelError:
+		return errorStyle
+	}
+	return logLineStyle
+}
+
+func renderEventFields(f output.F) string {
+	var parts []string
+	num := lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
+	muted := lipgloss.NewStyle().Foreground(colorMuted)
+	labels := lipgloss.NewStyle().Foreground(colorAccent)
+	agent := lipgloss.NewStyle().Foreground(colorPrimary).Bold(true)
+	verdictOK := lipgloss.NewStyle().Foreground(colorSuccess).Bold(true)
+	verdictKO := lipgloss.NewStyle().Foreground(colorError).Bold(true)
+
+	if f.Issue > 0 {
+		parts = append(parts, num.Render(fmt.Sprintf("#%d", f.Issue)))
+	}
+	if f.PR > 0 {
+		parts = append(parts, muted.Render("PR")+" "+num.Render(fmt.Sprintf("#%d", f.PR)))
+	}
+	if len(f.Labels) > 0 {
+		colored := make([]string, len(f.Labels))
+		for i, l := range f.Labels {
+			colored[i] = labels.Render(l)
+		}
+		parts = append(parts, muted.Render("[")+strings.Join(colored, muted.Render(", "))+muted.Render("]"))
+	}
+	if f.Iter > 0 {
+		parts = append(parts, muted.Render(fmt.Sprintf("iter=%d", f.Iter)))
+	}
+	if f.Agent != "" {
+		parts = append(parts, agent.Render("{"+f.Agent+"}"))
+	}
+	if f.Validator != "" {
+		parts = append(parts, agent.Render("{"+f.Validator+"}"))
+	}
+	if f.Attempt > 0 && f.Total > 0 {
+		parts = append(parts, muted.Render(fmt.Sprintf("(intento %d/%d)", f.Attempt, f.Total)))
+	}
+	if f.Verdict != "" {
+		verdictStyle := muted
+		switch strings.ToLower(strings.TrimSpace(f.Verdict)) {
+		case "approve":
+			verdictStyle = verdictOK
+		case "changes_requested", "changes-requested", "needs_human", "needs-human":
+			verdictStyle = verdictKO
+		}
+		parts = append(parts, muted.Render("verdict:")+" "+verdictStyle.Render(f.Verdict))
+	}
+	if f.Cause != nil {
+		parts = append(parts, muted.Render("—")+" "+errorStyle.Render("error: "+f.Cause.Error()))
+	}
+	if f.Detail != "" {
+		parts = append(parts, muted.Render("("+f.Detail+")"))
+	}
+	if f.URL != "" {
+		parts = append(parts, muted.Render("·")+" "+muted.Render(f.URL))
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/tui/event_sink.go
+++ b/internal/tui/event_sink.go
@@ -1,0 +1,74 @@
+package tui
+
+import (
+	"bytes"
+	"sync"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/chichex/che/internal/output"
+)
+
+// eventSink empuja Events estructurados del logger al channel del Model
+// como eventMsg. Concurrency-safe (channel send + select default para
+// no bloquear goroutines del flow si el buffer esta lleno).
+//
+// Diseño: la TUI NO recibe lineas pre-renderizadas — recibe el Event crudo
+// y arma su propio render con lipgloss (eventLineFor) para integrar con
+// sus estilos (logLineStyle, truncate, padding).
+type eventSink struct {
+	ch chan<- tea.Msg
+}
+
+func (s *eventSink) Emit(ev output.Event) {
+	select {
+	case s.ch <- eventMsg{ev: ev}:
+	default:
+		// Si el buffer esta lleno, dropeamos. Preferible perder una linea
+		// de log que bloquear el goroutine del flow.
+	}
+}
+
+// eventMsg entrega un Event al Update loop.
+type eventMsg struct{ ev output.Event }
+
+// payloadMsg entrega una linea de stdout "payload" (URLs creadas,
+// "Done.", "Executed", etc.). Se renderiza con logLineStyle para
+// matchear el look del runLog preexistente.
+type payloadMsg struct{ line string }
+
+// stdoutLineWriter es un io.Writer que bufferiza datos hasta un
+// newline y empuja cada linea completa al channel como payloadMsg. Sirve
+// para capturar los fmt.Fprintln(stdout, ...) de los flows sin duplicar
+// su logica en events. Concurrency-safe.
+type stdoutLineWriter struct {
+	ch  chan<- tea.Msg
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func newStdoutLineWriter(ch chan<- tea.Msg) *stdoutLineWriter {
+	return &stdoutLineWriter{ch: ch}
+}
+
+func (w *stdoutLineWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.buf.Write(p)
+	for {
+		data := w.buf.Bytes()
+		nl := bytes.IndexByte(data, '\n')
+		if nl < 0 {
+			break
+		}
+		line := string(data[:nl])
+		w.buf.Next(nl + 1)
+		if line == "" {
+			continue
+		}
+		select {
+		case w.ch <- payloadMsg{line: line}:
+		default:
+		}
+	}
+	return len(p), nil
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -25,6 +25,7 @@ import (
 	"github.com/chichex/che/internal/flow/idea"
 	"github.com/chichex/che/internal/flow/iterate"
 	"github.com/chichex/che/internal/flow/validate"
+	"github.com/chichex/che/internal/output"
 )
 
 type screen int
@@ -338,6 +339,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case progressMsg:
 		m.runLog = appendLog(m.runLog, msg.line)
 		// seguimos escuchando el channel
+		return m, waitForMsg(m.progressCh)
+
+	case eventMsg:
+		m.runLog = appendLog(m.runLog, renderEventLine(msg.ev))
+		return m, waitForMsg(m.progressCh)
+
+	case payloadMsg:
+		m.runLog = appendLog(m.runLog, logLineStyle.Render(msg.line))
 		return m, waitForMsg(m.progressCh)
 
 	case flowDoneMsg:
@@ -898,15 +907,12 @@ func (m Model) startIterateFlow(prRef string) (tea.Model, tea.Cmd) {
 	m.progressCh = make(chan tea.Msg, 64)
 
 	go func(ch chan<- tea.Msg) {
-		var stdout, stderr bytes.Buffer
+		var stderr bytes.Buffer
 		code := iterate.Run(prRef, iterate.Opts{
-			Stdout: &stdout,
-			Stderr: &stderr,
-			OnProgress: func(line string) {
-				ch <- progressMsg{line: line}
-			},
+			Stdout: newStdoutLineWriter(ch),
+			Out:    output.New(&eventSink{ch: ch}),
 		})
-		ch <- iterateDoneMsg{code: code, stdout: stdout.String(), stderr: stderr.String()}
+		ch <- iterateDoneMsg{code: code, stdout: "", stderr: stderr.String()}
 	}(m.progressCh)
 
 	return m, tea.Batch(waitForMsg(m.progressCh), tickCmd())
@@ -975,15 +981,12 @@ func (m Model) startCloseFlow(prRef string) (tea.Model, tea.Cmd) {
 	m.progressCh = make(chan tea.Msg, 64)
 
 	go func(ch chan<- tea.Msg) {
-		var stdout, stderr bytes.Buffer
+		var stderr bytes.Buffer
 		code := closing.Run(prRef, closing.Opts{
-			Stdout: &stdout,
-			Stderr: &stderr,
-			OnProgress: func(line string) {
-				ch <- progressMsg{line: line}
-			},
+			Stdout: newStdoutLineWriter(ch),
+			Out:    output.New(&eventSink{ch: ch}),
 		})
-		ch <- closeDoneMsg{code: code, stdout: stdout.String(), stderr: stderr.String()}
+		ch <- closeDoneMsg{code: code, stdout: "", stderr: stderr.String()}
 	}(m.progressCh)
 
 	return m, tea.Batch(waitForMsg(m.progressCh), tickCmd())
@@ -997,16 +1000,13 @@ func (m Model) startValidateFlow(prRef string, validators []validate.Validator) 
 	m.progressCh = make(chan tea.Msg, 64)
 
 	go func(ch chan<- tea.Msg) {
-		var stdout, stderr bytes.Buffer
+		var stderr bytes.Buffer
 		code := validate.Run(prRef, validate.Opts{
-			Stdout:     &stdout,
-			Stderr:     &stderr,
+			Stdout:     newStdoutLineWriter(ch),
+			Out:        output.New(&eventSink{ch: ch}),
 			Validators: validators,
-			OnProgress: func(line string) {
-				ch <- progressMsg{line: line}
-			},
 		})
-		ch <- validateDoneMsg{code: code, stdout: stdout.String(), stderr: stderr.String()}
+		ch <- validateDoneMsg{code: code, stdout: "", stderr: stderr.String()}
 	}(m.progressCh)
 
 	return m, tea.Batch(waitForMsg(m.progressCh), tickCmd())
@@ -1031,18 +1031,15 @@ func (m Model) startExecuteFlow(issueRef string, agent execute.Agent, validators
 	m.cancelRun = cancel
 
 	go func(ch chan<- tea.Msg, runCtx context.Context) {
-		var stdout, stderr bytes.Buffer
+		var stderr bytes.Buffer
 		code := execute.Run(issueRef, execute.Opts{
-			Stdout:     &stdout,
-			Stderr:     &stderr,
+			Stdout:     newStdoutLineWriter(ch),
+			Out:        output.New(&eventSink{ch: ch}),
 			Agent:      agent,
 			Validators: validators,
 			Ctx:        runCtx,
-			OnProgress: func(line string) {
-				ch <- progressMsg{line: line}
-			},
 		})
-		ch <- executeDoneMsg{code: code, stdout: stdout.String(), stderr: stderr.String()}
+		ch <- executeDoneMsg{code: code, stdout: "", stderr: stderr.String()}
 	}(m.progressCh, runCtx)
 
 	return m, tea.Batch(waitForMsg(m.progressCh), tickCmd())
@@ -1267,15 +1264,12 @@ func (m Model) startIdeaFlow(text string) (tea.Model, tea.Cmd) {
 	m.progressCh = make(chan tea.Msg, 64)
 
 	go func(ch chan<- tea.Msg) {
-		var stdout, stderr bytes.Buffer
+		var stderr bytes.Buffer
 		code := idea.Run(text, idea.Opts{
-			Stdout: &stdout,
-			Stderr: &stderr,
-			OnProgress: func(line string) {
-				ch <- progressMsg{line: line}
-			},
+			Stdout: newStdoutLineWriter(ch),
+			Out:    output.New(&eventSink{ch: ch}),
 		})
-		ch <- flowDoneMsg{code: code, stdout: stdout.String(), stderr: stderr.String()}
+		ch <- flowDoneMsg{code: code, stdout: "", stderr: stderr.String()}
 	}(m.progressCh)
 
 	return m, tea.Batch(waitForMsg(m.progressCh), tickCmd())
@@ -1291,17 +1285,14 @@ func (m Model) startExploreFlow(issueRef string, agent explore.Agent, validators
 	m.progressCh = make(chan tea.Msg, 64)
 
 	go func(ch chan<- tea.Msg) {
-		var stdout, stderr bytes.Buffer
+		var stderr bytes.Buffer
 		code := explore.Run(issueRef, explore.Opts{
-			Stdout:     &stdout,
-			Stderr:     &stderr,
+			Stdout:     newStdoutLineWriter(ch),
+			Out:        output.New(&eventSink{ch: ch}),
 			Agent:      agent,
 			Validators: validators,
-			OnProgress: func(line string) {
-				ch <- progressMsg{line: line}
-			},
 		})
-		ch <- exploreDoneMsg{code: code, stdout: stdout.String(), stderr: stderr.String()}
+		ch <- exploreDoneMsg{code: code, stdout: "", stderr: stderr.String()}
 	}(m.progressCh)
 
 	return m, tea.Batch(waitForMsg(m.progressCh), tickCmd())


### PR DESCRIPTION
## Summary

- Migra **idea, close, validate, iterate, explore, execute** al logger `internal/output`. Cada flow ahora emite `Event`s estructurados con campos (issue#, PR#, labels, URL, agent, verdict) en vez de `fmt.Fprintf(stderr, ...)` crudo.
- TUI consume eventos via `eventSink` (sin pre-render) y los renderiza con lipgloss local (`renderEventLine`) para integrar con sus propios estilos. El stdout "payload" se captura con `stdoutLineWriter`. El runLog queda enriquecido con badges Dracula.
- Agrega `output.Logger.AsWriter(level)` como adapter `io.Writer → Logger` para reusar helpers legacy sin tocar firmas.
- Preserva el payload de stdout ("Created URL", "Done.", "Executed", "Closed PR URL", reportes de validate/explore). Todos los tests e2e que asertan esos keywords siguen verdes.

## Test plan

- [x] `go test ./...` verde local (tuve que ajustar un solo mensaje: "creating issue X/Y" para preservar el assert existente)
- [x] `go test ./e2e/...` limpio sin caché (15s)
- [x] Build limpio
- [ ] Probar visualmente `che idea "..."`, `che close`, `che execute` en terminal TTY
- [ ] Probar la TUI (runLog con badges Dracula)
- [ ] CI verde

## Siguiente

- `cmd/upgrade.go` queda sin migrar (es cmd aislado, no crítico, output plano) — opcional para un PR siguiente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)