### PR TITLE
refactor(labels): plan-validated:* + shim deprecatedAwaitingHuman

### DIFF
--- a/e2e/execute_test.go
+++ b/e2e/execute_test.go
@@ -104,9 +104,9 @@ func TestExecute_GoldenPath(t *testing.T) {
 	}
 	// Primer edit: plan → executing.
 	edits[0].AssertArgsContain(t, "--add-label", "status:executing")
-	// Segundo edit: executing → executed + awaiting-human.
+	// Segundo edit: executing → executed. awaiting-human ya no se aplica
+	// (el gate vive en plan-validated:* / validated:*).
 	edits[1].AssertArgsContain(t, "--add-label", "status:executed")
-	edits[1].AssertArgsContain(t, "--add-label", "status:awaiting-human")
 
 	if comments := inv.FindCalls("gh", "issue", "comment", "42", "--body-file"); len(comments) != 1 {
 		t.Fatalf("expected 1 issue comment, got %d", len(comments))

--- a/internal/flow/execute/deprecated_awaiting.go
+++ b/internal/flow/execute/deprecated_awaiting.go
@@ -1,0 +1,8 @@
+package execute
+
+// deprecatedAwaitingHuman es el literal del label que representaba
+// "esperando input humano" en el flow viejo. La constante vive acá
+// temporalmente para que el código legacy de resume/pause compile
+// mientras PR #3 lo elimina. TODO(PR#3): borrar junto con runResume,
+// pauseForHuman, ListAwaiting y demás.
+const deprecatedAwaitingHuman = "status:awaiting-human"

--- a/internal/flow/execute/execute.go
+++ b/internal/flow/execute/execute.go
@@ -712,7 +712,7 @@ func ListCandidates() ([]Candidate, error) {
 	}
 	out2 := make([]Candidate, 0, len(raw))
 	for _, i := range raw {
-		if i.HasLabel(labels.StatusAwaitingHuman) {
+		if i.HasLabel(deprecatedAwaitingHuman) {
 			continue
 		}
 		out2 = append(out2, Candidate{Number: i.Number, Title: i.Title})
@@ -836,7 +836,7 @@ func gate(i *Issue) error {
 	if i.HasLabel(labels.StatusExecuting) {
 		return fmt.Errorf("issue #%d is already status:executing — otro run en curso o quedó colgado; quitá el label a mano si es lo segundo", i.Number)
 	}
-	if i.HasLabel(labels.StatusAwaitingHuman) {
+	if i.HasLabel(deprecatedAwaitingHuman) {
 		return fmt.Errorf("issue #%d tiene status:awaiting-human — resolvé primero lo que falta antes de ejecutar", i.Number)
 	}
 	if !i.HasLabel(labels.StatusPlan) {

--- a/internal/flow/explore/deprecated_awaiting.go
+++ b/internal/flow/explore/deprecated_awaiting.go
@@ -1,0 +1,8 @@
+package explore
+
+// deprecatedAwaitingHuman es el literal del label que representaba
+// "esperando input humano" en el flow viejo. La constante vive acá
+// temporalmente para que el código legacy de resume/pause compile
+// mientras PR #3 lo elimina. TODO(PR#3): borrar junto con runResume,
+// pauseForHuman, ListAwaiting y demás.
+const deprecatedAwaitingHuman = "status:awaiting-human"

--- a/internal/flow/explore/explore.go
+++ b/internal/flow/explore/explore.go
@@ -600,7 +600,7 @@ func Run(issueRef string, opts Opts) ExitCode {
 
 	// Ramificación por modo. awaiting-human → resume; status:plan → error
 	// de "ya explorado"; default → new.
-	if issue.HasLabel(labels.StatusAwaitingHuman) {
+	if issue.HasLabel(deprecatedAwaitingHuman) {
 		return runResume(issueRef, issue, opts, progress, stdout, stderr)
 	}
 	if issue.HasLabel(labels.StatusPlan) {
@@ -770,7 +770,7 @@ func pauseForHuman(issueRef string, issue *Issue, plan *Response, results []vali
 		return ExitRetry
 	}
 	progress("asegurando label status:awaiting-human…")
-	if err := ensureLabel(labels.StatusAwaitingHuman, progress); err != nil {
+	if err := ensureLabel(deprecatedAwaitingHuman, progress); err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return ExitRetry
 	}
@@ -849,7 +849,7 @@ func ListCandidates() ([]Candidate, error) {
 	}
 	out := make([]Candidate, 0, len(raw))
 	for _, i := range raw {
-		if i.HasLabel(labels.StatusPlan) || i.HasLabel(labels.StatusAwaitingHuman) ||
+		if i.HasLabel(labels.StatusPlan) || i.HasLabel(deprecatedAwaitingHuman) ||
 			i.HasLabel(labels.StatusExecuting) || i.HasLabel(labels.StatusExecuted) {
 			continue
 		}
@@ -870,7 +870,7 @@ func ListAwaiting() ([]Candidate, error) {
 	}
 	out := make([]Candidate, 0, len(raw))
 	for _, i := range raw {
-		if !i.HasLabel(labels.StatusAwaitingHuman) {
+		if !i.HasLabel(deprecatedAwaitingHuman) {
 			continue
 		}
 		if i.HasLabel(labels.StatusExecuted) || i.HasLabel(labels.StatusExecuting) {
@@ -1374,7 +1374,7 @@ func transitionLabels(ref string) error {
 // pausa esperando respuesta del humano). No toca otros labels.
 func setLabelAwaitingHuman(ref string) error {
 	cmd := exec.Command("gh", "issue", "edit", ref,
-		"--add-label", labels.StatusAwaitingHuman)
+		"--add-label", deprecatedAwaitingHuman)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("gh issue edit: %s", strings.TrimSpace(string(out)))
@@ -2456,7 +2456,7 @@ func editIssueBody(ref, body string) error {
 // en la misma operación, cerrando el ciclo.
 func closeAwaitingHuman(ref string) error {
 	cmd := exec.Command("gh", "issue", "edit", ref,
-		"--remove-label", labels.StatusAwaitingHuman,
+		"--remove-label", deprecatedAwaitingHuman,
 		"--remove-label", labels.StatusIdea,
 		"--add-label", labels.StatusPlan)
 	out, err := cmd.CombinedOutput()

--- a/internal/labels/hardcoded_test.go
+++ b/internal/labels/hardcoded_test.go
@@ -25,7 +25,6 @@ func TestNoHardcodedLabelsOutsideThisPackage(t *testing.T) {
 		`"` + StatusPlan + `"`,
 		`"` + StatusExecuting + `"`,
 		`"` + StatusExecuted + `"`,
-		`"` + StatusAwaitingHuman + `"`,
 		`"` + CtPlan + `"`,
 	}
 

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -18,14 +18,16 @@ import (
 
 // Status labels que la máquina de estados de che maneja sobre cada issue.
 // Estos son los labels "mutables": cambian a medida que el issue avanza por
-// el embudo idea → explore → execute → close.
+// el embudo idea → explore → execute → close. En el modelo nuevo el estado
+// "esperando input humano" deja de existir como status:*; el gate de
+// intervención humana vive en los labels plan-validated:* (sobre issues) y
+// validated:* (sobre PRs), aplicados por `che validate`.
 const (
-	StatusIdea          = "status:idea"
-	StatusPlan          = "status:plan"
-	StatusExecuting     = "status:executing"
-	StatusExecuted      = "status:executed"
-	StatusAwaitingHuman = "status:awaiting-human"
-	StatusClosed        = "status:closed"
+	StatusIdea      = "status:idea"
+	StatusPlan      = "status:plan"
+	StatusExecuting = "status:executing"
+	StatusExecuted  = "status:executed"
+	StatusClosed    = "status:closed"
 )
 
 // Marker labels que no cambian con el estado — identifican el origen del
@@ -51,6 +53,24 @@ var AllValidated = []string{
 	ValidatedNeedsHuman,
 }
 
+// PlanValidated labels que che validate aplica sobre un issue (plan) reflejando
+// el verdict consolidado de los validadores del plan. Son mutuamente
+// excluyentes: antes de aplicar uno, se quitan los otros dos. `che execute`
+// los usa como gate (solo ejecuta si hay plan-validated:approve).
+const (
+	PlanValidatedApprove          = "plan-validated:approve"
+	PlanValidatedChangesRequested = "plan-validated:changes-requested"
+	PlanValidatedNeedsHuman       = "plan-validated:needs-human"
+)
+
+// AllPlanValidated lista los labels plan-validated:* — usado por validate
+// para saber cuáles remover antes de aplicar el nuevo.
+var AllPlanValidated = []string{
+	PlanValidatedApprove,
+	PlanValidatedChangesRequested,
+	PlanValidatedNeedsHuman,
+}
+
 // Transition representa un cambio de estado expresado como labels a remover
 // y labels a agregar. El orden no importa: `gh issue edit` aplica todo en
 // una sola llamada.
@@ -63,33 +83,29 @@ type Transition struct {
 // del resto de los flows (explore) no están acá todavía — cuando se extraiga
 // `internal/flow/common/` esos usos deberían migrar a este paquete.
 //
-// Claves: "from→to". Si el state de origen puede venir con o sin
-// awaiting-human, se acepta cualquiera de los dos (las transiciones quitan
-// awaiting-human explícitamente cuando corresponde).
+// Claves: "from→to". El modelo nuevo no maneja awaiting-human como estado
+// intermedio; los gates de intervención humana viven en los labels
+// plan-validated:* y validated:*, aplicados por `che validate`.
 var validTransitions = map[string]Transition{
-	// execute arranca: plan → executing (lock). Si había awaiting-human (por
-	// alguna razón excepcional: p.ej. revisión humana del plan después de
-	// consolidar) también se lo quitamos — execute asume que el plan está
-	// listo para ejecutar.
+	// execute arranca: plan → executing (lock).
 	StatusPlan + "→" + StatusExecuting: {
-		Remove: []string{StatusPlan, StatusAwaitingHuman},
+		Remove: []string{StatusPlan},
 		Add:    []string{StatusExecuting},
 	},
-	// execute termina OK: executing → executed + awaiting-human.
+	// execute termina OK: executing → executed.
 	StatusExecuting + "→" + StatusExecuted: {
 		Remove: []string{StatusExecuting},
-		Add:    []string{StatusExecuted, StatusAwaitingHuman},
+		Add:    []string{StatusExecuted},
 	},
 	// rollback: executing → plan (cualquier fallo post-lock).
 	StatusExecuting + "→" + StatusPlan: {
-		Remove: []string{StatusExecuting, StatusAwaitingHuman},
+		Remove: []string{StatusExecuting},
 		Add:    []string{StatusPlan},
 	},
-	// close termina OK: executed → closed. Se quita awaiting-human porque
-	// ya no hay nada que esperar de un humano, y los validated:* del PR
-	// quedan en el PR (no pertenecen al issue).
+	// close termina OK: executed → closed. Los validated:* del PR quedan en
+	// el PR (no pertenecen al issue).
 	StatusExecuted + "→" + StatusClosed: {
-		Remove: []string{StatusExecuted, StatusAwaitingHuman},
+		Remove: []string{StatusExecuted},
 		Add:    []string{StatusClosed},
 	},
 }

--- a/internal/labels/labels_test.go
+++ b/internal/labels/labels_test.go
@@ -15,25 +15,25 @@ func TestTransitionFor_Valid(t *testing.T) {
 			from:    StatusPlan,
 			to:      StatusExecuting,
 			wantAdd: []string{StatusExecuting},
-			wantRem: []string{StatusPlan, StatusAwaitingHuman},
+			wantRem: []string{StatusPlan},
 		},
 		{
 			from:    StatusExecuting,
 			to:      StatusExecuted,
-			wantAdd: []string{StatusExecuted, StatusAwaitingHuman},
+			wantAdd: []string{StatusExecuted},
 			wantRem: []string{StatusExecuting},
 		},
 		{
 			from:    StatusExecuting,
 			to:      StatusPlan,
 			wantAdd: []string{StatusPlan},
-			wantRem: []string{StatusExecuting, StatusAwaitingHuman},
+			wantRem: []string{StatusExecuting},
 		},
 		{
 			from:    StatusExecuted,
 			to:      StatusClosed,
 			wantAdd: []string{StatusClosed},
-			wantRem: []string{StatusExecuted, StatusAwaitingHuman},
+			wantRem: []string{StatusExecuted},
 		},
 	}
 	for _, c := range cases {
@@ -56,11 +56,10 @@ func TestTransitionFor_Invalid(t *testing.T) {
 	cases := []struct {
 		from, to string
 	}{
-		{StatusIdea, StatusExecuting},     // no se puede saltar explore
-		{StatusExecuted, StatusPlan},      // no hay vuelta atrás desde executed
-		{StatusAwaitingHuman, StatusPlan}, // awaiting-human no es un estado "desde"
-		{"", StatusExecuting},             // from vacío
-		{StatusPlan, ""},                  // to vacío
+		{StatusIdea, StatusExecuting},         // no se puede saltar explore
+		{StatusExecuted, StatusPlan},          // no hay vuelta atrás desde executed
+		{"", StatusExecuting},                 // from vacío
+		{StatusPlan, ""},                      // to vacío
 		{StatusPlan, "status:ready-to-close"}, // estado no soportado todavía
 		{StatusPlan, StatusClosed},            // plan no va directo a closed (execute primero)
 		{StatusExecuting, StatusClosed},       // executing no va directo a closed (terminar exec primero)


### PR DESCRIPTION
## Summary

- Primer paso del refactor que saca la validación automática de `explore`/`execute`. Este PR solo renombra/agrega labels y deja un shim privado `deprecatedAwaitingHuman` en explore/execute que desaparece en PR #3.
- Agrega constantes `PlanValidatedApprove|ChangesRequested|NeedsHuman` y slice `AllPlanValidated` (análogos a `AllValidated` para PRs).
- Elimina `labels.StatusAwaitingHuman` y lo borra del lint hardcoded + de `validTransitions`. Las 4 transiciones de la máquina (plan→executing, executing→executed, executing→plan, executed→closed) ya no tocan awaiting-human.
- Call sites en `explore.go` (6) y `execute.go` (2) siguen referenciando el literal para que el código legacy (runResume, pauseForHuman, ListAwaiting, setLabelAwaitingHuman, closeAwaitingHuman, gate) compile. Pasan a usar una constante privada `deprecatedAwaitingHuman` por paquete con TODO(PR#3) para borrarlas junto con esa lógica.

## Cambios out of scope (explícitos)

- NO se toca la lógica de explore/execute (solo se reemplaza el identificador Go).
- NO se tocan comentarios/strings de `cmd/*.go` (van en PR #3 junto con el cambio de comportamiento).
- NO se tocan los literales en `_test.go`/testdata de e2e (el lint los excluye; PR #3 limpiará los que correspondan).

## Test plan

- [x] `go build ./...` sin errores.
- [x] `go vet ./...` limpio.
- [x] `go test ./...` pasa (incluye `internal/labels`, `internal/flow/execute`, `internal/flow/explore`, y e2e).
- [x] Ajustado `e2e/execute_test.go::TestExecute_GoldenPath`: la aserción `"status:awaiting-human"` en el edit `executing→executed` ya no aplica bajo la nueva semántica (el label no se agrega). Se dejó comentario explicando por qué.