### PR TITLE
refactor(agent): extraer paquete común internal/agent

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,0 +1,71 @@
+// Package agent centraliza la invocación de los CLIs externos que actúan como
+// ejecutores y validadores de los flows de che: `claude` (opus), `codex` y
+// `gemini`. Antes vivía duplicado en explore/execute/validate/iterate — cada
+// paquete tenía su copia del enum Agent, ParseAgent, ParseValidators, y del
+// plumbing de exec.Cmd con streaming por pipes. Este paquete absorbe todo eso
+// para que los flows sólo decidan QUÉ prompt mandar y cómo parsear la
+// respuesta; el CÓMO invocar al binario vive acá.
+//
+// Diferencias de comportamiento por flow que este paquete respeta:
+//   - Output format: text (explore/validate) vs stream-json --verbose
+//     (execute/iterate), seleccionado por RunOpts.Format.
+//   - Timeouts: cada flow configura el suyo vía RunOpts.Timeout (el env var
+//     que lo respalda sigue viviendo en cada paquete flow).
+//   - Signal handling: execute aísla al agente en su propio process group y
+//     escala SIGTERM→SIGKILL con gracia de 5s; iterate/explore/validate usan
+//     cancelación simple por context. RunOpts.KillGrace controla esto.
+//   - cwd: execute e iterate fijan el cwd al worktree; explore/validate
+//     heredan. RunOpts.Dir lo expone.
+//   - allowNone en ParseValidators: explore/execute permiten "none" → nil;
+//     validate lo rechaza. El flag vive en ParseValidators(s, allowNone).
+package agent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Agent identifica qué binario invocar. Los strings subyacentes son parte del
+// contrato con los usuarios (aparecen en flags, labels de comments, etc.), así
+// que cambiarlos es una break visible.
+type Agent string
+
+const (
+	AgentOpus   Agent = "opus"
+	AgentCodex  Agent = "codex"
+	AgentGemini Agent = "gemini"
+)
+
+// DefaultAgent es el ejecutor por defecto cuando el caller no elige uno.
+const DefaultAgent = AgentOpus
+
+// ValidAgents lista los agentes soportados en orden canónico (preservado para
+// UI: el iterador de la TUI depende del orden).
+var ValidAgents = []Agent{AgentOpus, AgentCodex, AgentGemini}
+
+// Binary devuelve el nombre del ejecutable asociado al agente. Opus se mapea
+// a `claude` porque el CLI oficial de Anthropic se llama así; Codex y Gemini
+// usan su nombre directo.
+func (a Agent) Binary() string {
+	switch a {
+	case AgentOpus:
+		return "claude"
+	case AgentCodex:
+		return "codex"
+	case AgentGemini:
+		return "gemini"
+	}
+	return ""
+}
+
+// ParseAgent normaliza un string a Agent, tolerando mayúsculas/espacios y
+// devolviendo error si no matchea ningún enum.
+func ParseAgent(s string) (Agent, error) {
+	s = strings.ToLower(strings.TrimSpace(s))
+	for _, a := range ValidAgents {
+		if string(a) == s {
+			return a, nil
+		}
+	}
+	return "", fmt.Errorf("unknown agent %q; valid: opus, codex, gemini", s)
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,0 +1,201 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseAgent(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    Agent
+		wantErr bool
+	}{
+		{"opus", AgentOpus, false},
+		{"codex", AgentCodex, false},
+		{"gemini", AgentGemini, false},
+		{"OPUS", AgentOpus, false},
+		{"  codex  ", AgentCodex, false},
+		{"foo", "", true},
+		{"", "", true},
+	}
+	for _, c := range cases {
+		got, err := ParseAgent(c.in)
+		if (err != nil) != c.wantErr {
+			t.Errorf("ParseAgent(%q): err=%v wantErr=%v", c.in, err, c.wantErr)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("ParseAgent(%q): got %v want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestAgentBinary(t *testing.T) {
+	cases := map[Agent]string{
+		AgentOpus:   "claude",
+		AgentCodex:  "codex",
+		AgentGemini: "gemini",
+	}
+	for a, want := range cases {
+		if got := a.Binary(); got != want {
+			t.Errorf("%v.Binary() = %q, want %q", a, got, want)
+		}
+	}
+	if got := Agent("unknown").Binary(); got != "" {
+		t.Errorf("unknown.Binary() = %q, want \"\"", got)
+	}
+}
+
+func TestAgentInvokeArgs_Opus(t *testing.T) {
+	// text
+	args := AgentOpus.InvokeArgs("hello", OutputText)
+	want := []string{"-p", "hello", "--output-format", "text"}
+	if !equalStrings(args, want) {
+		t.Errorf("opus text: got %v, want %v", args, want)
+	}
+	// stream-json adds --verbose
+	args = AgentOpus.InvokeArgs("hello", OutputStreamJSON)
+	want = []string{"-p", "hello", "--output-format", "stream-json", "--verbose"}
+	if !equalStrings(args, want) {
+		t.Errorf("opus stream-json: got %v, want %v", args, want)
+	}
+}
+
+func TestAgentInvokeArgs_CodexGemini(t *testing.T) {
+	// codex ignora format (siempre exec --full-auto)
+	args := AgentCodex.InvokeArgs("hi", OutputStreamJSON)
+	want := []string{"exec", "--full-auto", "hi"}
+	if !equalStrings(args, want) {
+		t.Errorf("codex: got %v, want %v", args, want)
+	}
+	args = AgentGemini.InvokeArgs("hi", OutputStreamJSON)
+	want = []string{"-p", "hi"}
+	if !equalStrings(args, want) {
+		t.Errorf("gemini: got %v, want %v", args, want)
+	}
+}
+
+func TestParseValidators_AllowNone(t *testing.T) {
+	cases := []struct {
+		in      string
+		wantLen int
+		wantErr bool
+	}{
+		{"", 0, false},
+		{"none", 0, false},
+		{"NONE", 0, false},
+		{"codex", 1, false},
+		{"codex,gemini", 2, false},
+		{"codex,codex,gemini", 3, false},
+		{"foo", 0, true},
+		{"codex,codex,codex,codex", 0, true},
+	}
+	for _, c := range cases {
+		got, err := ParseValidators(c.in, true)
+		if (err != nil) != c.wantErr {
+			t.Errorf("ParseValidators(%q, true): err=%v wantErr=%v", c.in, err, c.wantErr)
+			continue
+		}
+		if len(got) != c.wantLen {
+			t.Errorf("ParseValidators(%q, true): got %d items", c.in, len(got))
+		}
+	}
+
+	// Dedupe de instances: "codex,codex,gemini" → codex#1, codex#2, gemini#1.
+	got, _ := ParseValidators("codex,codex,gemini", true)
+	if got[0].Instance != 1 || got[1].Instance != 2 || got[2].Instance != 1 {
+		t.Errorf("instances wrong: %+v", got)
+	}
+}
+
+func TestParseValidators_DisallowNone(t *testing.T) {
+	// allowNone=false → "" y "none" son errores.
+	if _, err := ParseValidators("", false); err == nil {
+		t.Error("ParseValidators(\"\", false) expected error")
+	}
+	if _, err := ParseValidators("none", false); err == nil {
+		t.Error("ParseValidators(\"none\", false) expected error")
+	}
+	// válidos iguales que antes.
+	got, err := ParseValidators("opus", false)
+	if err != nil {
+		t.Fatalf("ParseValidators(\"opus\", false): %v", err)
+	}
+	if len(got) != 1 || got[0].Agent != AgentOpus {
+		t.Errorf("got %+v, want [opus]", got)
+	}
+}
+
+func TestFormatOpusLine_NoPrefix(t *testing.T) {
+	// Sin prefijo (comportamiento de execute).
+	cases := []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{"", "", false},
+		{"plain text", "plain text", true},
+		{`{"type":"system","subtype":"init"}`, "sesión lista, arrancando…", true},
+		{`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/tmp/foo.go"}}]}}`, "Edit /tmp/foo.go", true},
+		{`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"SomethingNew","input":{}}]}}`, "SomethingNew", true},
+		{`{"type":"result","subtype":"success"}`, "agente terminó OK", true},
+		{`{"type":"result","subtype":"error_max_turns"}`, "agente terminó (error_max_turns)", true},
+		{`{"type":"assistant","message":{"content":[{"type":"text","text":"…"}]}}`, "", false},
+	}
+	for _, c := range cases {
+		got, ok := FormatOpusLine(c.in, "")
+		if ok != c.ok {
+			t.Errorf("FormatOpusLine(%q, \"\"): ok=%v want=%v (got=%q)", c.in, ok, c.ok, got)
+			continue
+		}
+		if ok && got != c.want {
+			t.Errorf("FormatOpusLine(%q, \"\"): got %q want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestFormatOpusLine_WithPrefix(t *testing.T) {
+	// Con prefijo "tool: " (comportamiento de iterate). Sólo los tool_use
+	// se prefijan; system init y result no.
+	got, ok := FormatOpusLine(`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{"file_path":"/tmp/foo.go"}}]}}`, "tool: ")
+	if !ok || got != "tool: Edit /tmp/foo.go" {
+		t.Errorf("tool_use with prefix: got %q (ok=%v), want %q", got, ok, "tool: Edit /tmp/foo.go")
+	}
+	got, ok = FormatOpusLine(`{"type":"system","subtype":"init"}`, "tool: ")
+	if !ok || got != "sesión lista, arrancando…" {
+		t.Errorf("init with prefix: got %q (ok=%v), want no-prefix message", got, ok)
+	}
+	got, ok = FormatOpusLine(`{"type":"result","subtype":"success"}`, "tool: ")
+	if !ok || got != "agente terminó OK" {
+		t.Errorf("result success with prefix: got %q (ok=%v), want no-prefix message", got, ok)
+	}
+}
+
+func TestFormatOpusLine_BashTruncation(t *testing.T) {
+	// Bash commands >80 chars se truncan.
+	long := strings.Repeat("a", 200)
+	line := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"` + long + `"}}]}}`
+	got, ok := FormatOpusLine(line, "")
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if !strings.HasPrefix(got, "Bash ") {
+		t.Errorf("expected prefix \"Bash \", got %q", got)
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("expected ellipsis suffix, got %q", got)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/agent/invoke.go
+++ b/internal/agent/invoke.go
@@ -1,0 +1,43 @@
+package agent
+
+// OutputFormat selecciona el modo de salida de los CLIs. Los flows que sólo
+// necesitan el JSON final (explore, validate) usan OutputText; los que
+// benefician de ver progreso por tool_use (execute, iterate) usan
+// OutputStreamJSON para que cada evento llegue en tiempo real.
+type OutputFormat string
+
+const (
+	// OutputText es el default: el CLI devuelve una sola respuesta al final.
+	// En claude se traduce a `--output-format text`; para codex/gemini el
+	// default ya es texto.
+	OutputText OutputFormat = "text"
+
+	// OutputStreamJSON emite eventos NDJSON por stdout en vivo. Sólo claude
+	// lo soporta (requiere `--verbose`). Para codex/gemini no cambia nada
+	// respecto a OutputText — los parsers ignoran el flag.
+	OutputStreamJSON OutputFormat = "stream-json"
+)
+
+// InvokeArgs devuelve los args de línea de comando para correr al agente en
+// modo no-interactivo con el prompt dado y el formato pedido. Cada CLI tiene
+// su propia sintaxis:
+//   - claude  -p <prompt> --output-format text
+//             -p <prompt> --output-format stream-json --verbose
+//   - codex   exec --full-auto <prompt>   (full-auto evita prompts de
+//     confirmación de sandbox que colgarían el proceso sin TTY; --output-
+//     format no aplica)
+//   - gemini  -p <prompt>                 (text es el default)
+func (a Agent) InvokeArgs(prompt string, format OutputFormat) []string {
+	switch a {
+	case AgentOpus:
+		if format == OutputStreamJSON {
+			return []string{"-p", prompt, "--output-format", "stream-json", "--verbose"}
+		}
+		return []string{"-p", prompt, "--output-format", "text"}
+	case AgentCodex:
+		return []string{"exec", "--full-auto", prompt}
+	case AgentGemini:
+		return []string{"-p", prompt}
+	}
+	return nil
+}

--- a/internal/agent/run.go
+++ b/internal/agent/run.go
@@ -1,0 +1,208 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// RunOpts configura la invocación del agente. Cada flow setea los campos que
+// necesita; los que dejás en zero valor caen al comportamiento default:
+//   - Ctx=nil       → context.Background() (sólo el timeout cancela).
+//   - Dir=""        → hereda cwd del proceso actual.
+//   - Timeout=0     → error de validación (el caller DEBE pasarlo; cada flow
+//                     tiene su default configurable por env).
+//   - Format=""     → tratado como OutputText.
+//   - OnLine=nil    → el output se acumula en RunResult.Stdout pero no se
+//                     emite en vivo a nadie.
+//   - OnStderrLine=nil → el stderr se acumula en RunResult.Stderr pero no se
+//                     emite en vivo.
+//   - KillGrace=0   → no hay escalado SIGTERM→SIGKILL; Ctx cancel mata el
+//                     PID directo (comportamiento de explore/validate/
+//                     iterate). Con KillGrace>0, el agente corre en su
+//                     propio process group y al cancelar se le manda SIGTERM
+//                     al -pgid; si no termina en KillGrace, cmd.WaitDelay
+//                     escala a SIGKILL (comportamiento de execute).
+//   - StreamFormatter=nil → cada línea de stdout se emite tal cual. Con
+//                     formatter, cada línea pasa por él antes de emitirse
+//                     (devuelve msg+ok; si ok=false la línea se omite). Las
+//                     líneas NO se guardan transformadas en RunResult.Stdout:
+//                     el Stdout bruto queda intacto para parsers posteriores.
+type RunOpts struct {
+	Ctx             context.Context
+	Dir             string
+	Timeout         time.Duration
+	Format          OutputFormat
+	OnLine          func(string)
+	OnStderrLine    func(string)
+	KillGrace       time.Duration
+	StreamFormatter func(line string) (string, bool)
+}
+
+// RunResult captura el stdout y stderr completos acumulados durante la
+// ejecución. Incluso cuando hay streaming en vivo, el caller necesita el
+// stdout completo para parsear el JSON final de explore/validate, y el
+// stderr completo para mensajes de error con contexto.
+type RunResult struct {
+	Stdout string
+	Stderr string
+}
+
+// ErrTimeout se devuelve cuando el contexto interno (compuesto por el parent
+// ctx + Timeout) expira por deadline. Los callers lo distinguen de errores
+// de exit code para construir mensajes específicos de timeout.
+var ErrTimeout = errors.New("agent: timed out")
+
+// ErrCancelled se devuelve cuando el parent ctx se canceló externamente
+// (señal, cancel explícito). Los callers lo distinguen para mapearlo a un
+// exit code semántico (ExitCancelled en execute).
+var ErrCancelled = errors.New("agent: cancelled")
+
+// ExitError wrapea *exec.ExitError preservando el exit code y el stderr
+// para que los callers puedan construir su mensaje de error típico
+// ("opus exit 1: auth failed"). Se mantiene ErrorIs(err, ErrTimeout)-style
+// sin sacrificar detalle.
+type ExitError struct {
+	Agent    Agent
+	ExitCode int
+	Stderr   string
+}
+
+func (e *ExitError) Error() string {
+	return fmt.Sprintf("%s exit %d: %s", e.Agent, e.ExitCode, e.Stderr)
+}
+
+// Run invoca al agente con el prompt dado según opts, streamea el output en
+// vivo si el caller lo pidió, y devuelve el stdout/stderr completos junto con
+// un error si algo falló. El stdout se devuelve siempre (incluso con error)
+// para que el caller pueda intentar parsearlo o loguearlo.
+func Run(a Agent, prompt string, opts RunOpts) (RunResult, error) {
+	parent := opts.Ctx
+	if parent == nil {
+		parent = context.Background()
+	}
+
+	var ctx context.Context
+	var cancel context.CancelFunc
+	if opts.Timeout > 0 {
+		ctx, cancel = context.WithTimeout(parent, opts.Timeout)
+	} else {
+		ctx, cancel = context.WithCancel(parent)
+	}
+	defer cancel()
+
+	format := opts.Format
+	if format == "" {
+		format = OutputText
+	}
+
+	cmd := exec.CommandContext(ctx, a.Binary(), a.InvokeArgs(prompt, format)...)
+	if opts.Dir != "" {
+		cmd.Dir = opts.Dir
+	}
+
+	// KillGrace > 0 activa el modo "process group": el agente corre aislado
+	// en su propio pgid, y al cancelar el ctx mandamos SIGTERM al -pgid
+	// (mata todo el árbol: tool-use bash/ripgrep que claude pudo forkear) y
+	// escalamos a SIGKILL si no termina en KillGrace. Sin KillGrace el
+	// comportamiento es el de exec.CommandContext: cancelar ctx → Process.Kill
+	// directo al PID, sin escalado.
+	if opts.KillGrace > 0 {
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		cmd.Cancel = func() error {
+			if cmd.Process == nil {
+				return nil
+			}
+			pgid, err := syscall.Getpgid(cmd.Process.Pid)
+			if err != nil {
+				return cmd.Process.Signal(syscall.SIGTERM)
+			}
+			return syscall.Kill(-pgid, syscall.SIGTERM)
+		}
+		cmd.WaitDelay = opts.KillGrace
+	}
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return RunResult{}, err
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return RunResult{}, err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return RunResult{}, fmt.Errorf("starting %s: %w", a.Binary(), err)
+	}
+
+	var fullStdout, fullStderr strings.Builder
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go drainPipe(&wg, stdoutPipe, &fullStdout, opts.OnLine, opts.StreamFormatter)
+	go drainPipe(&wg, stderrPipe, &fullStderr, opts.OnStderrLine, nil)
+
+	// IMPORTANTE: las goroutines DEBEN terminar antes de cmd.Wait() — los
+	// docs de exec.Cmd.StdoutPipe dicen "it is thus incorrect to call Wait
+	// before all reads from the pipe have completed". Al revés se pierden
+	// bytes de stdout bajo carga y el JSON llega truncado al parser.
+	wg.Wait()
+	waitErr := cmd.Wait()
+
+	res := RunResult{Stdout: fullStdout.String(), Stderr: fullStderr.String()}
+
+	// Cancelación por parent (señal del caller, ctrl+c en la TUI, etc.)
+	// tiene prioridad sobre timeout: si el parent murió, no es "timeout del
+	// agente", es cancelación de usuario.
+	if parent.Err() != nil {
+		return res, ErrCancelled
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return res, ErrTimeout
+	}
+	if waitErr != nil {
+		if ee, ok := waitErr.(*exec.ExitError); ok {
+			return res, &ExitError{
+				Agent:    a,
+				ExitCode: ee.ExitCode(),
+				Stderr:   strings.TrimSpace(res.Stderr),
+			}
+		}
+		return res, waitErr
+	}
+	return res, nil
+}
+
+// drainPipe lee un pipe línea por línea, acumula todo en full (sin
+// transformar, para preservar stdout/stderr bruto) y reenvía cada línea al
+// callback. Si formatter != nil, la línea pasa por él antes de emitirse;
+// formatter puede devolver ok=false para omitir la línea del callback.
+func drainPipe(wg *sync.WaitGroup, r io.Reader, full *strings.Builder, cb func(string), formatter func(string) (string, bool)) {
+	defer wg.Done()
+	scanner := bufio.NewScanner(r)
+	// Buffer 16 MiB: claude con stream-json puede emitir eventos gigantes
+	// (tool_result con outputs largos), y queremos que no nos corte mitad de
+	// un JSON.
+	scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		full.WriteString(line + "\n")
+		out := line
+		if formatter != nil {
+			msg, ok := formatter(line)
+			if !ok {
+				continue
+			}
+			out = msg
+		}
+		if strings.TrimSpace(out) != "" && cb != nil {
+			cb(out)
+		}
+	}
+}

--- a/internal/agent/stream.go
+++ b/internal/agent/stream.go
@@ -1,0 +1,110 @@
+package agent
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// FormatOpusLine traduce una línea del stream-json de claude a un mensaje
+// corto y descriptivo. Devuelve (msg, true) si hay algo que mostrar, o
+// ("", false) para omitir la línea (eventos irrelevantes como tool_result o
+// bloques de texto del asistente, que inundarían la TUI sin info accionable).
+//
+// Si la línea no parsea como JSON (caso típico de los fakes en e2e, que
+// devuelven texto plano), se devuelve tal cual vino — así no rompemos los
+// tests que escriben al stdout del agente sin serializar como evento.
+//
+// toolPrefix se antepone al detalle de tool_use: execute usa "" para mostrar
+// "Edit foo.go"; iterate usa "tool: " para mostrar "tool: Edit foo.go". El
+// prefijo va sólo adelante del nombre de la tool, NO del mensaje de system
+// init ni del resultado final — que históricamente no se prefijan en ningún
+// flow.
+func FormatOpusLine(line string, toolPrefix string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return "", false
+	}
+	if !strings.HasPrefix(trimmed, "{") {
+		return line, true
+	}
+	var ev struct {
+		Type    string `json:"type"`
+		Subtype string `json:"subtype"`
+		Message struct {
+			Content []struct {
+				Type  string                 `json:"type"`
+				Name  string                 `json:"name"`
+				Input map[string]interface{} `json:"input"`
+			} `json:"content"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(trimmed), &ev); err != nil {
+		return line, true
+	}
+	switch ev.Type {
+	case "system":
+		if ev.Subtype == "init" {
+			return "sesión lista, arrancando…", true
+		}
+	case "assistant":
+		for _, c := range ev.Message.Content {
+			if c.Type == "tool_use" {
+				return toolPrefix + describeOpusTool(c.Name, c.Input), true
+			}
+		}
+	case "result":
+		if ev.Subtype == "success" {
+			return "agente terminó OK", true
+		}
+		if ev.Subtype != "" {
+			return "agente terminó (" + ev.Subtype + ")", true
+		}
+	}
+	return "", false
+}
+
+// describeOpusTool arma el nombre + detalle de una tool_use event del stream
+// de claude. Path para file edits/reads; comando truncado a 80 chars para
+// Bash; patrón para Glob/Grep; descripción para Task; URL para WebFetch.
+// Tools no reconocidas caen al nombre pelado.
+func describeOpusTool(name string, input map[string]interface{}) string {
+	detail := ""
+	switch name {
+	case "Read", "Write", "Edit", "NotebookEdit":
+		if v, ok := input["file_path"].(string); ok {
+			detail = v
+		}
+	case "Bash":
+		if v, ok := input["command"].(string); ok {
+			detail = truncate(v, 80)
+		}
+	case "Glob", "Grep":
+		if v, ok := input["pattern"].(string); ok {
+			detail = v
+		}
+	case "Task":
+		if v, ok := input["description"].(string); ok {
+			detail = v
+		}
+	case "WebFetch":
+		if v, ok := input["url"].(string); ok {
+			detail = v
+		}
+	}
+	if detail == "" {
+		return name
+	}
+	return name + " " + detail
+}
+
+// truncate recorta un string a max caracteres, reemplazando newlines por
+// espacios primero (para no ensuciar los logs de 1-línea). Si no pasa del
+// máximo, lo devuelve intacto. Si lo pasa, corta y pone "…" al final.
+func truncate(s string, max int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) <= max {
+		return s
+	}
+	return s[:max-1] + "…"
+}
+

