### PR TITLE
feat(validate): soportar target plan — validación de planes en issues

### DIFF
--- a/cmd/close.go
+++ b/cmd/close.go
@@ -44,7 +44,7 @@ Formatos aceptados para <pr-ref>:
 No hay flag --agent: close usa opus (claude) por diseño.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if _, err := validate.ParsePRRef(args[0]); err != nil {
+		if _, err := validate.ParseRef(args[0]); err != nil {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
 			os.Stderr.WriteString("error: invalid pr ref: " + err.Error() + "\n")

--- a/cmd/iterate.go
+++ b/cmd/iterate.go
@@ -38,7 +38,7 @@ Formatos aceptados para <pr-ref>:
 No hay flag --agent: iterate usa opus (claude) por diseño.`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if _, err := validate.ParsePRRef(args[0]); err != nil {
+		if _, err := validate.ParseRef(args[0]); err != nil {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
 			os.Stderr.WriteString("error: invalid pr ref: " + err.Error() + "\n")

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -11,20 +11,25 @@ import (
 var validateValidatorsFlag string
 
 var validateCmd = &cobra.Command{
-	Use:   "validate <pr-ref>",
-	Short: "valida un PR corriendo validadores (opus/codex/gemini) sobre el diff y postea findings como comments",
-	Long: `validate toma una referencia a un PR abierto, descarga su diff, y corre
-1-3 validadores en paralelo (opus, codex, gemini) sobre el diff. Cada
-validador postea su análisis como un comment del PR, y al final se postea
-un comment resumen con la tabla de verdicts. validate es SYNC: espera a
-que todos los comments estén posteados antes de retornar.
+	Use:   "validate <ref>",
+	Short: "valida un plan (issue) o un PR corriendo validadores (opus/codex/gemini) y postea findings como comments",
+	Long: `validate detecta automáticamente si <ref> apunta a un issue en status:plan
+o a un PR abierto, y despacha al modo correspondiente:
 
-validate NO toca el draft/ready del PR, ni los labels del issue vinculado,
-ni cierra nada — solo comments.
+  che validate 42       # issue en status:plan → valida el plan consolidado del body,
+                        #   postea comments en el issue y aplica plan-validated:*
+  che validate 7        # PR abierto → valida el diff, postea comments en el PR y
+                        #   aplica validated:*
 
-Formatos aceptados para <pr-ref>:
+En ambos modos corren 1-3 validadores en paralelo (opus, codex, gemini);
+cada uno postea su análisis como un comment y al final se postea un comment
+resumen con la tabla de verdicts. validate es SYNC: espera a que todos los
+comments estén posteados antes de retornar.
+
+Formatos aceptados para <ref>:
   che validate 7
   che validate https://github.com/owner/repo/pull/7
+  che validate https://github.com/owner/repo/issues/42
   che validate owner/repo#7
 
 Validadores (--validators): 1-3 separados por coma, pueden repetir tipo
@@ -46,7 +51,7 @@ abrir el HTML.`,
 		if _, err := validate.ParsePRRef(args[0]); err != nil {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
-			os.Stderr.WriteString("error: invalid pr ref: " + err.Error() + "\n")
+			os.Stderr.WriteString("error: invalid ref: " + err.Error() + "\n")
 			os.Exit(int(validate.ExitSemantic))
 		}
 		code := validate.Run(args[0], validate.Opts{

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -48,7 +48,7 @@ abrir el HTML.`,
 			os.Stderr.WriteString("error: invalid --validators: " + err.Error() + "\n")
 			os.Exit(int(validate.ExitSemantic))
 		}
-		if _, err := validate.ParsePRRef(args[0]); err != nil {
+		if _, err := validate.ParseRef(args[0]); err != nil {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
 			os.Stderr.WriteString("error: invalid ref: " + err.Error() + "\n")

--- a/e2e/testdata/validate/gh_api_issue.json
+++ b/e2e/testdata/validate/gh_api_issue.json
@@ -1,0 +1,6 @@
+{
+  "number": 42,
+  "title": "Agregar rate limiting al endpoint /login",
+  "state": "open",
+  "pull_request": null
+}

--- a/e2e/testdata/validate/gh_api_pr.json
+++ b/e2e/testdata/validate/gh_api_pr.json
@@ -1,0 +1,12 @@
+{
+  "number": 7,
+  "title": "feat(execute): nuevo flow",
+  "state": "open",
+  "pull_request": {
+    "url": "https://api.github.com/repos/acme/demo/pulls/7",
+    "html_url": "https://github.com/acme/demo/pull/7",
+    "diff_url": "https://github.com/acme/demo/pull/7.diff",
+    "patch_url": "https://github.com/acme/demo/pull/7.patch",
+    "merged_at": null
+  }
+}

--- a/e2e/testdata/validate/gh_issue_view_no_status_plan.json
+++ b/e2e/testdata/validate/gh_issue_view_no_status_plan.json
@@ -1,0 +1,13 @@
+{
+  "number": 42,
+  "title": "Idea vaga sin explorar",
+  "body": "no hay plan consolidado acá",
+  "url": "https://github.com/acme/demo/issues/42",
+  "state": "OPEN",
+  "labels": [
+    {"name": "ct:plan"},
+    {"name": "status:idea"},
+    {"name": "type:feat"},
+    {"name": "size:m"}
+  ]
+}

--- a/e2e/testdata/validate/gh_issue_view_plan_consolidated.json
+++ b/e2e/testdata/validate/gh_issue_view_plan_consolidated.json
@@ -1,0 +1,13 @@
+{
+  "number": 42,
+  "title": "Agregar rate limiting al endpoint /login",
+  "body": "## Plan consolidado (post-exploración)\n\n**Resumen:** Rate limit al login para frenar brute force.\n\n**Goal:** Bloquear >5 intentos/minuto por IP en /login.\n\n### Criterios de aceptación\n- [ ] El 6to intento dentro de una ventana de 60s devuelve HTTP 429.\n- [ ] El contador se resetea tras 60s de inactividad.\n- [ ] Tests unitarios cubren la ventana deslizante.\n\n### Approach\nMiddleware in-memory con LRU cacheada por IP. Se monta solo en /login; no global.\n\n### Pasos\n1. Agregar middleware ratelimit con LRU de tamaño 10_000.\n2. Wirearlo únicamente a /login en el router.\n3. Agregar test de ventana deslizante y test de expiración.\n\n### Riesgos a mitigar\n- **IPs compartidas (NAT)** (likelihood=low, impact=medium) — usar IP+user-agent como key.\n\n### Fuera de alcance\n- Rate limit global para otros endpoints.\n\n---\n\n## Idea original (de `che idea`)\n\nNecesitamos frenar brute force al login; alguien nos reportó 500 intentos/hora.\n",
+  "url": "https://github.com/acme/demo/issues/42",
+  "state": "OPEN",
+  "labels": [
+    {"name": "ct:plan"},
+    {"name": "status:plan"},
+    {"name": "type:feat"},
+    {"name": "size:s"}
+  ]
+}

--- a/e2e/testdata/validate/gh_issue_view_status_plan_no_consolidated.json
+++ b/e2e/testdata/validate/gh_issue_view_status_plan_no_consolidated.json
@@ -1,0 +1,11 @@
+{
+  "number": 42,
+  "title": "Issue con status:plan pero sin plan consolidado",
+  "body": "alguien puso el label a mano pero el body es solo texto libre sin header de plan consolidado.",
+  "url": "https://github.com/acme/demo/issues/42",
+  "state": "OPEN",
+  "labels": [
+    {"name": "ct:plan"},
+    {"name": "status:plan"}
+  ]
+}

--- a/e2e/validate_test.go
+++ b/e2e/validate_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/chichex/che/e2e/harness"
@@ -53,6 +54,7 @@ func TestValidate_InvalidPRRef_Exit3(t *testing.T) {
 func TestValidate_GoldenPath_OpusApproves(t *testing.T) {
 	env := setupValidateEnv(t)
 	scriptValidatePrechecks(env)
+	scriptDetectTargetPR(env, 7)
 
 	env.ExpectGh(`^pr view 7 --json number,title,url,state,isDraft,author,headRefName`).
 		RespondStdoutFromFixture("validate/gh_pr_view_open.json", 0)
@@ -100,6 +102,7 @@ func TestValidate_GoldenPath_OpusApproves(t *testing.T) {
 func TestValidate_ClosedPR_Exit3(t *testing.T) {
 	env := setupValidateEnv(t)
 	scriptValidatePrechecks(env)
+	scriptDetectTargetPR(env, 7)
 
 	env.ExpectGh(`^pr view 7 --json number,title`).
 		RespondStdoutFromFixture("validate/gh_pr_view_closed.json", 0)
@@ -117,6 +120,7 @@ func TestValidate_ClosedPR_Exit3(t *testing.T) {
 func TestValidate_Iter2_IncrementsFromPreviousComments(t *testing.T) {
 	env := setupValidateEnv(t)
 	scriptValidatePrechecks(env)
+	scriptDetectTargetPR(env, 7)
 
 	env.ExpectGh(`^pr view 7 --json number,title`).
 		RespondStdoutFromFixture("validate/gh_pr_view_open.json", 0)
@@ -151,6 +155,7 @@ func TestValidate_Iter2_IncrementsFromPreviousComments(t *testing.T) {
 func TestValidate_MultipleValidators_AllPosted(t *testing.T) {
 	env := setupValidateEnv(t)
 	scriptValidatePrechecks(env)
+	scriptDetectTargetPR(env, 7)
 
 	env.ExpectGh(`^pr view 7 --json number,title`).
 		RespondStdoutFromFixture("validate/gh_pr_view_open.json", 0)
@@ -202,6 +207,7 @@ func TestValidate_MultipleValidators_AllPosted(t *testing.T) {
 func TestValidate_EmptyDiff_Exit3(t *testing.T) {
 	env := setupValidateEnv(t)
 	scriptValidatePrechecks(env)
+	scriptDetectTargetPR(env, 7)
 
 	env.ExpectGh(`^pr view 7 --json number,title`).
 		RespondStdoutFromFixture("validate/gh_pr_view_open.json", 0)
@@ -212,6 +218,87 @@ func TestValidate_EmptyDiff_Exit3(t *testing.T) {
 		t.Fatalf("expected exit 3, got %d\nstderr: %s", r.ExitCode, r.Stderr)
 	}
 	harness.AssertContains(t, r.Stderr, "vacío")
+	env.Invocations().AssertNotCalled(t, "claude")
+}
+
+// TestValidate_Plan_GoldenPath_OpusApproves: issue abierto con status:plan y
+// body con plan consolidado → validador aprueba → 2 comments en el issue
+// (validator + summary) + label plan-validated:approve aplicado.
+func TestValidate_Plan_GoldenPath_OpusApproves(t *testing.T) {
+	env := setupValidateEnv(t)
+	scriptValidatePrechecks(env)
+	scriptDetectTargetPlan(env, 42)
+
+	env.ExpectGh(`^issue view 42 --json number,title,body,labels,url,state$`).
+		RespondStdoutFromFixture("validate/gh_issue_view_plan_consolidated.json", 0)
+	env.ExpectGh(`^issue view 42 --json comments$`).
+		RespondStdout(`{"comments": []}`, 0)
+
+	env.ExpectAgent("claude").
+		WhenArgsMatch(`validador técnico senior`).
+		RespondStdoutFromFixture("validate/validator_approve.json", 0)
+
+	// 2 comments esperados: uno del validator, uno del resumen.
+	env.ExpectGh(`^issue comment 42 --body-file`).Consumable().RespondStdout("ok\n", 0)
+	env.ExpectGh(`^issue comment 42 --body-file`).Consumable().RespondStdout("ok\n", 0)
+
+	// Label plan-validated:approve: ensure + issue edit.
+	env.ExpectGh(`^label create plan-validated:approve --force$`).RespondStdout("ok\n", 0)
+	env.ExpectGh(`^issue edit 42 --add-label plan-validated:approve$`).RespondStdout("ok\n", 0)
+
+	out := env.MustRun("validate", "--validators", "opus", "42")
+	harness.AssertContains(t, out, "che ya dejó los comments")
+	harness.AssertContains(t, out, "opus#1: approve")
+
+	inv := env.Invocations()
+	if len(inv.For("claude")) != 1 {
+		t.Fatalf("expected 1 claude call, got %d", len(inv.For("claude")))
+	}
+	comments := inv.FindCalls("gh", "issue", "comment", "42", "--body-file")
+	if len(comments) != 2 {
+		t.Fatalf("expected 2 issue comment calls (validator + summary), got %d", len(comments))
+	}
+	edits := inv.FindCalls("gh", "issue", "edit", "42", "--add-label", "plan-validated:approve")
+	if len(edits) != 1 {
+		t.Fatalf("expected 1 issue edit with plan-validated:approve, got %d", len(edits))
+	}
+}
+
+// TestValidate_Plan_NoStatusPlan_Exit3: issue abierto sin status:plan →
+// exit semantic con mensaje accionable ("corré che explore"). No llama
+// validadores.
+func TestValidate_Plan_NoStatusPlan_Exit3(t *testing.T) {
+	env := setupValidateEnv(t)
+	scriptValidatePrechecks(env)
+	scriptDetectTargetPlan(env, 42)
+
+	env.ExpectGh(`^issue view 42 --json number,title,body,labels,url,state$`).
+		RespondStdoutFromFixture("validate/gh_issue_view_no_status_plan.json", 0)
+
+	r := env.Run("validate", "--validators", "opus", "42")
+	if r.ExitCode != 3 {
+		t.Fatalf("expected exit 3, got %d\nstderr: %s", r.ExitCode, r.Stderr)
+	}
+	harness.AssertContains(t, r.Stderr, "status:plan")
+	harness.AssertContains(t, r.Stderr, "che explore")
+	env.Invocations().AssertNotCalled(t, "claude")
+}
+
+// TestValidate_Plan_NoConsolidatedPlan_Exit3: issue con status:plan pero
+// body sin "## Plan consolidado" → exit semantic. No llama validadores.
+func TestValidate_Plan_NoConsolidatedPlan_Exit3(t *testing.T) {
+	env := setupValidateEnv(t)
+	scriptValidatePrechecks(env)
+	scriptDetectTargetPlan(env, 42)
+
+	env.ExpectGh(`^issue view 42 --json number,title,body,labels,url,state$`).
+		RespondStdoutFromFixture("validate/gh_issue_view_status_plan_no_consolidated.json", 0)
+
+	r := env.Run("validate", "--validators", "opus", "42")
+	if r.ExitCode != 3 {
+		t.Fatalf("expected exit 3, got %d\nstderr: %s", r.ExitCode, r.Stderr)
+	}
+	harness.AssertContains(t, r.Stderr, "plan consolidado")
 	env.Invocations().AssertNotCalled(t, "claude")
 }
 
@@ -238,4 +325,21 @@ func setupValidateEnv(t *testing.T) *harness.Env {
 func scriptValidatePrechecks(env *harness.Env) {
 	env.ExpectGh(`^auth status$`).Consumable().
 		RespondStdout("Logged in as acme\n", 0)
+}
+
+// scriptDetectTargetPR scriptea la respuesta de `gh api repos/.../issues/<n>`
+// que detectTarget consulta para decidir PR vs plan. El JSON mínimo incluye
+// pull_request:{} para que el detector retorne TargetPR.
+func scriptDetectTargetPR(env *harness.Env, number int) {
+	env.ExpectGh(fmt.Sprintf(`^api repos/\{owner\}/\{repo\}/issues/%d$`, number)).
+		Consumable().
+		RespondStdout(fmt.Sprintf(`{"number":%d,"pull_request":{"url":"https://api.github.com/repos/acme/demo/pulls/%d"}}`, number, number), 0)
+}
+
+// scriptDetectTargetPlan scriptea la respuesta para el modo plan: pull_request
+// ausente o null indica issue (no PR).
+func scriptDetectTargetPlan(env *harness.Env, number int) {
+	env.ExpectGh(fmt.Sprintf(`^api repos/\{owner\}/\{repo\}/issues/%d$`, number)).
+		Consumable().
+		RespondStdout(fmt.Sprintf(`{"number":%d,"pull_request":null}`, number), 0)
 }

--- a/internal/flow/close/closing.go
+++ b/internal/flow/close/closing.go
@@ -322,7 +322,7 @@ func Run(prRef string, opts Opts) ExitCode {
 		log.Error("pr ref is empty")
 		return ExitSemantic
 	}
-	if _, err := validate.ParsePRRef(prRef); err != nil {
+	if _, err := validate.ParseRef(prRef); err != nil {
 		log.Error("pr ref invalido", output.F{Cause: err})
 		return ExitSemantic
 	}

--- a/internal/flow/iterate/iterate.go
+++ b/internal/flow/iterate/iterate.go
@@ -121,7 +121,7 @@ func Run(prRef string, opts Opts) ExitCode {
 		log.Error("pr ref is empty")
 		return ExitSemantic
 	}
-	if _, err := validate.ParsePRRef(prRef); err != nil {
+	if _, err := validate.ParseRef(prRef); err != nil {
 		log.Error("pr ref invalido", output.F{Cause: err})
 		return ExitSemantic
 	}

--- a/internal/flow/validate/validate.go
+++ b/internal/flow/validate/validate.go
@@ -297,6 +297,18 @@ func Run(ref string, opts Opts) ExitCode {
 	log.Step("detectando si el ref es un issue o un PR")
 	target, err := detectTarget(ref)
 	if err != nil {
+		// resolveRefNumber falla solo si el formato del ref es irreparable
+		// (no número, no URL con /pull/N o /issues/N, no owner/repo#N). Eso
+		// es input inválido del usuario → ExitSemantic. El resto de los
+		// fallos vienen de `gh api` (red o 404) y son potencialmente
+		// remediables → ExitRetry. Nota: tras el fix de ParseRef, la rama
+		// semantic es prácticamente inalcanzable desde cmd/validate porque
+		// ya validamos antes; queda como defensa en profundidad para otros
+		// callers (TUI, futuros) que invoquen Run sin pre-validar.
+		if errors.Is(err, errInvalidRef) {
+			log.Error("ref invalido", output.F{Cause: err})
+			return ExitSemantic
+		}
 		log.Error("no se pudo determinar si es issue o PR", output.F{Cause: err})
 		return ExitRetry
 	}
@@ -483,6 +495,13 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 	return ExitOK
 }
 
+// errInvalidRef marca errores de detectTarget/resolveRefNumber que vienen
+// de un ref con formato irreparable (no número, no URL con /pull/ o
+// /issues/, no owner/repo#N). Permite al caller distinguir "input del
+// usuario malformado" (ExitSemantic) de "gh api falló" (ExitRetry) sin
+// tener que parsear strings.
+var errInvalidRef = errors.New("invalid ref")
+
 // detectTarget decide si un ref apunta a un issue o un PR. Consulta el
 // endpoint `gh api repos/:owner/:repo/issues/:n`, que devuelve el mismo
 // shape para issues y PRs pero con un campo `pull_request` no-null cuando
@@ -498,7 +517,7 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 func detectTarget(ref string) (Target, error) {
 	ref = strings.TrimSpace(ref)
 	if ref == "" {
-		return TargetUnknown, fmt.Errorf("empty ref")
+		return TargetUnknown, fmt.Errorf("%w: empty ref", errInvalidRef)
 	}
 	number, err := resolveRefNumber(ref)
 	if err != nil {
@@ -561,7 +580,7 @@ func resolveRefNumber(ref string) (int, error) {
 			}
 		}
 	}
-	return 0, fmt.Errorf("could not resolve number from ref %q", ref)
+	return 0, fmt.Errorf("%w: could not resolve number from ref %q", errInvalidRef, ref)
 }
 
 // consolidateVerdict devuelve el verdict consolidado (peor caso) de todos los
@@ -704,26 +723,33 @@ func filterValidatable(raw []PullRequest) []Candidate {
 	return res
 }
 
-// ParsePRRef acepta varios formatos de ref y devuelve una forma que gh
-// entiende:
+// ParseRef acepta varios formatos de ref a issue o PR y devuelve una forma
+// que gh entiende:
 //   - "7" → "7"
 //   - "owner/repo#7" → "owner/repo#7" (gh lo soporta nativo)
-//   - URL completa "https://github.com/owner/repo/pull/7" → tal cual (gh ok)
+//   - URL "https://github.com/owner/repo/pull/7" → tal cual (gh ok)
+//   - URL "https://github.com/owner/repo/issues/42" → tal cual (gh ok)
 //
-// El único formato que rechazamos es el vacío. Para el resto delegamos la
-// validación a `gh pr view` (si el ref es inválido, gh devuelve error y lo
-// propagamos con contexto).
-func ParsePRRef(ref string) (string, error) {
+// El único formato que rechazamos es el vacío o formas irreconocibles. Para
+// el resto delegamos la validación a `gh pr view` / `gh issue view` (si el
+// ref es inválido, gh devuelve error y lo propagamos con contexto).
+//
+// `che validate` lo usa para ambos targets (issue en status:plan o PR); los
+// flows PR-exclusive (iterate, close) siguen llamándolo — si el usuario
+// pasa un issue a esos, el preflight de `FetchPR` falla con un mensaje
+// claro.
+func ParseRef(ref string) (string, error) {
 	ref = strings.TrimSpace(ref)
 	if ref == "" {
-		return "", fmt.Errorf("pr ref is empty")
+		return "", fmt.Errorf("ref is empty")
 	}
 	// "7" o número puro → ok.
 	if _, err := strconv.Atoi(ref); err == nil {
 		return ref, nil
 	}
-	// URL de GitHub con /pull/<n> → ok.
-	if strings.HasPrefix(ref, "https://github.com/") && strings.Contains(ref, "/pull/") {
+	// URL de GitHub con /pull/<n> o /issues/<n> → ok.
+	if strings.HasPrefix(ref, "https://github.com/") &&
+		(strings.Contains(ref, "/pull/") || strings.Contains(ref, "/issues/")) {
 		return ref, nil
 	}
 	// owner/repo#N → ok.
@@ -735,7 +761,7 @@ func ParsePRRef(ref string) (string, error) {
 			}
 		}
 	}
-	return "", fmt.Errorf("unrecognized PR ref %q — accepted: '7', 'owner/repo#7', URL", ref)
+	return "", fmt.Errorf("unrecognized ref %q — accepted: '7', 'owner/repo#7', '/pull/N' URL, '/issues/N' URL", ref)
 }
 
 // ---- prechecks ----

--- a/internal/flow/validate/validate.go
+++ b/internal/flow/validate/validate.go
@@ -31,6 +31,28 @@ import (
 	"github.com/chichex/che/internal/output"
 )
 
+// Target discrimina el tipo de ref que recibió `che validate`. La detección
+// corre contra `gh api repos/{owner}/{repo}/issues/{n}`: ese endpoint devuelve
+// el mismo shape para issues y PRs, con la diferencia de que los PRs incluyen
+// un campo `pull_request` no-null. Ambos targets comparten el runner de
+// validadores en paralelo, la consolidación de verdict y el render de
+// comments; lo que cambia es qué se valida (diff vs plan del body), dónde
+// se postea el comment (pr vs issue) y qué label se aplica (validated:* vs
+// plan-validated:*).
+type Target int
+
+const (
+	// TargetUnknown es el valor cero; no debería retornarlo detectTarget
+	// salvo que haya un bug.
+	TargetUnknown Target = iota
+	// TargetPlan indica que el ref apunta a un issue (no-PR) y el modo
+	// plan del flow aplica: valida el body consolidado del issue.
+	TargetPlan
+	// TargetPR indica que el ref apunta a un pull request; modo PR
+	// (comportamiento histórico: valida el diff).
+	TargetPR
+)
+
 // ExitCode es el código de salida semántico para el caller.
 type ExitCode int
 
@@ -231,19 +253,17 @@ type validatorResult struct {
 	Err       error
 }
 
-// Run ejecuta el flow completo sobre un PR. Es sync: espera a que todos los
-// validadores terminen y sus comments estén posteados antes de retornar.
-// Decisiones:
-//   - Preflight: gh auth + remote github.
-//   - Fetch del PR: gh pr view --json ...
-//   - Diff: gh pr diff <n>
-//   - Iter: max(flow=validate) + 1 sobre comments previos.
-//   - Validadores: goroutines en paralelo, wait sin timeout global (cada uno
-//     tiene su AgentTimeout individual — si se cuelga, muere).
-//   - Comments: 1 por validador con título visible + header HTML + 1 resumen
-//     final con tabla.
-//   - Stdout: reporte resumido (verdict + findings count por validador).
-func Run(prRef string, opts Opts) ExitCode {
+// Run ejecuta el flow despachando por tipo de ref. Detecta si <ref> es un
+// issue (modo plan) o un PR (modo PR actual) usando `gh api` y delega. La
+// API pública del paquete no cambia — cmd/validate.go sigue llamando a
+// validate.Run(ref, opts) sin saber qué target tocó.
+//
+// Preflight común (gh auth + remote) vive en el despachador: es idéntico en
+// ambos modos y no queremos repetirlo en runPR/runPlan. El preflight también
+// corre ANTES de detectTarget para que errores de entorno (no auth, no
+// remote github) no disparen una llamada a `gh api` que igual va a fallar —
+// así el usuario ve el error accionable primero.
+func Run(ref string, opts Opts) ExitCode {
 	stdout := opts.Stdout
 	if stdout == nil {
 		stdout = io.Discard
@@ -253,12 +273,11 @@ func Run(prRef string, opts Opts) ExitCode {
 		log = output.New(nil)
 	}
 
-	prRef = strings.TrimSpace(prRef)
-	if prRef == "" {
-		log.Error("pr ref is empty")
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		log.Error("ref is empty")
 		return ExitSemantic
 	}
-
 	if len(opts.Validators) == 0 {
 		log.Error("at least 1 validator is required")
 		return ExitSemantic
@@ -274,6 +293,29 @@ func Run(prRef string, opts Opts) ExitCode {
 		return ExitRetry
 	}
 
+	log.Step("detectando si el ref es un issue o un PR")
+	target, err := detectTarget(ref)
+	if err != nil {
+		log.Error("no se pudo determinar si es issue o PR", output.F{Cause: err})
+		return ExitRetry
+	}
+	switch target {
+	case TargetPR:
+		return runPR(ref, opts, stdout, log)
+	case TargetPlan:
+		// TODO (próximo commit): implementar runPlan.
+		log.Error("target plan (issue) aún no implementado — solo PR por ahora")
+		return ExitSemantic
+	default:
+		log.Error(fmt.Sprintf("tipo de ref desconocido: %v", target))
+		return ExitRetry
+	}
+}
+
+// runPR es el flow histórico: valida el diff de un PR abierto, postea
+// comments en el PR y aplica validated:*. El preflight (auth + remote)
+// ya corrió en Run.
+func runPR(prRef string, opts Opts, stdout io.Writer, log *output.Logger) ExitCode {
 	log.Info("obteniendo PR desde GitHub")
 	pr, err := FetchPR(prRef)
 	if err != nil {
@@ -305,7 +347,8 @@ func Run(prRef string, opts Opts) ExitCode {
 	iter := DetermineIter(comments)
 
 	log.Info(fmt.Sprintf("corriendo %d validador(es) en paralelo", len(opts.Validators)), output.F{Iter: iter, PR: pr.Number})
-	results := runValidatorsParallel(pr, diff, opts.Validators, log)
+	prompt := buildPRValidatorPrompt(pr, diff)
+	results := runValidatorsParallel(prompt, opts.Validators, log)
 
 	log.Step("posteando comments de validadores")
 	for _, r := range results {
@@ -345,6 +388,87 @@ func Run(prRef string, opts Opts) ExitCode {
 	fmt.Fprintln(stdout, renderReport(results))
 	fmt.Fprintf(stdout, "che ya dejó los comments en el PR %s\n", pr.URL)
 	return ExitOK
+}
+
+// detectTarget decide si un ref apunta a un issue o un PR. Consulta el
+// endpoint `gh api repos/:owner/:repo/issues/:n`, que devuelve el mismo
+// shape para issues y PRs pero con un campo `pull_request` no-null cuando
+// es un PR (documentado en la REST API de GitHub). Es el approach más
+// confiable: no depende de errores como "not a pull request" que tienen
+// wording sensible a idioma o versión de gh.
+//
+// Para soportar refs que no son números puros (URL, owner/repo#N), usamos
+// `gh issue view <ref> --json number` primero para obtener el número
+// canónico; eso nos da el número aunque el ref sea "https://.../pull/7"
+// (gh normaliza: a un PR lo acepta también como issue en el REST view).
+// Si eso falla caemos a detectar si es un número directo; si no, error.
+func detectTarget(ref string) (Target, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return TargetUnknown, fmt.Errorf("empty ref")
+	}
+	number, err := resolveRefNumber(ref)
+	if err != nil {
+		return TargetUnknown, err
+	}
+	cmd := exec.Command("gh", "api", fmt.Sprintf("repos/{owner}/{repo}/issues/%d", number))
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return TargetUnknown, fmt.Errorf("gh api issues/%d: %s", number, strings.TrimSpace(string(ee.Stderr)))
+		}
+		return TargetUnknown, err
+	}
+	// Parseamos solo los campos que necesitamos. pull_request aparece como
+	// objeto cuando el número corresponde a un PR; está ausente o null en
+	// issues regulares. json.RawMessage nos deja distinguir null de objeto
+	// sin depender del shape interno (que es documentado pero extenso).
+	var probe struct {
+		PullRequest json.RawMessage `json:"pull_request"`
+	}
+	if err := json.Unmarshal(out, &probe); err != nil {
+		return TargetUnknown, fmt.Errorf("parse gh api output: %w", err)
+	}
+	if len(probe.PullRequest) > 0 && string(probe.PullRequest) != "null" {
+		return TargetPR, nil
+	}
+	return TargetPlan, nil
+}
+
+// resolveRefNumber devuelve el número del issue/PR que corresponde al ref.
+// Si el ref es un número puro, lo devuelve tal cual (sin tocar red). Para
+// URLs / owner/repo#N extraemos el número con parsing local — no llamamos
+// a gh para evitar un round-trip extra cuando el usuario tipeó "7" o una
+// URL perfectamente formada. Los refs que no matcheamos acá los dejamos
+// caer al caller (detectTarget) con un error accionable.
+func resolveRefNumber(ref string) (int, error) {
+	if n, err := strconv.Atoi(ref); err == nil {
+		return n, nil
+	}
+	if strings.Contains(ref, "#") {
+		parts := strings.SplitN(ref, "#", 2)
+		if len(parts) == 2 {
+			if n, err := strconv.Atoi(strings.TrimSpace(parts[1])); err == nil {
+				return n, nil
+			}
+		}
+	}
+	// URL de GitHub: /pull/N o /issues/N.
+	for _, segment := range []string{"/pull/", "/issues/"} {
+		if i := strings.Index(ref, segment); i >= 0 {
+			tail := ref[i+len(segment):]
+			// cortar query / fragment / path extra
+			for _, sep := range []string{"/", "?", "#"} {
+				if j := strings.Index(tail, sep); j >= 0 {
+					tail = tail[:j]
+				}
+			}
+			if n, err := strconv.Atoi(tail); err == nil {
+				return n, nil
+			}
+		}
+	}
+	return 0, fmt.Errorf("could not resolve number from ref %q", ref)
 }
 
 // consolidateVerdict devuelve el verdict consolidado (peor caso) de todos los
@@ -605,7 +729,11 @@ func FetchPRComments(ref string) ([]PRComment, error) {
 // devuelve el slice alineado con el input. Ninguno cancela a los otros — los
 // errores quedan en el validatorResult individual y se reportan como "ERROR"
 // en el comment correspondiente.
-func runValidatorsParallel(pr *PullRequest, diff string, validators []Validator, log *output.Logger) []validatorResult {
+//
+// El prompt es el mismo para todos los validadores de un run dado (cambia
+// solo según el target: PR vs plan). Lo recibimos como string construido
+// afuera para que el runner sea agnóstico de qué se valida.
+func runValidatorsParallel(prompt string, validators []Validator, log *output.Logger) []validatorResult {
 	results := make([]validatorResult, len(validators))
 	var wg sync.WaitGroup
 	for i, v := range validators {
@@ -614,7 +742,7 @@ func runValidatorsParallel(pr *PullRequest, diff string, validators []Validator,
 			defer wg.Done()
 			label := fmt.Sprintf("%s#%d", v.Agent, v.Instance)
 			log.Step(label + ": consultando")
-			resp, err := callValidator(v, pr, diff, log, label)
+			resp, err := callValidator(v, prompt, log, label)
 			results[i] = validatorResult{Validator: v, Response: resp, Err: err}
 		}(i, v)
 	}
@@ -622,10 +750,10 @@ func runValidatorsParallel(pr *PullRequest, diff string, validators []Validator,
 	return results
 }
 
-// callValidator invoca al binario del agente validador con el prompt del PR
-// diff y parsea la respuesta.
-func callValidator(v Validator, pr *PullRequest, diff string, log *output.Logger, label string) (*Response, error) {
-	prompt := buildValidatorPrompt(pr, diff)
+// callValidator invoca al binario del agente validador con el prompt dado y
+// parsea la respuesta. El prompt ya viene construido desde el caller (build
+// PR o build plan); el validador no distingue el target.
+func callValidator(v Validator, prompt string, log *output.Logger, label string) (*Response, error) {
 	out, err := runAgentCmd(v.Agent, prompt, log, label+": ")
 	if err != nil {
 		return nil, err
@@ -711,9 +839,12 @@ func parseResponse(raw string) (*Response, error) {
 
 // ---- prompt builder ----
 
-// buildValidatorPrompt arma el prompt del validador: le da el título del PR
-// y el diff, y le pide un JSON estructurado con el verdict y los findings.
-func buildValidatorPrompt(pr *PullRequest, diff string) string {
+// buildPRValidatorPrompt arma el prompt del validador en modo PR: le da el
+// título del PR y el diff, y le pide un JSON estructurado con el verdict y
+// los findings. El contrato de respuesta (verdict/summary/findings con kind
+// product/technical/documented) se comparte con buildPlanValidatorPrompt —
+// la diferencia es qué se valida (código ya escrito vs plan por escribirse).
+func buildPRValidatorPrompt(pr *PullRequest, diff string) string {
 	var sb strings.Builder
 	sb.WriteString(`Sos un validador técnico senior. Otro agente implementó cambios en un PR.
 Tu tarea es leer el DIFF del PR y marcar lo que falta o está mal — NO reimplementar nada.

--- a/internal/flow/validate/validate.go
+++ b/internal/flow/validate/validate.go
@@ -29,6 +29,7 @@ import (
 	"github.com/chichex/che/internal/agent"
 	"github.com/chichex/che/internal/labels"
 	"github.com/chichex/che/internal/output"
+	planpkg "github.com/chichex/che/internal/plan"
 )
 
 // Target discrimina el tipo de ref que recibió `che validate`. La detección
@@ -303,9 +304,7 @@ func Run(ref string, opts Opts) ExitCode {
 	case TargetPR:
 		return runPR(ref, opts, stdout, log)
 	case TargetPlan:
-		// TODO (próximo commit): implementar runPlan.
-		log.Error("target plan (issue) aún no implementado — solo PR por ahora")
-		return ExitSemantic
+		return runPlan(ref, opts, stdout, log)
 	default:
 		log.Error(fmt.Sprintf("tipo de ref desconocido: %v", target))
 		return ExitRetry
@@ -387,6 +386,100 @@ func runPR(prRef string, opts Opts, stdout io.Writer, log *output.Logger) ExitCo
 
 	fmt.Fprintln(stdout, renderReport(results))
 	fmt.Fprintf(stdout, "che ya dejó los comments en el PR %s\n", pr.URL)
+	return ExitOK
+}
+
+// runPlan es el flow nuevo: valida el plan consolidado del body de un issue
+// en status:plan, postea comments en el issue y aplica plan-validated:*.
+// El preflight (auth + remote) ya corrió en Run.
+//
+// Gates:
+//   - issue abierto
+//   - issue tiene status:plan (corré `che explore` si no)
+//   - body del issue tiene un plan consolidado parseable (no basta
+//     HasConsolidatedHeader: Parse puede devolver ambigüedad irrecuperable
+//     o sin sub-secciones; acá rechazamos con mensaje accionable).
+func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) ExitCode {
+	log.Info("obteniendo issue desde GitHub")
+	issue, err := FetchIssue(issueRef)
+	if err != nil {
+		log.Error("fetching issue failed", output.F{Cause: err})
+		return ExitRetry
+	}
+	if issue.State != "OPEN" {
+		log.Error(fmt.Sprintf("issue #%d is not OPEN (state=%s)", issue.Number, issue.State))
+		return ExitSemantic
+	}
+	if !issue.HasLabel(labels.StatusPlan) {
+		log.Error(fmt.Sprintf("issue #%d no está en status:plan — corré `che explore %d` primero", issue.Number, issue.Number))
+		return ExitSemantic
+	}
+
+	// Parseamos el plan consolidado del body. Dos modos de fallo semantic:
+	//   - ErrAmbiguousPlan: body con múltiples headers "## Plan consolidado"
+	//     (typically porque alguien editó a mano o corrieron explore dos
+	//     veces). Acción del humano: limpiar el body.
+	//   - Plan parseado pero sin header real ni sub-secciones: el issue tiene
+	//     status:plan pero nunca se consolidó. Acción: correr explore.
+	consolidated, parseErr := planpkg.Parse(issue.Body)
+	if parseErr != nil {
+		log.Error(fmt.Sprintf("no pude parsear el plan consolidado del issue #%d: %v", issue.Number, parseErr))
+		return ExitSemantic
+	}
+	if !planpkg.HasConsolidatedHeader(issue.Body) {
+		log.Error(fmt.Sprintf("issue #%d tiene status:plan pero no tiene plan consolidado en el body — corré `che explore %d`", issue.Number, issue.Number))
+		return ExitSemantic
+	}
+
+	log.Step("leyendo comments previos para calcular iter")
+	comments, err := FetchIssueComments(issueRef)
+	if err != nil {
+		log.Error("fetching comments failed", output.F{Cause: err})
+		return ExitRetry
+	}
+	iter := DetermineIter(comments)
+
+	log.Info(fmt.Sprintf("corriendo %d validador(es) en paralelo sobre el plan", len(opts.Validators)), output.F{Iter: iter, Issue: issue.Number})
+	prompt := buildPlanValidatorPrompt(issue, consolidated)
+	results := runValidatorsParallel(prompt, opts.Validators, log)
+
+	log.Step("posteando comments de validadores")
+	for _, r := range results {
+		body := renderValidatorComment(r, iter)
+		if err := postIssueComment(issueRef, body); err != nil {
+			log.Error(fmt.Sprintf("posting %s#%d comment failed", r.Validator.Agent, r.Validator.Instance),
+				output.F{Validator: fmt.Sprintf("%s#%d", r.Validator.Agent, r.Validator.Instance), Cause: err})
+			return ExitRetry
+		}
+		verdict := ""
+		if r.Response != nil {
+			verdict = r.Response.Verdict
+		}
+		log.Success("comment posteado",
+			output.F{Validator: fmt.Sprintf("%s#%d", r.Validator.Agent, r.Validator.Instance), Verdict: verdict})
+	}
+
+	log.Step("posteando comment resumen")
+	summary := renderSummaryComment(results, iter)
+	if err := postIssueComment(issueRef, summary); err != nil {
+		log.Error("posting summary comment failed", output.F{Cause: err})
+		return ExitRetry
+	}
+
+	if verdict := consolidateVerdict(results); verdict != "" {
+		target := verdictToPlanLabel(verdict)
+		log.Step("aplicando label al issue", output.F{Labels: []string{target}, Issue: issue.Number})
+		if err := applyPlanValidatedLabel(issueRef, issue, target); err != nil {
+			log.Warn("warning: no pude aplicar label al issue",
+				output.F{Labels: []string{target}, Issue: issue.Number, Cause: err})
+		} else {
+			log.Success("verdict consolidado",
+				output.F{Issue: issue.Number, Verdict: verdict, Labels: []string{target}})
+		}
+	}
+
+	fmt.Fprintln(stdout, renderReport(results))
+	fmt.Fprintf(stdout, "che ya dejó los comments en el issue %s\n", issue.URL)
 	return ExitOK
 }
 
@@ -1027,4 +1120,330 @@ func postPRComment(prRef, body string) error {
 		return fmt.Errorf("gh pr comment: %s", strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// ---- modo plan: issue fetch, comments, prompt, labels ----
+
+// Issue modela el subset de `gh issue view --json ...` que usamos en el modo
+// plan. Mismo shape minimalista que usa explore; no lo importamos de ahí
+// para no crear dependencia cruzada entre flows.
+type Issue struct {
+	Number int         `json:"number"`
+	Title  string      `json:"title"`
+	Body   string      `json:"body"`
+	URL    string      `json:"url"`
+	State  string      `json:"state"`
+	Labels []IssueLabel `json:"labels"`
+}
+
+// IssueLabel es el shape que gh devuelve para cada label del issue.
+type IssueLabel struct {
+	Name string `json:"name"`
+}
+
+// HasLabel devuelve true si el issue tiene un label con ese nombre.
+func (i *Issue) HasLabel(name string) bool {
+	for _, l := range i.Labels {
+		if l.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// FetchIssue corre `gh issue view <ref> --json ...` para el modo plan. Trae
+// un superset mínimo: number/title/body/labels/url/state. Los comments se
+// fetchean aparte con FetchIssueComments porque es consistente con cómo se
+// hace en modo PR (dos round-trips, más barato que pedir un JSON enorme).
+func FetchIssue(ref string) (*Issue, error) {
+	cmd := exec.Command("gh", "issue", "view", ref,
+		"--json", "number,title,body,labels,url,state")
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("gh issue view: %s", strings.TrimSpace(string(ee.Stderr)))
+		}
+		return nil, err
+	}
+	var issue Issue
+	if err := json.Unmarshal(out, &issue); err != nil {
+		return nil, fmt.Errorf("parse gh issue view output: %w", err)
+	}
+	return &issue, nil
+}
+
+// FetchIssueComments trae los comments del issue (para calcular iter). Usa
+// una llamada separada a gh issue view con --json comments. El shape de
+// comments es el mismo que para PRs (PRComment lo reusamos).
+func FetchIssueComments(ref string) ([]PRComment, error) {
+	cmd := exec.Command("gh", "issue", "view", ref, "--json", "comments")
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("gh issue view comments: %s", strings.TrimSpace(string(ee.Stderr)))
+		}
+		return nil, err
+	}
+	var wrap struct {
+		Comments []PRComment `json:"comments"`
+	}
+	if err := json.Unmarshal(out, &wrap); err != nil {
+		return nil, fmt.Errorf("parse gh issue view comments: %w", err)
+	}
+	return wrap.Comments, nil
+}
+
+// postIssueComment postea un comment en el issue via `gh issue comment <ref>
+// --body-file`. Hermano de postPRComment — los mantenemos separados porque
+// la abstracción "dispatcher por target" es más ruido que señal: son dos
+// líneas de diferencia y el llamador siempre sabe qué target está.
+func postIssueComment(issueRef, body string) error {
+	tmpDir, err := os.MkdirTemp("", "che-validate-issuec-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+	bodyFile := filepath.Join(tmpDir, "body.md")
+	if err := os.WriteFile(bodyFile, []byte(body), 0o644); err != nil {
+		return err
+	}
+	cmd := exec.Command("gh", "issue", "comment", issueRef, "--body-file", bodyFile)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh issue comment: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// verdictToPlanLabel mapea un verdict JSON (snake_case) al label plan-validated
+// correspondiente (kebab-case). Hermano de verdictToLabel, pero con los labels
+// del set AllPlanValidated (aplicado sobre issues, no PRs).
+func verdictToPlanLabel(verdict string) string {
+	switch verdict {
+	case "approve":
+		return labels.PlanValidatedApprove
+	case "changes_requested":
+		return labels.PlanValidatedChangesRequested
+	case "needs_human":
+		return labels.PlanValidatedNeedsHuman
+	}
+	return ""
+}
+
+// applyPlanValidatedLabel es al modo plan lo que applyValidatedLabel al modo
+// PR: asegura que target exista, lo aplica al issue, y remueve los otros
+// plan-validated:* presentes (son mutuamente excluyentes). Idempotente.
+func applyPlanValidatedLabel(issueRef string, issue *Issue, target string) error {
+	if target == "" {
+		return fmt.Errorf("empty target label")
+	}
+	if err := labels.Ensure(target); err != nil {
+		return err
+	}
+	args := []string{"issue", "edit", issueRef}
+	changes := false
+	for _, l := range labels.AllPlanValidated {
+		if l == target {
+			continue
+		}
+		if issue.HasLabel(l) {
+			args = append(args, "--remove-label", l)
+			changes = true
+		}
+	}
+	if !issue.HasLabel(target) {
+		args = append(args, "--add-label", target)
+		changes = true
+	}
+	if !changes {
+		return nil
+	}
+	cmd := exec.Command("gh", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh issue edit: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// buildPlanValidatorPrompt arma el prompt del validador en modo plan. La
+// diferencia con buildPRValidatorPrompt es qué se le pide analizar (un plan
+// escrito, no código) y qué anti-patrones buscar (ambigüedad de producto,
+// gaps técnicos del plan, criterios poco observables, effort sospechoso).
+// El contrato de respuesta (verdict + findings con severity/area/kind) es
+// idéntico — así el render de comments, el consolidador de verdict y el
+// parser de respuestas se comparten tal cual.
+//
+// Si el plan parseado vino sin secciones (degradado) pasamos el body raw
+// como input secundario para que el validador igual pueda opinar.
+func buildPlanValidatorPrompt(issue *Issue, c *planpkg.ConsolidatedPlan) string {
+	var sb strings.Builder
+	sb.WriteString(`Sos un validador técnico senior. Otro agente produjo un PLAN DE IMPLEMENTACIÓN para un issue.
+Tu tarea es revisar el plan ANTES de que se empiece a codear y marcar lo que está flojo — NO reescribir el plan.
+
+Estamos en la etapa previa a ` + "`che execute`" + `: si aprobás, el plan va a alimentar directo a un agente que implementa.
+
+Chequeá específicamente:
+1. ¿El goal y el summary son consistentes con el título del issue?
+2. ¿Los criterios de aceptación son observables y testeables? (Evitá "funciona bien".)
+3. ¿Los pasos son concretos y accionables? ¿Cubren end-to-end el approach?
+4. ¿El effort implícito (número y tamaño de pasos) es razonable para el approach?
+5. ¿Faltan riesgos obvios que el plan no menciona?
+6. ¿Hay asunciones del plan que no son correctas (e.g. dep que no existe, API distinta)?
+7. ¿El approach elegido tiene caminos alternativos razonables que el plan descartó sin justificar?
+8. ¿Hay ambigüedad de producto irreducible que el plan resolvió arbitrariamente y debería escalarse al humano?
+
+IMPORTANTE — Clasificación de findings:
+
+- kind="product": ambigüedad irreducible de dominio/producto (política, UX opinada, alcance).
+  Puede ir con needs_human=true si requiere decisión del dueño.
+- kind="technical": gap técnico del plan (paso faltante, criterio poco claro, riesgo no listado, asunción incorrecta).
+  needs_human=false — es feedback para re-consolidar el plan.
+- kind="documented": el plan ignoró algo que está en el body del issue / criterios iniciales / labels.
+  needs_human=false — bug del consolidador, se resuelve re-leyendo.
+
+Valores válidos:
+- verdict: "approve" (plan listo para ejecutar), "changes_requested" (gaps técnicos a corregir antes de ejecutar), "needs_human" (ambigüedad de producto irreducible)
+- severity: "blocker" | "major" | "minor"
+- area: "code" | "tests" | "docs" | "security" | "other"
+- kind: "product" | "technical" | "documented"
+
+Reglas:
+- Si el plan es sólido y accionable, verdict=approve y findings=[].
+- needs_human=true requiere kind=product Y decisión del dueño del producto.
+- No inventes faltantes — si el plan cubre algo aunque sea brevemente, no lo marques como gap.
+- "where" puede referenciar una sección del plan ("steps[3]", "acceptance_criteria", "approach") — no hay paths de archivo todavía.
+
+Devolvé EXCLUSIVAMENTE un objeto JSON con este shape — sin texto antes ni después, sin markdown code fences:
+
+{
+  "verdict": "approve|changes_requested|needs_human",
+  "summary": "Tu opinión global en 1-2 oraciones",
+  "findings": [
+    {
+      "severity": "major",
+      "area": "code",
+      "where": "steps[2] o approach o acceptance_criteria[1]",
+      "issue": "qué está flojo o mal",
+      "suggestion": "cómo arreglarlo antes de ejecutar",
+      "needs_human": false,
+      "kind": "technical"
+    }
+  ]
+}
+
+Issue #`)
+	sb.WriteString(fmt.Sprint(issue.Number))
+	sb.WriteString(` (título: "`)
+	sb.WriteString(issue.Title)
+	sb.WriteString(`")
+
+PLAN CONSOLIDADO (parseado del body):
+`)
+	if c != nil {
+		if strings.TrimSpace(c.Summary) != "" {
+			sb.WriteString("Resumen: " + c.Summary + "\n")
+		}
+		if strings.TrimSpace(c.Goal) != "" {
+			sb.WriteString("Goal: " + c.Goal + "\n")
+		}
+		if strings.TrimSpace(c.Approach) != "" {
+			sb.WriteString("Approach: " + c.Approach + "\n")
+		}
+		if len(c.AcceptanceCriteria) > 0 {
+			sb.WriteString("Acceptance criteria:\n")
+			for i, crit := range c.AcceptanceCriteria {
+				sb.WriteString(fmt.Sprintf("  %d. %s\n", i+1, crit))
+			}
+		}
+		if len(c.Steps) > 0 {
+			sb.WriteString("Steps:\n")
+			for i, step := range c.Steps {
+				sb.WriteString(fmt.Sprintf("  %d. %s\n", i+1, step))
+			}
+		}
+		if len(c.RisksToMitigate) > 0 {
+			sb.WriteString("Risks to mitigate:\n")
+			for _, r := range c.RisksToMitigate {
+				sb.WriteString(fmt.Sprintf("  - %s (likelihood=%s, impact=%s) — %s\n",
+					r.Risk, r.Likelihood, r.Impact, r.Mitigation))
+			}
+		}
+		if len(c.OutOfScope) > 0 {
+			sb.WriteString("Out of scope:\n")
+			for _, o := range c.OutOfScope {
+				sb.WriteString("  - " + o + "\n")
+			}
+		}
+	}
+	// Fallback: si el plan parseado viene sin secciones (body con el header
+	// pero sin sub-secciones reconocibles) incluimos el body raw para que
+	// el validador pueda opinar sobre el texto real, no sobre vacío.
+	planEmpty := c == nil ||
+		(strings.TrimSpace(c.Goal) == "" && strings.TrimSpace(c.Approach) == "" &&
+			len(c.AcceptanceCriteria) == 0 && len(c.Steps) == 0)
+	if planEmpty {
+		sb.WriteString("\n(El parser no extrajo secciones estructuradas; se adjunta el body raw como fallback.)\n")
+	}
+	sb.WriteString("\nBody raw del issue:\n<<<\n")
+	sb.WriteString(issue.Body)
+	sb.WriteString("\n>>>\n")
+	return sb.String()
+}
+
+// ---- list candidates (para TUI PR #6) ----
+
+// PlanCandidate es la vista mínima de un issue listo para validar como plan:
+// abierto, con status:plan, sin plan-validated:approve. La TUI lo consume
+// para poblar la lista "plans pending validation". Es un struct dedicado en
+// vez de reusar explore.Candidate porque el set de labels relevantes y los
+// filtros de exclusión son distintos (acá excluimos plan-validated:approve,
+// allá filtramos por ct:plan sin status).
+type PlanCandidate struct {
+	Number int
+	Title  string
+	URL    string
+}
+
+// ListPlanCandidates devuelve los issues abiertos con status:plan que NO
+// tienen plan-validated:approve — candidatos a validar como plan. Limita a
+// 50 (la TUI se vuelve inmanejable con más, igual que ListOpenPRs).
+//
+// Excluye plan-validated:approve pero mantiene :changes-requested y
+// :needs-human visibles: el humano puede re-validar tras editar el plan.
+func ListPlanCandidates() ([]PlanCandidate, error) {
+	cmd := exec.Command("gh", "issue", "list",
+		"--label", labels.StatusPlan,
+		"--state", "open",
+		"--json", "number,title,url,labels",
+		"--limit", "50")
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("gh issue list: %s", strings.TrimSpace(string(ee.Stderr)))
+		}
+		return nil, err
+	}
+	var raw []Issue
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("parse gh issue list output: %w", err)
+	}
+	return filterPlanCandidates(raw), nil
+}
+
+// filterPlanCandidates aplica la regla de exclusión de approve. Lo separamos
+// en función testeable para no depender de `gh` en los unit tests.
+func filterPlanCandidates(raw []Issue) []PlanCandidate {
+	out := make([]PlanCandidate, 0, len(raw))
+	for _, i := range raw {
+		if i.HasLabel(labels.PlanValidatedApprove) {
+			continue
+		}
+		out = append(out, PlanCandidate{
+			Number: i.Number,
+			Title:  i.Title,
+			URL:    i.URL,
+		})
+	}
+	return out
 }

--- a/internal/flow/validate/validate_test.go
+++ b/internal/flow/validate/validate_test.go
@@ -3,11 +3,14 @@ package validate
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/chichex/che/internal/labels"
+	planpkg "github.com/chichex/che/internal/plan"
 )
 
 func TestParsePRRef(t *testing.T) {
@@ -417,5 +420,302 @@ func TestRenderSummaryComment_Table(t *testing.T) {
 	}
 	if !strings.Contains(out, "| codex#1 | changes_requested | 1 |") {
 		t.Fatalf("summary row for codex missing. Got:\n%s", out)
+	}
+}
+
+// TestResolveRefNumber cubre el helper local que extrae el número sin tocar
+// gh. Es la base de detectTarget: fallamos acá si el parsing local no toma
+// los formatos que cmd/validate acepta (número, URL de pull o issues,
+// owner/repo#N).
+func TestResolveRefNumber(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		want    int
+		wantErr bool
+	}{
+		{"plain number", "7", 7, false},
+		{"large number", "1234", 1234, false},
+		{"owner/repo#N", "acme/demo#42", 42, false},
+		{"URL pull", "https://github.com/acme/demo/pull/7", 7, false},
+		{"URL issues", "https://github.com/acme/demo/issues/42", 42, false},
+		{"URL pull with suffix", "https://github.com/acme/demo/pull/7/files", 7, false},
+		{"URL pull with query", "https://github.com/acme/demo/pull/7?tab=1", 7, false},
+		{"URL pull with fragment", "https://github.com/acme/demo/pull/7#issuecomment-1", 7, false},
+		{"unrecognized", "nonsense", 0, true},
+		{"# without number", "acme/demo#foo", 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := resolveRefNumber(c.in)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got %d", c.in, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", c.in, err)
+			}
+			if got != c.want {
+				t.Fatalf("want %d, got %d", c.want, got)
+			}
+		})
+	}
+}
+
+// TestDetectTarget valida el despachador target usando fakes de `gh api`
+// inyectados en PATH. No ejecuta runPR/runPlan — solo chequea que el
+// campo pull_request discrimina issue vs PR.
+func TestDetectTarget(t *testing.T) {
+	// Stub de gh que devuelve el fixture según el número pedido. Lo
+	// hacemos con un shim bash simple en un tempdir + PATH.
+	cases := []struct {
+		name        string
+		apiResponse string
+		want        Target
+		wantErr     bool
+	}{
+		{
+			name:        "issue (pull_request null)",
+			apiResponse: `{"number": 42, "pull_request": null}`,
+			want:        TargetPlan,
+		},
+		{
+			name:        "issue (pull_request absent)",
+			apiResponse: `{"number": 42, "title": "foo"}`,
+			want:        TargetPlan,
+		},
+		{
+			name:        "PR (pull_request object)",
+			apiResponse: `{"number": 7, "pull_request": {"url": "https://api.github.com/repos/acme/demo/pulls/7"}}`,
+			want:        TargetPR,
+		},
+		{
+			name:        "malformed JSON",
+			apiResponse: `not json`,
+			want:        TargetUnknown,
+			wantErr:     true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			withFakeGh(t, c.apiResponse, 0)
+			got, err := detectTarget("42")
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != c.want {
+				t.Fatalf("want %v, got %v", c.want, got)
+			}
+		})
+	}
+}
+
+// TestDetectTarget_GhError verifica que un exit non-zero de gh se
+// propague como error (caller debería hacer retry).
+func TestDetectTarget_GhError(t *testing.T) {
+	withFakeGh(t, "", 1)
+	_, err := detectTarget("99")
+	if err == nil {
+		t.Fatalf("expected error when gh api fails")
+	}
+}
+
+// withFakeGh instala un fake gh en PATH que siempre responde con stdout y
+// exit dado, independiente de los args. Útil para tests donde el contenido
+// depende del test pero los args son siempre `api repos/.../issues/<n>`.
+func withFakeGh(t *testing.T, stdout string, exit int) {
+	t.Helper()
+	dir := t.TempDir()
+	script := "#!/bin/sh\n"
+	if stdout != "" {
+		// usar printf para evitar problemas con escaping shell de los JSON
+		// braces
+		script += "printf '%s' " + shellQuote(stdout) + "\n"
+	}
+	script += fmt.Sprintf("exit %d\n", exit)
+	path := filepath.Join(dir, "gh")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake gh: %v", err)
+	}
+	t.Setenv("PATH", dir+":"+os.Getenv("PATH"))
+}
+
+// shellQuote pone el contenido entre comillas simples, escapando las que ya
+// estuvieran dentro. Suficiente para los fixtures JSON cortos de estos
+// tests.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// TestVerdictToPlanLabel cubre el mapeo del verdict al label plan-validated:*.
+// Es el hermano de TestVerdictToLabel; los dos viven para que un rename o
+// cambio de constantes lo rompa de inmediato.
+func TestVerdictToPlanLabel(t *testing.T) {
+	cases := map[string]string{
+		"approve":           labels.PlanValidatedApprove,
+		"changes_requested": labels.PlanValidatedChangesRequested,
+		"needs_human":       labels.PlanValidatedNeedsHuman,
+		"":                  "",
+		"bogus":             "",
+	}
+	for in, want := range cases {
+		if got := verdictToPlanLabel(in); got != want {
+			t.Errorf("verdictToPlanLabel(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestBuildPlanValidatorPrompt chequea que el prompt incluya los campos
+// clave del plan parseado (goal, summary, acceptance_criteria, steps) para
+// que el validador tenga contexto suficiente. El contrato de respuesta
+// (verdict + findings con severity/area/kind) también debe estar presente.
+func TestBuildPlanValidatorPrompt(t *testing.T) {
+	issue := &Issue{
+		Number: 42,
+		Title:  "Agregar rate limiting al endpoint /login",
+		Body:   "## Plan consolidado\n\ndetalles...",
+	}
+	cplan := &planpkg.ConsolidatedPlan{
+		Summary:            "Rate limit a /login para frenar brute force",
+		Goal:               "Bloquear >5 intentos/minuto por IP",
+		Approach:           "Middleware in-memory con LRU",
+		AcceptanceCriteria: []string{"6to intento devuelve 429", "contador se resetea tras 1min"},
+		Steps:              []string{"agregar middleware", "wirearlo a /login", "test"},
+		RisksToMitigate: []planpkg.Risk{
+			{Risk: "IP share (NAT)", Likelihood: "low", Impact: "medium", Mitigation: "usar IP+useragent"},
+		},
+		OutOfScope: []string{"rate limit global"},
+	}
+
+	prompt := buildPlanValidatorPrompt(issue, cplan)
+
+	// Campos del plan deben aparecer textualmente.
+	mustContain := []string{
+		"Issue #42",
+		"Agregar rate limiting",
+		"Rate limit a /login",
+		"Bloquear >5 intentos/minuto",
+		"Middleware in-memory",
+		"6to intento devuelve 429",
+		"agregar middleware",
+		"IP share (NAT)",
+		"rate limit global",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(prompt, s) {
+			t.Errorf("prompt missing %q", s)
+		}
+	}
+
+	// Contrato de respuesta: enumera los verdicts válidos y el kind
+	// product/technical/documented.
+	contract := []string{"approve", "changes_requested", "needs_human", "product", "technical", "documented"}
+	for _, s := range contract {
+		if !strings.Contains(prompt, s) {
+			t.Errorf("prompt missing contract keyword %q", s)
+		}
+	}
+}
+
+// TestBuildPlanValidatorPrompt_Fallback: si el plan parseado viene vacío
+// (caller pasó un plan degradado), el prompt incluye el body raw para que
+// el validador al menos pueda opinar sobre lo que hay en el issue.
+func TestBuildPlanValidatorPrompt_Fallback(t *testing.T) {
+	issue := &Issue{
+		Number: 9,
+		Title:  "legacy issue",
+		Body:   "body raw que no parseó bien",
+	}
+	empty := &planpkg.ConsolidatedPlan{}
+	prompt := buildPlanValidatorPrompt(issue, empty)
+	if !strings.Contains(prompt, "body raw que no parseó bien") {
+		t.Errorf("fallback prompt missing raw body")
+	}
+	if !strings.Contains(prompt, "fallback") && !strings.Contains(prompt, "Body raw") {
+		t.Errorf("fallback marker or raw body section missing")
+	}
+}
+
+// TestFilterPlanCandidates cubre la regla de exclusión: plan-validated:approve
+// desaparece de la lista; los otros plan-validated:* siguen visibles.
+func TestFilterPlanCandidates(t *testing.T) {
+	mk := func(n int, lbls ...string) Issue {
+		i := Issue{Number: n, Title: fmt.Sprintf("Issue %d", n), URL: fmt.Sprintf("https://x/%d", n)}
+		for _, l := range lbls {
+			i.Labels = append(i.Labels, IssueLabel{Name: l})
+		}
+		return i
+	}
+
+	cases := []struct {
+		name    string
+		in      []Issue
+		wantNum []int
+	}{
+		{"empty", nil, nil},
+		{"sin labels", []Issue{mk(1), mk(2)}, []int{1, 2}},
+		{
+			"plan-validated:approve excluido",
+			[]Issue{mk(1, labels.PlanValidatedApprove), mk(2)},
+			[]int{2},
+		},
+		{
+			"changes-requested incluido",
+			[]Issue{mk(1, labels.PlanValidatedChangesRequested)},
+			[]int{1},
+		},
+		{
+			"needs-human incluido",
+			[]Issue{mk(1, labels.PlanValidatedNeedsHuman)},
+			[]int{1},
+		},
+		{
+			"mix: solo approve se excluye",
+			[]Issue{
+				mk(1, labels.PlanValidatedApprove),
+				mk(2, labels.PlanValidatedChangesRequested),
+				mk(3, labels.PlanValidatedNeedsHuman),
+				mk(4),
+			},
+			[]int{2, 3, 4},
+		},
+		{
+			"otros labels no interfieren",
+			[]Issue{mk(1, labels.StatusPlan, "ct:plan")},
+			[]int{1},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := filterPlanCandidates(c.in)
+			if len(got) != len(c.wantNum) {
+				t.Fatalf("want %d candidates, got %d", len(c.wantNum), len(got))
+			}
+			for i, n := range c.wantNum {
+				if got[i].Number != n {
+					t.Errorf("candidate %d: want number %d, got %d", i, n, got[i].Number)
+				}
+			}
+		})
+	}
+}
+
+// TestIssue_HasLabel cubre el helper análogo al de PullRequest.
+func TestIssue_HasLabel(t *testing.T) {
+	i := &Issue{}
+	i.Labels = append(i.Labels, IssueLabel{Name: labels.PlanValidatedApprove})
+	if !i.HasLabel(labels.PlanValidatedApprove) {
+		t.Errorf("expected HasLabel(plan-validated:approve)=true")
+	}
+	if i.HasLabel(labels.PlanValidatedNeedsHuman) {
+		t.Errorf("expected HasLabel(plan-validated:needs-human)=false")
 	}
 }

--- a/internal/flow/validate/validate_test.go
+++ b/internal/flow/validate/validate_test.go
@@ -13,7 +13,7 @@ import (
 	planpkg "github.com/chichex/che/internal/plan"
 )
 
-func TestParsePRRef(t *testing.T) {
+func TestParseRef(t *testing.T) {
 	cases := []struct {
 		name    string
 		in      string
@@ -22,16 +22,18 @@ func TestParsePRRef(t *testing.T) {
 		{"number", "7", false},
 		{"large number", "1234", false},
 		{"owner/repo#N", "acme/demo#7", false},
-		{"github URL", "https://github.com/acme/demo/pull/7", false},
+		{"github pull URL", "https://github.com/acme/demo/pull/7", false},
+		{"github issues URL", "https://github.com/acme/demo/issues/42", false},
 		{"empty", "", true},
 		{"whitespace", "   ", true},
 		{"plain text", "foo", true},
-		{"url without /pull/", "https://github.com/acme/demo/issues/7", true},
+		{"non-github URL", "https://gitlab.com/acme/demo/pull/7", true},
+		{"github URL without pull or issues", "https://github.com/acme/demo", true},
 		{"# without repo", "#7", true},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			_, err := ParsePRRef(c.in)
+			_, err := ParseRef(c.in)
 			if c.wantErr && err == nil {
 				t.Fatalf("expected error for %q, got nil", c.in)
 			}


### PR DESCRIPTION
## Alcance

4to PR del refactor de 6. Extiende \`che validate\` para que acepte también issues (no solo PRs):

- \`che validate 42\` con issue en \`status:plan\` → valida el plan consolidado del body, postea comments en el issue, aplica label \`plan-validated:{approve|changes-requested|needs-human}\`.
- \`che validate 7\` con PR abierto → comportamiento actual: valida diff, aplica \`validated:*\`.

Detección automática via \`gh api repos/{owner}/{repo}/issues/{n}\` (campo \`pull_request\` no-null → PR).

## Qué cambia internamente

- \`Run\` pasa a ser despachador que corre el preflight común y delega en \`runPR\` (renombre del Run anterior) o \`runPlan\` (nuevo).
- \`detectTarget\` + \`resolveRefNumber\` nuevos. El número se resuelve localmente (sin tocar red) desde "7", URL, u owner/repo#N.
- \`runValidatorsParallel\` se vuelve agnóstico del target: recibe el prompt ya construido.
- \`buildPRValidatorPrompt\` (renombre de \`buildValidatorPrompt\`) y \`buildPlanValidatorPrompt\` nuevo. Misma forma de respuesta JSON (verdict + findings con kind product/technical/documented), prompts distintos.
- Labels modo plan: \`verdictToPlanLabel\` + \`applyPlanValidatedLabel\` (mutex dentro de \`AllPlanValidated\`, idempotente).
- Fetch modo plan: \`FetchIssue\`, \`FetchIssueComments\` (shape \`Issue\` minimalista, dedicado al paquete para no depender de explore).
- Post: \`postIssueComment\` hermano de \`postPRComment\`.
- Export \`ListPlanCandidates()\` + \`PlanCandidate\` — listo para que el PR #6 (TUI con dos listas) lo consuma. Excluye \`plan-validated:approve\`, mantiene \`:changes-requested\` y \`:needs-human\` visibles para re-validación.

## Ejemplos CLI

\`\`\`
che validate 42       # issue en status:plan → valida plan → plan-validated:*
che validate 7        # PR abierto → valida diff → validated:*
che validate https://github.com/owner/repo/issues/42
che validate owner/repo#7
\`\`\`

## Gates semánticos modo plan

- issue cerrado → ExitSemantic
- sin \`status:plan\` → mensaje \"corré \`che explore %d\` primero\"
- body sin plan consolidado parseable → mismo mensaje accionable
- ambigüedad (\`ErrAmbiguousPlan\` desde \`plan.Parse\`) → ExitSemantic

## Test plan

- [x] \`go build ./...\` verde
- [x] \`go vet ./...\` verde
- [x] \`go test -count=1 ./...\` verde (unit + e2e)
- [x] Tests unit: \`TestResolveRefNumber\`, \`TestDetectTarget\` (con fake gh inyectado en PATH), \`TestVerdictToPlanLabel\`, \`TestBuildPlanValidatorPrompt\` + fallback, \`TestFilterPlanCandidates\`, \`TestIssue_HasLabel\`.
- [x] Tests e2e nuevos: \`TestValidate_Plan_GoldenPath_OpusApproves\`, \`TestValidate_Plan_NoStatusPlan_Exit3\`, \`TestValidate_Plan_NoConsolidatedPlan_Exit3\`.
- [x] Tests e2e PR existentes siguen pasando (agregué helper \`scriptDetectTargetPR\` para el call a \`gh api\` que ahora hace el despachador).

## Nota para PR #6 (TUI)

\`validate.ListPlanCandidates()\` ya está exportado con shape \`PlanCandidate{Number, Title, URL}\`. Excluye \`plan-validated:approve\` pero deja visibles los otros dos plan-validated:*. La TUI puede armar la lista \"plans pending validation\" con esa función.

🤖 Generated with [Claude Code](https://claude.com/claude-code)