--- a/internal/agent/validator.go
+++ b/internal/agent/validator.go
@@ -1,0 +1,55 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Validator identifica un validador: agente + instancia 1..N (para distinguir
+// cuando el mismo agente aparece varias veces, ej "codex,codex,gemini" → los
+// dos codex tienen Instance 1 y 2).
+type Validator struct {
+	Agent    Agent
+	Instance int
+}
+
+// ParseValidators parsea una lista separada por coma ("codex,gemini",
+// "codex,codex,gemini"). Acepta 1-3 items.
+//
+// allowNone=true (explore/execute): "" o "none" → nil, []Validator vacío
+// permitido, no se corre validación.
+// allowNone=false (validate): "" o "none" → error — validate no tiene sentido
+// sin al menos un validador.
+func ParseValidators(s string, allowNone bool) ([]Validator, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		if allowNone {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("validators: empty — validate requires at least 1 validator")
+	}
+	if strings.EqualFold(s, "none") {
+		if allowNone {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("validators: 'none' is not allowed — validate requires at least 1 validator")
+	}
+	parts := strings.Split(s, ",")
+	if len(parts) < 1 || len(parts) > 3 {
+		if allowNone {
+			return nil, fmt.Errorf("validators: need 1-3 items (or `none`), got %d", len(parts))
+		}
+		return nil, fmt.Errorf("validators: need 1-3 items, got %d", len(parts))
+	}
+	counts := map[Agent]int{}
+	out := make([]Validator, 0, len(parts))
+	for _, p := range parts {
+		a, err := ParseAgent(p)
+		if err != nil {
+			return nil, fmt.Errorf("validators: %w", err)
+		}
+		counts[a]++
+		out = append(out, Validator{Agent: a, Instance: counts[a]})
+	}
+	return out, nil
+}

--- a/internal/flow/execute/execute.go
+++ b/internal/flow/execute/execute.go
@@ -11,7 +11,6 @@
 package execute
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
@@ -22,10 +21,10 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
+	"github.com/chichex/che/internal/agent"
 	"github.com/chichex/che/internal/comments"
 	"github.com/chichex/che/internal/labels"
 	"github.com/chichex/che/internal/output"
@@ -52,64 +51,22 @@ const (
 // queremos exit determinista aunque el agente ignore SIGTERM.
 const agentKillGrace = 5 * time.Second
 
-// Agent identifica qué ejecutor usar. Replica el enum de explore para no
-// acoplar los paquetes; cuando se extraiga `internal/flow/common/`, los dos
-// enums migran allá.
-type Agent string
+// Agent es un alias del enum centralizado en internal/agent. Re-exportado
+// para que cmd/execute.go y la TUI sigan escribiendo `execute.Agent`.
+type Agent = agent.Agent
 
 const (
-	AgentOpus   Agent = "opus"
-	AgentCodex  Agent = "codex"
-	AgentGemini Agent = "gemini"
+	AgentOpus   = agent.AgentOpus
+	AgentCodex  = agent.AgentCodex
+	AgentGemini = agent.AgentGemini
 )
 
-const DefaultAgent = AgentOpus
+const DefaultAgent = agent.DefaultAgent
 
-var ValidAgents = []Agent{AgentOpus, AgentCodex, AgentGemini}
+var ValidAgents = agent.ValidAgents
 
-// Binary devuelve el nombre del ejecutable correspondiente al agente.
-func (a Agent) Binary() string {
-	switch a {
-	case AgentOpus:
-		return "claude"
-	case AgentCodex:
-		return "codex"
-	case AgentGemini:
-		return "gemini"
-	}
-	return ""
-}
-
-// InvokeArgs devuelve los args de línea de comando para cada CLI en modo
-// no-interactivo.
-//
-// Para Opus usamos stream-json + --verbose para que cada tool use llegue al
-// harness en tiempo real: con --output-format text, claude no emite nada
-// hasta que termina, y una ejecución de varios minutos aparece como un
-// silencio sospechoso en la TUI. formatOpusLine() parsea los eventos y los
-// traduce a líneas descriptivas ("Edit foo.go", "Bash go test …").
-func (a Agent) InvokeArgs(prompt string) []string {
-	switch a {
-	case AgentOpus:
-		return []string{"-p", prompt, "--output-format", "stream-json", "--verbose"}
-	case AgentCodex:
-		return []string{"exec", "--full-auto", prompt}
-	case AgentGemini:
-		return []string{"-p", prompt}
-	}
-	return nil
-}
-
-// ParseAgent normaliza un string a Agent.
-func ParseAgent(s string) (Agent, error) {
-	s = strings.ToLower(strings.TrimSpace(s))
-	for _, a := range ValidAgents {
-		if string(a) == s {
-			return a, nil
-		}
-	}
-	return "", fmt.Errorf("unknown agent %q; valid: opus, codex, gemini", s)
-}
+// ParseAgent delega en internal/agent.
+func ParseAgent(s string) (Agent, error) { return agent.ParseAgent(s) }
 
 // AgentTimeout para llamadas al CLI del agente. execute tiene un default
 // mayor que explore porque generar diff + tool use es típicamente más largo
@@ -159,35 +116,14 @@ type Opts struct {
 	Ctx context.Context
 }
 
-// Validator es una re-declaración del enum de explore para no acoplar los
-// paquetes. Instance permite repetir tipo (codex×2) aunque execute en v1 no
-// lo requiera; queda para futuro.
-type Validator struct {
-	Agent    Agent
-	Instance int
-}
+// Validator es un alias del struct centralizado. Instance permite repetir
+// tipo (codex×2) aunque execute en v1 no lo requiera; queda para futuro.
+type Validator = agent.Validator
 
-// ParseValidators parsea "codex,gemini" o "none".
+// ParseValidators parsea "codex,gemini" o "none". "none" (y string vacío)
+// → nil, lo que desactiva el panel de validadores.
 func ParseValidators(s string) ([]Validator, error) {
-	s = strings.TrimSpace(s)
-	if s == "" || strings.EqualFold(s, "none") {
-		return nil, nil
-	}
-	parts := strings.Split(s, ",")
-	if len(parts) < 1 || len(parts) > 3 {
-		return nil, fmt.Errorf("validators: need 1-3 items (or `none`), got %d", len(parts))
-	}
-	counts := map[Agent]int{}
-	out := make([]Validator, 0, len(parts))
-	for _, p := range parts {
-		a, err := ParseAgent(p)
-		if err != nil {
-			return nil, fmt.Errorf("validators: %w", err)
-		}
-		counts[a]++
-		out = append(out, Validator{Agent: a, Instance: counts[a]})
-	}
-	return out, nil
+	return agent.ParseValidators(s, true /* allowNone */)
 }
 
 // Issue modela el subset del output de `gh issue view --json ...`.
@@ -904,207 +840,65 @@ Título: ` + issue.Title + `
 
 // runAgent invoca al CLI del agente con el prompt construido, corriendo con
 // cwd en el worktree para que cualquier herramienta de file edit afecte ese
-// directorio. Usa StdoutPipe + streaming igual que explore. El parent ctx
-// se compone con el timeout del agente; cualquier cancelación (timeout o
-// señal) mata el process group entero para evitar subprocesos zombies —
-// claude/codex pueden fork-ar tool-use processes (bash, ripgrep, etc.) que
-// si solo matamos al PID directo siguen corriendo sueltos.
-func runAgent(parent context.Context, agent Agent, cwd, prompt string, progress func(string)) error {
-	ctx, cancel := context.WithTimeout(parent, AgentTimeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, agent.Binary(), agent.InvokeArgs(prompt)...)
-	cmd.Dir = cwd
-	// Setpgid aisla al agente (y su descendencia) en su propio process group;
-	// Cancel custom manda SIGTERM al -pgid en vez de al PID directo, así
-	// matamos el árbol entero. WaitDelay asegura SIGKILL si no termina
-	// después de agentKillGrace.
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	cmd.Cancel = func() error {
-		if cmd.Process == nil {
-			return nil
-		}
-		pgid, err := syscall.Getpgid(cmd.Process.Pid)
-		if err != nil {
-			return cmd.Process.Signal(syscall.SIGTERM)
-		}
-		return syscall.Kill(-pgid, syscall.SIGTERM)
-	}
-	cmd.WaitDelay = agentKillGrace
-
-	stdoutPipe, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-	stderrPipe, err := cmd.StderrPipe()
-	if err != nil {
-		return err
-	}
-
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("starting %s: %w", agent.Binary(), err)
-	}
-
+// directorio. El parent ctx se compone con el timeout del agente; cualquier
+// cancelación (timeout o señal) mata el process group entero (Setpgid + kill
+// al -pgid) para evitar subprocesos zombies — claude/codex pueden fork-ar
+// tool-use processes (bash, ripgrep, etc.) que si solo matamos al PID
+// directo siguen corriendo sueltos. El plumbing concreto vive en
+// internal/agent.Run; acá solo traducimos errores al formato que esperan los
+// tests (mensajes con "timed out after", "exit N:", "cancelado por señal").
+func runAgent(parent context.Context, a Agent, cwd, prompt string, progress func(string)) error {
 	var stdoutFormat func(string) (string, bool)
-	if agent == AgentOpus {
+	if a == AgentOpus {
 		stdoutFormat = formatOpusLine
 	}
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-	var stderrBuf strings.Builder
-	go streamPipe(&wg, stdoutPipe, nil, progress, string(agent)+": ", stdoutFormat)
-	go streamPipe(&wg, stderrPipe, &stderrBuf, progress, string(agent)+" stderr: ", nil)
-	wg.Wait()
-
-	waitErr := cmd.Wait()
+	res, err := agent.Run(a, prompt, agent.RunOpts{
+		Ctx:       parent,
+		Dir:       cwd,
+		Timeout:   AgentTimeout,
+		Format:    agent.OutputStreamJSON,
+		KillGrace: agentKillGrace,
+		OnLine: func(line string) {
+			if progress != nil {
+				progress(string(a) + ": " + line)
+			}
+		},
+		OnStderrLine: func(line string) {
+			if progress != nil {
+				progress(string(a) + " stderr: " + line)
+			}
+		},
+		StreamFormatter: stdoutFormat,
+	})
 	// Cancel por señal del parent: no es "error del agente", es cancelación
-	// del usuario. Devolvemos un error distintivo que el caller traduce a
-	// ExitCancelled tras verificar parent.Err().
-	if parent.Err() != nil {
-		return fmt.Errorf("%s: cancelado por señal", agent)
+	// del usuario. Mensaje distintivo que el caller traduce a ExitCancelled
+	// tras verificar parent.Err().
+	if errors.Is(err, agent.ErrCancelled) {
+		return fmt.Errorf("%s: cancelado por señal", a)
 	}
-	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+	if errors.Is(err, agent.ErrTimeout) {
 		// Incluimos el stderr acumulado cuando lo hay: un timeout puede
 		// venir acompañado de pistas (auth expirado, prompt rechazado,
 		// warnings del CLI) que el usuario necesita ver para distinguir
 		// "el agente trabajó 15 min y no terminó" vs "el agente se colgó
 		// en el segundo 1 porque algo está mal".
-		if se := strings.TrimSpace(stderrBuf.String()); se != "" {
-			return fmt.Errorf("%s timed out after %s; stderr: %s", agent, AgentTimeout, se)
+		if se := strings.TrimSpace(res.Stderr); se != "" {
+			return fmt.Errorf("%s timed out after %s; stderr: %s", a, AgentTimeout, se)
 		}
-		return fmt.Errorf("%s timed out after %s (sin stderr — subí CHE_EXEC_AGENT_TIMEOUT_SECS si el agente necesita más tiempo)", agent, AgentTimeout)
+		return fmt.Errorf("%s timed out after %s (sin stderr — subí CHE_EXEC_AGENT_TIMEOUT_SECS si el agente necesita más tiempo)", a, AgentTimeout)
 	}
-	if waitErr != nil {
-		if ee, ok := waitErr.(*exec.ExitError); ok {
-			return fmt.Errorf("%s exit %d: %s", agent, ee.ExitCode(), strings.TrimSpace(stderrBuf.String()))
-		}
-		return waitErr
+	var ee *agent.ExitError
+	if errors.As(err, &ee) {
+		return fmt.Errorf("%s exit %d: %s", a, ee.ExitCode, ee.Stderr)
 	}
-	return nil
+	return err
 }
 
-// streamPipe lee un pipe y reenvía las líneas al progress con un prefix.
-// Si format != nil, cada línea se pasa por él antes de emitirse: el
-// formatter puede reescribir la línea o pedir que se omita (ok=false).
-// Las líneas se acumulan siempre en acc (si no es nil) sin transformar,
-// para preservar el stderr tal como vino para mensajes de error.
-func streamPipe(wg *sync.WaitGroup, r io.Reader, acc *strings.Builder, progress func(string), prefix string, format func(string) (string, bool)) {
-	defer wg.Done()
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if acc != nil {
-			acc.WriteString(line + "\n")
-		}
-		out := line
-		if format != nil {
-			msg, ok := format(line)
-			if !ok {
-				continue
-			}
-			out = msg
-		}
-		if strings.TrimSpace(out) != "" && progress != nil {
-			progress(prefix + out)
-		}
-	}
-}
-
-// formatOpusLine traduce una línea del stream-json del CLI de claude a un
-// mensaje corto y descriptivo. Devuelve (msg, true) si hay algo que mostrar,
-// o ("", false) para omitir la línea (eventos irrelevantes como tool_result
-// o bloques de texto del asistente, que inundarían la TUI sin aportar info
-// accionable).
-//
-// Si la línea no parsea como JSON (caso típico de los fakes en e2e, que
-// devuelven "ok\n"), se devuelve tal cual vino — así no rompemos los tests
-// que todavía escriben texto plano al stdout del agente.
+// formatOpusLine es un thin wrapper sobre agent.FormatOpusLine con el prefijo
+// de tool que históricamente usa execute (sin prefijo, ej "Edit foo.go"). El
+// test de este paquete lo ejercita directamente.
 func formatOpusLine(line string) (string, bool) {
-	trimmed := strings.TrimSpace(line)
-	if trimmed == "" {
-		return "", false
-	}
-	if !strings.HasPrefix(trimmed, "{") {
-		return line, true
-	}
-	var ev struct {
-		Type    string `json:"type"`
-		Subtype string `json:"subtype"`
-		Message struct {
-			Content []struct {
-				Type  string                 `json:"type"`
-				Name  string                 `json:"name"`
-				Input map[string]interface{} `json:"input"`
-			} `json:"content"`
-		} `json:"message"`
-	}
-	if err := json.Unmarshal([]byte(trimmed), &ev); err != nil {
-		return line, true
-	}
-	switch ev.Type {
-	case "system":
-		if ev.Subtype == "init" {
-			return "sesión lista, arrancando…", true
-		}
-	case "assistant":
-		for _, c := range ev.Message.Content {
-			if c.Type == "tool_use" {
-				return describeOpusTool(c.Name, c.Input), true
-			}
-		}
-	case "result":
-		if ev.Subtype == "success" {
-			return "agente terminó OK", true
-		}
-		if ev.Subtype != "" {
-			return "agente terminó (" + ev.Subtype + ")", true
-		}
-	}
-	return "", false
-}
-
-// describeOpusTool arma el detalle que acompaña al nombre de la tool. Para
-// tools que tocan archivos usamos el path; para Bash, el comando truncado;
-// para búsquedas, el patrón. Si no reconocemos la tool, mostramos solo el
-// nombre.
-func describeOpusTool(name string, input map[string]interface{}) string {
-	detail := ""
-	switch name {
-	case "Read", "Write", "Edit", "NotebookEdit":
-		if v, ok := input["file_path"].(string); ok {
-			detail = v
-		}
-	case "Bash":
-		if v, ok := input["command"].(string); ok {
-			detail = truncate(v, 80)
-		}
-	case "Glob", "Grep":
-		if v, ok := input["pattern"].(string); ok {
-			detail = v
-		}
-	case "Task":
-		if v, ok := input["description"].(string); ok {
-			detail = v
-		}
-	case "WebFetch":
-		if v, ok := input["url"].(string); ok {
-			detail = v
-		}
-	}
-	if detail == "" {
-		return name
-	}
-	return name + " " + detail
-}
-
-func truncate(s string, max int) string {
-	s = strings.ReplaceAll(s, "\n", " ")
-	if len(s) <= max {
-		return s
-	}
-	return s[:max-1] + "…"
+	return agent.FormatOpusLine(line, "")
 }
 
 // ---- git ops sobre el worktree ----
@@ -1266,28 +1060,25 @@ func fireValidators(parent context.Context, prURL string, issue *Issue, plan *Co
 				}
 			}()
 			prompt := buildValidatorPrompt(issue, plan)
-			ctx, cancel := context.WithTimeout(parent, AgentTimeout)
-			defer cancel()
-			cmd := exec.CommandContext(ctx, v.Agent.Binary(), v.Agent.InvokeArgs(prompt)...)
-			cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-			cmd.Cancel = func() error {
-				if cmd.Process == nil {
-					return nil
-				}
-				pgid, err := syscall.Getpgid(cmd.Process.Pid)
-				if err != nil {
-					return cmd.Process.Signal(syscall.SIGTERM)
-				}
-				return syscall.Kill(-pgid, syscall.SIGTERM)
-			}
-			cmd.WaitDelay = agentKillGrace
-			out, _ := cmd.Output()
+			// Preservamos EXACTAMENTE el formato histórico: los validadores
+			// de execute invocan con el MISMO InvokeArgs que el ejecutor
+			// (stream-json para opus), así que el comment del PR termina
+			// conteniendo los eventos NDJSON cuando el validador es opus.
+			// Cambiar esto acá sería un behavior change — vive como deuda
+			// separada. KillGrace>0 + Dir="" replican el plumbing anterior.
+			res, _ := agent.Run(v.Agent, prompt, agent.RunOpts{
+				Ctx:       parent,
+				Timeout:   AgentTimeout,
+				Format:    agent.OutputStreamJSON,
+				KillGrace: agentKillGrace,
+			})
+			out := res.Stdout
 			// Si el parent se canceló, no tiene sentido pelear con gh para
 			// postear el comment — retornamos y dejamos que el caller siga.
 			if parent.Err() != nil {
 				return
 			}
-			_ = postPRComment(parent, prURL, renderValidatorComment(iter, v, string(out)))
+			_ = postPRComment(parent, prURL, renderValidatorComment(iter, v, out))
 		}()
 	}
 	return done

--- a/internal/flow/explore/explore.go
+++ b/internal/flow/explore/explore.go
@@ -5,8 +5,6 @@
 package explore
 
 import (
-	"bufio"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -19,6 +17,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/chichex/che/internal/agent"
 	"github.com/chichex/che/internal/comments"
 	"github.com/chichex/che/internal/flow/idea"
 	"github.com/chichex/che/internal/labels"
@@ -35,59 +34,40 @@ const (
 	ExitSemantic ExitCode = 3 // ref vacío, issue sin ct:plan, cerrado, ya explorado, agente inválido
 )
 
-// Agent identifica qué ejecutor usar para producir el análisis. Cada agente
-// corresponde a un binario distinto en el PATH; el mapeo vive en Binary().
-type Agent string
+// Agent es un alias del enum centralizado en internal/agent. Se re-exporta
+// para que cmd/ y la TUI sigan escribiendo `explore.Agent` como antes.
+type Agent = agent.Agent
 
+// Re-exports del enum y helpers: cmd/explore.go y la TUI los consumen, así
+// que cambiar de nombre o sacarlos rompe la build.
 const (
-	AgentOpus   Agent = "opus"
-	AgentCodex  Agent = "codex"
-	AgentGemini Agent = "gemini"
+	AgentOpus   = agent.AgentOpus
+	AgentCodex  = agent.AgentCodex
+	AgentGemini = agent.AgentGemini
 )
 
-// DefaultAgent es el ejecutor que usa explore si el caller no elige uno.
-const DefaultAgent = AgentOpus
+// DefaultAgent es el ejecutor por defecto si el caller no elige uno.
+const DefaultAgent = agent.DefaultAgent
 
-// ValidAgents lista todos los agentes soportados (orden preservado para UI).
-var ValidAgents = []Agent{AgentOpus, AgentCodex, AgentGemini}
+// ValidAgents lista los agentes soportados en orden canónico.
+var ValidAgents = agent.ValidAgents
 
-// Binary devuelve el nombre del ejecutable que se invoca para este agente.
-// Opus se mapea a `claude` porque el CLI oficial se llama así; Codex y Gemini
-// usan su nombre directo.
-func (a Agent) Binary() string {
-	switch a {
-	case AgentOpus:
-		return "claude"
-	case AgentCodex:
-		return "codex"
-	case AgentGemini:
-		return "gemini"
-	}
-	return ""
-}
+// ParseAgent delega en internal/agent.
+func ParseAgent(s string) (Agent, error) { return agent.ParseAgent(s) }
 
-// InvokeArgs devuelve los args de línea de comando para correr al agente en
-// modo no-interactivo con el prompt dado. Cada CLI tiene su propia sintaxis:
-//   - claude  -p <prompt> --output-format text
-//   - codex   exec --full-auto <prompt>      (full-auto evita prompts de
-//     confirmación de sandbox que colgarían el proceso sin TTY)
-//   - gemini  -p <prompt>                    (text es el default)
-func (a Agent) InvokeArgs(prompt string) []string {
-	switch a {
-	case AgentOpus:
-		return []string{"-p", prompt, "--output-format", "text"}
-	case AgentCodex:
-		return []string{"exec", "--full-auto", prompt}
-	case AgentGemini:
-		return []string{"-p", prompt}
-	}
-	return nil
+// Validator es un alias del struct centralizado.
+type Validator = agent.Validator
+
+// ParseValidators parsea "codex,gemini" o "codex,codex,gemini". "none" (o
+// string vacío) → nil (desactiva validación); 1-3 items permitidos.
+func ParseValidators(s string) ([]Validator, error) {
+	return agent.ParseValidators(s, true /* allowNone */)
 }
 
 // AgentTimeout es el tiempo máximo que esperamos a que un agente responda
-// antes de cancelarlo. Valor configurable vía env CHE_AGENT_TIMEOUT_SECS
-// (útil para tests lentos o agentes pesados). Default 5 minutos: holgado
-// para un call a claude/codex/gemini sin dejar flows colgados para siempre.
+// antes de cancelarlo. Configurable vía env CHE_AGENT_TIMEOUT_SECS. Default
+// 5 minutos: holgado para un call a claude/codex/gemini sin dejar flows
+// colgados para siempre.
 var AgentTimeout = func() time.Duration {
 	if s := strings.TrimSpace(os.Getenv("CHE_AGENT_TIMEOUT_SECS")); s != "" {
 		if n, err := time.ParseDuration(s + "s"); err == nil && n > 0 {
@@ -97,117 +77,38 @@ var AgentTimeout = func() time.Duration {
 	return 5 * time.Minute
 }()
 
-// runAgentCmd invoca al binario del agente con el prompt ya construido.
-// Streamea stdout y stderr en vivo al progress (así el usuario ve qué está
-// haciendo), aplica AgentTimeout con context cancellation (si se cuelga,
-// lo mata), y devuelve el stdout completo o un error con contexto.
-//
-// Todos los callers específicos (callAgent, callValidator, etc.) pasan por
-// acá; lo único que varía es qué prompt construyen y cómo parsean el output.
-func runAgentCmd(agent Agent, prompt string, progress func(string), progressPrefix string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), AgentTimeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, agent.Binary(), agent.InvokeArgs(prompt)...)
-	stdoutPipe, err := cmd.StdoutPipe()
+// runAgentCmd es el adapter local sobre agent.Run que preserva el contrato
+// histórico: streamea stdout+stderr al progress con el prefijo dado, aplica
+// AgentTimeout, y compone los mismos mensajes de error que la implementación
+// previa. El stdout completo (sin transformar) vuelve para que parseResponse
+// pueda extraer el JSON.
+func runAgentCmd(a Agent, prompt string, progress func(string), progressPrefix string) (string, error) {
+	res, err := agent.Run(a, prompt, agent.RunOpts{
+		Timeout: AgentTimeout,
+		Format:  agent.OutputText,
+		OnLine: func(line string) {
+			if progress != nil {
+				progress(progressPrefix + line)
+			}
+		},
+		OnStderrLine: func(line string) {
+			if progress != nil {
+				progress(progressPrefix + "stderr: " + line)
+			}
+		},
+	})
+	if errors.Is(err, agent.ErrTimeout) {
+		return res.Stdout, fmt.Errorf("%s timed out after %s (stderr: %s)",
+			a, AgentTimeout, truncate(strings.TrimSpace(res.Stderr), 200))
+	}
+	var ee *agent.ExitError
+	if errors.As(err, &ee) {
+		return res.Stdout, fmt.Errorf("exit %d: %s", ee.ExitCode, ee.Stderr)
+	}
 	if err != nil {
-		return "", err
+		return res.Stdout, err
 	}
-	stderrPipe, err := cmd.StderrPipe()
-	if err != nil {
-		return "", err
-	}
-
-	if err := cmd.Start(); err != nil {
-		return "", err
-	}
-
-	var fullStdout, fullStderr strings.Builder
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go streamPipe(&wg, stdoutPipe, &fullStdout, progress, progressPrefix)
-	go streamPipe(&wg, stderrPipe, &fullStderr, progress, progressPrefix+"stderr: ")
-
-	// IMPORTANTE: según docs de exec.Cmd.StdoutPipe, "it is thus incorrect
-	// to call Wait before all reads from the pipe have completed". Primero
-	// esperamos a que las goroutines drenen los pipes hasta EOF (llega
-	// cuando el proceso termina); recién después cmd.Wait() para recoger el
-	// exit code. Al revés se pierden bytes de stdout bajo carga y el JSON
-	// llega truncado al parser.
-	wg.Wait()
-	waitErr := cmd.Wait()
-
-	if ctx.Err() == context.DeadlineExceeded {
-		return fullStdout.String(), fmt.Errorf("%s timed out after %s (stderr: %s)",
-			agent, AgentTimeout, truncate(strings.TrimSpace(fullStderr.String()), 200))
-	}
-	if waitErr != nil {
-		if ee, ok := waitErr.(*exec.ExitError); ok {
-			return fullStdout.String(), fmt.Errorf("exit %d: %s",
-				ee.ExitCode(), strings.TrimSpace(fullStderr.String()))
-		}
-		return fullStdout.String(), waitErr
-	}
-	return fullStdout.String(), nil
-}
-
-// streamPipe lee línea por línea un pipe (stdout o stderr) y la reenvía a
-// progress con el prefix dado. Acumula todo en el Builder para que el caller
-// pueda usarlo después (parsing, error reporting).
-func streamPipe(wg *sync.WaitGroup, r io.Reader, full *strings.Builder, progress func(string), prefix string) {
-	defer wg.Done()
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
-	for scanner.Scan() {
-		line := scanner.Text()
-		full.WriteString(line + "\n")
-		if strings.TrimSpace(line) != "" && progress != nil {
-			progress(prefix + line)
-		}
-	}
-}
-
-// ParseAgent normaliza un string a Agent, o error si no matchea ningún enum.
-func ParseAgent(s string) (Agent, error) {
-	s = strings.ToLower(strings.TrimSpace(s))
-	for _, a := range ValidAgents {
-		if string(a) == s {
-			return a, nil
-		}
-	}
-	return "", fmt.Errorf("unknown agent %q; valid: opus, codex, gemini", s)
-}
-
-// Validator identifica un validador del plan: agente + instancia (1..N) para
-// diferenciar cuando el mismo agente aparece varias veces en la lista.
-type Validator struct {
-	Agent    Agent
-	Instance int
-}
-
-// ParseValidators parsea una lista separada por coma ("codex,gemini",
-// "codex,codex,gemini"). Acepta "none" (o vacío) para desactivar validación.
-// Requiere 1-3 items cuando no es "none".
-func ParseValidators(s string) ([]Validator, error) {
-	s = strings.TrimSpace(s)
-	if s == "" || strings.EqualFold(s, "none") {
-		return nil, nil
-	}
-	parts := strings.Split(s, ",")
-	if len(parts) < 1 || len(parts) > 3 {
-		return nil, fmt.Errorf("validators: need 1-3 items (or `none`), got %d", len(parts))
-	}
-	counts := map[Agent]int{}
-	out := make([]Validator, 0, len(parts))
-	for _, p := range parts {
-		a, err := ParseAgent(p)
-		if err != nil {
-			return nil, fmt.Errorf("validators: %w", err)
-		}
-		counts[a]++
-		out = append(out, Validator{Agent: a, Instance: counts[a]})
-	}
-	return out, nil
+	return res.Stdout, nil
 }
 
 // Opts agrupa el writer de stdout (payload: "Explored ...", "Paused ...",

--- a/internal/flow/iterate/iterate.go
+++ b/internal/flow/iterate/iterate.go
@@ -23,18 +23,17 @@
 package iterate
 
 import (
-	"bufio"
 	"context"
-	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
+	"github.com/chichex/che/internal/agent"
 	"github.com/chichex/che/internal/flow/execute"
 	"github.com/chichex/che/internal/flow/validate"
 	"github.com/chichex/che/internal/labels"
@@ -371,158 +370,51 @@ func RenderIterateComment(iter int, commitSubjects []string) string {
 	return sb.String()
 }
 
-// ---- agent invocation (copy-adapted del patrón de close/execute) ----
+// ---- agent invocation (delega en internal/agent) ----
 
+// runAgent invoca a opus sobre el worktree (cwd=cwd) en modo stream-json
+// para que cada tool_use aparezca en los logs vía formatOpusLine.
+//
+// Iterate NO usa process group isolation (a diferencia de execute): cancel
+// por timeout mata el PID directo. Históricamente el flow se usa en entornos
+// donde opus no forkea herramientas problemáticas (los commits/push los hace
+// iterate después, no opus), así que no hace falta. Si en el futuro esto
+// cambia, se setea KillGrace=N*time.Second y listo.
 func runAgent(cwd, prompt string, log *output.Logger) error {
-	ctx, cancel := context.WithTimeout(context.Background(), AgentTimeout)
-	defer cancel()
-
-	args := []string{"-p", prompt, "--output-format", "stream-json", "--verbose"}
-	cmd := exec.CommandContext(ctx, AgentBinary, args...)
-	cmd.Dir = cwd
-	stdoutPipe, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-	stderrPipe, err := cmd.StderrPipe()
-	if err != nil {
-		return err
-	}
-
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("starting %s: %w", AgentBinary, err)
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(2)
-	var stderrBuf strings.Builder
-	go streamPipe(&wg, stdoutPipe, nil, log, "opus: ", formatOpusLine)
-	go streamPipe(&wg, stderrPipe, &stderrBuf, log, "opus stderr: ", nil)
-	wg.Wait()
-
-	waitErr := cmd.Wait()
-	if ctx.Err() == context.DeadlineExceeded {
-		if se := strings.TrimSpace(stderrBuf.String()); se != "" {
+	res, err := agent.Run(agent.AgentOpus, prompt, agent.RunOpts{
+		Dir:     cwd,
+		Timeout: AgentTimeout,
+		Format:  agent.OutputStreamJSON,
+		OnLine: func(line string) {
+			if log != nil {
+				log.Step("opus: " + line)
+			}
+		},
+		OnStderrLine: func(line string) {
+			if log != nil {
+				log.Step("opus stderr: " + line)
+			}
+		},
+		StreamFormatter: formatOpusLine,
+	})
+	if errors.Is(err, agent.ErrTimeout) {
+		if se := strings.TrimSpace(res.Stderr); se != "" {
 			return fmt.Errorf("opus timed out after %s; stderr: %s", AgentTimeout, se)
 		}
 		return fmt.Errorf("opus timed out after %s (subí CHE_ITERATE_AGENT_TIMEOUT_SECS)", AgentTimeout)
 	}
-	if waitErr != nil {
-		if ee, ok := waitErr.(*exec.ExitError); ok {
-			return fmt.Errorf("opus exit %d: %s", ee.ExitCode(), strings.TrimSpace(stderrBuf.String()))
-		}
-		return waitErr
+	var ee *agent.ExitError
+	if errors.As(err, &ee) {
+		return fmt.Errorf("opus exit %d: %s", ee.ExitCode, ee.Stderr)
 	}
-	return nil
+	return err
 }
 
-func streamPipe(wg *sync.WaitGroup, r io.Reader, acc *strings.Builder, log *output.Logger, prefix string, format func(string) (string, bool)) {
-	defer wg.Done()
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if acc != nil {
-			acc.WriteString(line + "\n")
-		}
-		out := line
-		if format != nil {
-			msg, ok := format(line)
-			if !ok {
-				continue
-			}
-			out = msg
-		}
-		if strings.TrimSpace(out) != "" && log != nil {
-			log.Step(prefix + out)
-		}
-	}
-}
-
+// formatOpusLine es un thin wrapper sobre agent.FormatOpusLine con el prefijo
+// histórico que usa iterate ("tool: "). Los tests de este paquete lo
+// ejercitan directamente con asserts sobre strings exactos.
 func formatOpusLine(line string) (string, bool) {
-	trimmed := strings.TrimSpace(line)
-	if trimmed == "" {
-		return "", false
-	}
-	if !strings.HasPrefix(trimmed, "{") {
-		return line, true
-	}
-	var ev struct {
-		Type    string `json:"type"`
-		Subtype string `json:"subtype"`
-		Message struct {
-			Content []struct {
-				Type  string                 `json:"type"`
-				Name  string                 `json:"name"`
-				Input map[string]interface{} `json:"input"`
-			} `json:"content"`
-		} `json:"message"`
-	}
-	if err := json.Unmarshal([]byte(trimmed), &ev); err != nil {
-		return line, true
-	}
-	switch ev.Type {
-	case "system":
-		if ev.Subtype == "init" {
-			return "sesión lista, arrancando…", true
-		}
-	case "assistant":
-		for _, c := range ev.Message.Content {
-			if c.Type == "tool_use" {
-				return describeOpusTool(c.Name, c.Input), true
-			}
-		}
-	case "result":
-		if ev.Subtype == "success" {
-			return "agente terminó OK", true
-		}
-		if ev.Subtype != "" {
-			return "agente terminó (" + ev.Subtype + ")", true
-		}
-	}
-	return "", false
-}
-
-// describeOpusTool arma el detalle que acompaña al nombre de la tool:
-// path para edits/reads, comando truncado para Bash, patrón para
-// Glob/Grep. Copia del helper de execute — mismo formato para que el
-// usuario reconozca los logs de distintos flows.
-func describeOpusTool(name string, input map[string]interface{}) string {
-	detail := ""
-	switch name {
-	case "Read", "Write", "Edit", "NotebookEdit":
-		if v, ok := input["file_path"].(string); ok {
-			detail = v
-		}
-	case "Bash":
-		if v, ok := input["command"].(string); ok {
-			detail = truncate(v, 80)
-		}
-	case "Glob", "Grep":
-		if v, ok := input["pattern"].(string); ok {
-			detail = v
-		}
-	case "Task":
-		if v, ok := input["description"].(string); ok {
-			detail = v
-		}
-	case "WebFetch":
-		if v, ok := input["url"].(string); ok {
-			detail = v
-		}
-	}
-	if detail == "" {
-		return "tool: " + name
-	}
-	return "tool: " + name + " " + detail
-}
-
-func truncate(s string, max int) string {
-	s = strings.ReplaceAll(s, "\n", " ")
-	if len(s) <= max {
-		return s
-	}
-	return s[:max-1] + "…"
+	return agent.FormatOpusLine(line, "tool: ")
 }
 
 // ---- worktree resolution (copy-adapted de close) ----

--- a/internal/flow/validate/validate.go
+++ b/internal/flow/validate/validate.go
@@ -13,9 +13,8 @@
 package validate
 
 import (
-	"bufio"
-	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -27,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/chichex/che/internal/agent"
 	"github.com/chichex/che/internal/labels"
 	"github.com/chichex/che/internal/output"
 )
@@ -40,13 +40,14 @@ const (
 	ExitSemantic ExitCode = 3 // ref vacío, PR cerrado, validators inválidos
 )
 
-// Agent identifica qué CLI invocar como validador.
-type Agent string
+// Agent es un alias del enum centralizado en internal/agent. Re-exportado
+// para que cmd/validate.go y la TUI sigan escribiendo `validate.Agent`.
+type Agent = agent.Agent
 
 const (
-	AgentOpus   Agent = "opus"
-	AgentCodex  Agent = "codex"
-	AgentGemini Agent = "gemini"
+	AgentOpus   = agent.AgentOpus
+	AgentCodex  = agent.AgentCodex
+	AgentGemini = agent.AgentGemini
 )
 
 // DefaultValidators es el panel por defecto cuando el caller no pasa uno
@@ -54,45 +55,10 @@ const (
 const DefaultValidators = "opus"
 
 // ValidAgents lista los agentes soportados (orden preservado para UI).
-var ValidAgents = []Agent{AgentOpus, AgentCodex, AgentGemini}
+var ValidAgents = agent.ValidAgents
 
-// Binary devuelve el nombre del ejecutable para cada agente.
-func (a Agent) Binary() string {
-	switch a {
-	case AgentOpus:
-		return "claude"
-	case AgentCodex:
-		return "codex"
-	case AgentGemini:
-		return "gemini"
-	}
-	return ""
-}
-
-// InvokeArgs devuelve los args de CLI en modo no-interactivo (mismo mapping
-// que explore/execute — si cambian los flags de los CLIs, hay que tocar los 3).
-func (a Agent) InvokeArgs(prompt string) []string {
-	switch a {
-	case AgentOpus:
-		return []string{"-p", prompt, "--output-format", "text"}
-	case AgentCodex:
-		return []string{"exec", "--full-auto", prompt}
-	case AgentGemini:
-		return []string{"-p", prompt}
-	}
-	return nil
-}
-
-// ParseAgent normaliza un string a Agent.
-func ParseAgent(s string) (Agent, error) {
-	s = strings.ToLower(strings.TrimSpace(s))
-	for _, a := range ValidAgents {
-		if string(a) == s {
-			return a, nil
-		}
-	}
-	return "", fmt.Errorf("unknown agent %q; valid: opus, codex, gemini", s)
-}
+// ParseAgent delega en internal/agent.
+func ParseAgent(s string) (Agent, error) { return agent.ParseAgent(s) }
 
 // AgentTimeout es el tiempo máximo de espera para cada validador individual.
 // Configurable con CHE_VALIDATE_AGENT_TIMEOUT_SECS. Default 10min: el diff de
@@ -106,39 +72,15 @@ var AgentTimeout = func() time.Duration {
 	return 10 * time.Minute
 }()
 
-// Validator identifica un validador: agente + instancia (1..N) para distinguir
-// cuando el mismo agente aparece varias veces en la lista.
-type Validator struct {
-	Agent    Agent
-	Instance int
-}
+// Validator es un alias del struct centralizado.
+type Validator = agent.Validator
 
 // ParseValidators parsea la flag `--validators` (ej: "opus", "codex,gemini",
 // "codex,codex,gemini"). validate requiere al menos 1 validador — a diferencia
-// de execute, aca "none" no tiene sentido (el flow completo se reduce a nada).
+// de execute, aca "none" no tiene sentido (el flow completo se reduce a nada),
+// así que lo rechazamos explícitamente con allowNone=false.
 func ParseValidators(s string) ([]Validator, error) {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return nil, fmt.Errorf("validators: empty — validate requires at least 1 validator")
-	}
-	if strings.EqualFold(s, "none") {
-		return nil, fmt.Errorf("validators: 'none' is not allowed — validate requires at least 1 validator")
-	}
-	parts := strings.Split(s, ",")
-	if len(parts) < 1 || len(parts) > 3 {
-		return nil, fmt.Errorf("validators: need 1-3 items, got %d", len(parts))
-	}
-	counts := map[Agent]int{}
-	out := make([]Validator, 0, len(parts))
-	for _, p := range parts {
-		a, err := ParseAgent(p)
-		if err != nil {
-			return nil, fmt.Errorf("validators: %w", err)
-		}
-		counts[a]++
-		out = append(out, Validator{Agent: a, Instance: counts[a]})
-	}
-	return out, nil
+	return agent.ParseValidators(s, false /* allowNone */)
 }
 
 // Opts agrupa el writer de stdout (payload: reporte final) y el logger
@@ -691,60 +633,36 @@ func callValidator(v Validator, pr *PullRequest, diff string, log *output.Logger
 	return parseResponse(out)
 }
 
-// runAgentCmd invoca al binario del agente con el prompt construido. Streamea
-// stdout/stderr en vivo al log y aplica AgentTimeout con context.
-func runAgentCmd(agent Agent, prompt string, log *output.Logger, progressPrefix string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), AgentTimeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, agent.Binary(), agent.InvokeArgs(prompt)...)
-	stdoutPipe, err := cmd.StdoutPipe()
+// runAgentCmd invoca al binario del agente con el prompt construido. Adapter
+// sobre agent.Run que preserva los mensajes de error históricos y el hecho
+// de que cada línea se emite como log.Step(prefix + line).
+func runAgentCmd(a Agent, prompt string, log *output.Logger, progressPrefix string) (string, error) {
+	res, err := agent.Run(a, prompt, agent.RunOpts{
+		Timeout: AgentTimeout,
+		Format:  agent.OutputText,
+		OnLine: func(line string) {
+			if log != nil {
+				log.Step(progressPrefix + line)
+			}
+		},
+		OnStderrLine: func(line string) {
+			if log != nil {
+				log.Step(progressPrefix + "stderr: " + line)
+			}
+		},
+	})
+	if errors.Is(err, agent.ErrTimeout) {
+		return res.Stdout, fmt.Errorf("%s timed out after %s (stderr: %s)",
+			a, AgentTimeout, truncate(strings.TrimSpace(res.Stderr), 200))
+	}
+	var ee *agent.ExitError
+	if errors.As(err, &ee) {
+		return res.Stdout, fmt.Errorf("exit %d: %s", ee.ExitCode, ee.Stderr)
+	}
 	if err != nil {
-		return "", err
+		return res.Stdout, err
 	}
-	stderrPipe, err := cmd.StderrPipe()
-	if err != nil {
-		return "", err
-	}
-
-	if err := cmd.Start(); err != nil {
-		return "", err
-	}
-
-	var fullStdout, fullStderr strings.Builder
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go streamPipe(&wg, stdoutPipe, &fullStdout, log, progressPrefix)
-	go streamPipe(&wg, stderrPipe, &fullStderr, log, progressPrefix+"stderr: ")
-
-	wg.Wait()
-	waitErr := cmd.Wait()
-
-	if ctx.Err() == context.DeadlineExceeded {
-		return fullStdout.String(), fmt.Errorf("%s timed out after %s (stderr: %s)",
-			agent, AgentTimeout, truncate(strings.TrimSpace(fullStderr.String()), 200))
-	}
-	if waitErr != nil {
-		if ee, ok := waitErr.(*exec.ExitError); ok {
-			return fullStdout.String(), fmt.Errorf("exit %d: %s",
-				ee.ExitCode(), strings.TrimSpace(fullStderr.String()))
-		}
-		return fullStdout.String(), waitErr
-	}
-	return fullStdout.String(), nil
-}
-
-func streamPipe(wg *sync.WaitGroup, r io.Reader, full *strings.Builder, log *output.Logger, prefix string) {
-	defer wg.Done()
-	scanner := bufio.NewScanner(r)
-	scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
-	for scanner.Scan() {
-		line := scanner.Text()
-		full.WriteString(line + "\n")
-		if strings.TrimSpace(line) != "" && log != nil {
-			log.Step(prefix + line)
-		}
-	}
+	return res.Stdout, nil
 }
 
 func truncate(s string, n int) string {


### PR DESCRIPTION
## Motivación

Los paquetes `internal/flow/explore`, `internal/flow/execute`, `internal/flow/validate` e `internal/flow/iterate` tenían cada uno su propia copia del plumbing del agente: ~500 líneas duplicadas entre `Agent` enum + `Binary()` + `InvokeArgs()` + `ParseAgent` + `Validator` + `ParseValidators` + `runAgentCmd` + `streamPipe` + `truncate` + (en 2 de ellos) `formatOpusLine` + `describeOpusTool`. Los comentarios ya anotaban la deuda ("deliberadamente una copia adaptada de explore/execute — la deuda de extraer lo común queda para un issue futuro").

## Alcance

Refactor puro, **cero cambio de comportamiento**. Este PR:

1. Crea `internal/agent/` (paquete común) con `agent.go`, `invoke.go`, `validator.go`, `run.go`, `stream.go` + tests unit.
2. Migra los 4 paquetes flow a delegar en `internal/agent`, reexportando `Agent`/`Validator`/etc vía `type` aliases para no romper a `cmd/*.go` ni `internal/tui/model.go`.

El paquete `close` no entra en este PR (tiene su propia variante simplificada del plumbing, que queda para otro refactor).

## Comportamiento preservado exactamente

- **Output format** por flow: `explore`/`validate` usan `--output-format text`; `execute`/`iterate` usan `--output-format stream-json --verbose`.
- **Timeouts** (cada paquete mantiene su env var y su default):
  - `explore`: `CHE_AGENT_TIMEOUT_SECS`, 5min.
  - `execute`: `CHE_EXEC_AGENT_TIMEOUT_SECS`, 30min.
  - `validate`: `CHE_VALIDATE_AGENT_TIMEOUT_SECS`, 10min.
  - `iterate`: `CHE_ITERATE_AGENT_TIMEOUT_SECS`, 30min.
- **Signal handling**: `execute` sigue aislando al agente en su propio process group con `Setpgid + cmd.Cancel + WaitDelay` para SIGTERM→SIGKILL en 5s (a través de `RunOpts.KillGrace`). `explore`/`validate`/`iterate` siguen con cancelación simple por context (`KillGrace=0`).
- **`ParseValidators`**: `explore`/`execute` aceptan `"none"` → `nil`; `validate` lo rechaza con error. El común ofrece `ParseValidators(s, allowNone bool)`.
- **cwd**: `execute` e `iterate` fijan `cmd.Dir = worktreePath`; `explore`/`validate` heredan. Expuesto como `RunOpts.Dir`.
- **Mensajes de error** que los tests asertan (`"timed out after %s"`, `"exit %d: %s"`, `"%s: cancelado por señal"`, etc.) se replican byte-por-byte en los adapters locales.
- **`describeOpusTool`**: `execute` lo usa sin prefijo (`"Edit foo.go"`); `iterate` con prefijo `"tool: "` (`"tool: Edit foo.go"`). `FormatOpusLine(line, toolPrefix)` cubre ambos casos.
- **`fireValidators` de execute**: sigue invocando a los validadores con `Format=OutputStreamJSON` (= lo que hacía `v.Agent.InvokeArgs(prompt)` antes). Es un sharp edge conocido que se preserva por ser refactor puro.

## Diff stat

- Nuevo paquete: 688 líneas (incluye 201 de tests).
- Los 4 flow packages: -706 / +208 = **-498 netas**.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -count=1 ./...` (incluye `internal/tui`, `e2e`, los 4 flows).
- [x] Tests nuevos en `internal/agent/agent_test.go` cubren `ParseAgent`, `ParseValidators` con ambos flags de `allowNone`, `InvokeArgs` por formato, y `FormatOpusLine` con y sin prefijo.

## Out of scope (próximos PRs)

- PR #3: simplificar `explore`/`execute`, eliminar `deprecatedAwaitingHuman` (shims que el PR #1 dejó).
- PR #4: `validate` plan.
- PR #5: `iterate` plan.
- PR #6: TUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)