### PR TITLE
refactor(dash): 9 columnas + closed capped + che:* (PR 3/5)

### DIFF
--- a/internal/dash/gh_source.go
+++ b/internal/dash/gh_source.go
@@ -34,12 +34,26 @@ import (
 	"github.com/chichex/che/internal/labels"
 )
 
+// defaultClosedCap es el cap default de issues closed que el poller trae al
+// snapshot. Se elige 20 como compromiso: suficiente para mostrar continuidad
+// histórica reciente sin inflar el board (la columna closed scrollea
+// internamente). Configurable via GhSource.ClosedCap si en el futuro se
+// expone como flag de `che dash`.
+//
+// TODO: confirmar — si el repo tiene mucho throughput puede que 20 quede
+// corto; por ahora es lo más conservador para evitar payloads grandes.
+const defaultClosedCap = 20
+
 // GhSource es un poller que refleja el estado del repo via `gh`. Se refresca
 // cada `interval`; entre refreshes Snapshot() devuelve el último corte bueno.
 type GhSource struct {
 	repoDir  string
 	nwo      string // owner/name — informativo, no se usa en las queries
 	interval time.Duration
+	// ClosedCap es el límite de issues closed (con label che:closed) que el
+	// poller trae al snapshot. Default defaultClosedCap. La columna "closed"
+	// del board solo muestra los más recientes.
+	ClosedCap int
 
 	mu   sync.RWMutex
 	snap Snapshot
@@ -89,9 +103,10 @@ func NewGhSource(repoDir string, interval time.Duration) (*GhSource, error) {
 		return nil, errors.New("gh repo view: nameWithOwner vacío")
 	}
 	return &GhSource{
-		repoDir:  repoDir,
-		nwo:      probe.NameWithOwner,
-		interval: interval,
+		repoDir:   repoDir,
+		nwo:       probe.NameWithOwner,
+		interval:  interval,
+		ClosedCap: defaultClosedCap,
 	}, nil
 }
 
@@ -166,9 +181,10 @@ type ghPR struct {
 	StatusCheckRollup       []ghCheck    `json:"statusCheckRollup"`
 }
 
-// refresh es un poll único. Lanza las dos queries en paralelo y combina los
-// resultados; si cualquiera falla, marcamos el snapshot stale y salimos sin
-// pisar los datos anteriores.
+// refresh es un poll único. Lanza tres queries en paralelo (issues open,
+// PRs open, issues closed con label che:closed) y combina los resultados;
+// si cualquiera falla, marcamos el snapshot stale y salimos sin pisar los
+// datos anteriores.
 func (g *GhSource) refresh(ctx context.Context) error {
 	type issuesRes struct {
 		data []ghIssue
@@ -179,6 +195,7 @@ func (g *GhSource) refresh(ctx context.Context) error {
 		err  error
 	}
 	issuesCh := make(chan issuesRes, 1)
+	closedCh := make(chan issuesRes, 1)
 	prsCh := make(chan prsRes, 1)
 
 	go func() {
@@ -186,14 +203,22 @@ func (g *GhSource) refresh(ctx context.Context) error {
 		issuesCh <- issuesRes{data, err}
 	}()
 	go func() {
+		data, err := g.fetchClosedIssues(ctx)
+		closedCh <- issuesRes{data, err}
+	}()
+	go func() {
 		data, err := g.fetchPRs(ctx)
 		prsCh <- prsRes{data, err}
 	}()
 
 	ir := <-issuesCh
+	cr := <-closedCh
 	pr := <-prsCh
-	if ir.err != nil || pr.err != nil {
+	if ir.err != nil || cr.err != nil || pr.err != nil {
 		err := ir.err
+		if err == nil {
+			err = cr.err
+		}
 		if err == nil {
 			err = pr.err
 		}
@@ -204,7 +229,13 @@ func (g *GhSource) refresh(ctx context.Context) error {
 		return err
 	}
 
-	entities := combineEntities(ir.data, pr.data)
+	// Mezclar issues open + closed antes de combinar con PRs. combineEntities
+	// no distingue open/closed — el filtro real ocurre via labels (los closed
+	// que vienen del query ya tienen che:closed, así que caen en su columna).
+	allIssues := make([]ghIssue, 0, len(ir.data)+len(cr.data))
+	allIssues = append(allIssues, ir.data...)
+	allIssues = append(allIssues, cr.data...)
+	entities := combineEntities(allIssues, pr.data)
 	g.mu.Lock()
 	g.snap = Snapshot{
 		Entities: entities,
@@ -235,6 +266,37 @@ func (g *GhSource) fetchIssues(ctx context.Context) ([]ghIssue, error) {
 			return nil, fmt.Errorf("gh issue list: %s", strings.TrimSpace(string(ee.Stderr)))
 		}
 		return nil, fmt.Errorf("gh issue list: %w", err)
+	}
+	return parseIssues(out)
+}
+
+// fetchClosedIssues corre `gh issue list --state closed --label che:closed`
+// con el cap del poller. Permite que la columna closed muestre los últimos
+// N issues completados sin traer todo el histórico del repo (que en un
+// proyecto activo puede ser miles).
+//
+// Si el repo no usa el label che:closed (proyecto recién migrado), gh
+// devuelve [] y este path es no-op.
+func (g *GhSource) fetchClosedIssues(ctx context.Context) ([]ghIssue, error) {
+	limit := g.ClosedCap
+	if limit <= 0 {
+		limit = defaultClosedCap
+	}
+	cmd := exec.CommandContext(ctx, "gh", "issue", "list",
+		"--state", "closed",
+		"--label", labels.CheClosed,
+		"--limit", fmt.Sprintf("%d", limit),
+		"--json", "number,title,labels,state,body",
+	)
+	if g.repoDir != "" {
+		cmd.Dir = g.repoDir
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("gh issue list (closed): %s", strings.TrimSpace(string(ee.Stderr)))
+		}
+		return nil, fmt.Errorf("gh issue list (closed): %w", err)
 	}
 	return parseIssues(out)
 }
@@ -355,6 +417,12 @@ func combineEntities(issues []ghIssue, prs []ghPR) []Entity {
 // applyLabels rellena los campos de Entity derivados de labels: Type, Size,
 // Status, PlanVerdict, PRVerdict, Locked. Es aditivo — se puede llamar dos
 // veces (issue + PR) y los labels más recientes ganan.
+//
+// Status se deriva del prefijo `che:` (post-PR1/PR2): che:idea → "idea",
+// che:planning → "planning", etc. El label `che:locked` es la única
+// excepción — es un marker, no un estado, y prende e.Locked en vez de
+// pisar Status. plan-validated:* / validated:* son los verdicts de los
+// validadores (no son estados).
 func applyLabels(e *Entity, ls []ghLabel) {
 	for _, l := range ls {
 		name := l.Name
@@ -365,12 +433,18 @@ func applyLabels(e *Entity, ls []ghLabel) {
 			e.Type = strings.TrimPrefix(name, "type:")
 		case strings.HasPrefix(name, "size:"):
 			e.Size = strings.TrimPrefix(name, "size:")
-		case strings.HasPrefix(name, "status:"):
-			e.Status = strings.TrimPrefix(name, "status:")
 		case strings.HasPrefix(name, "plan-validated:"):
+			// Chequear plan-validated antes de validated: (más específico
+			// gana — sino el case validated: matchearía a plan-validated:X).
 			e.PlanVerdict = strings.TrimPrefix(name, "plan-validated:")
 		case strings.HasPrefix(name, "validated:"):
 			e.PRVerdict = strings.TrimPrefix(name, "validated:")
+		case strings.HasPrefix(name, "che:"):
+			// che:idea / che:planning / che:plan / che:executing /
+			// che:executed / che:validating / che:validated / che:closing /
+			// che:closed → sufijo va a Status. che:locked se intercepta
+			// arriba (no llega acá).
+			e.Status = strings.TrimPrefix(name, "che:")
 		}
 	}
 }

--- a/internal/dash/gh_source_test.go
+++ b/internal/dash/gh_source_test.go
@@ -63,8 +63,9 @@ func TestParseIssues(t *testing.T) {
 			if !hasLabel(i.Labels, "ct:plan") {
 				t.Errorf("issue #7 should have ct:plan label")
 			}
-			if !hasLabel(i.Labels, "status:idea") {
-				t.Errorf("issue #7 should have status:idea label")
+			// PR3: labels migrados de status:* a che:*.
+			if !hasLabel(i.Labels, "che:idea") {
+				t.Errorf("issue #7 should have che:idea label")
 			}
 		}
 	}
@@ -232,8 +233,10 @@ func TestCombineEntities_PRVerdictFromLabels(t *testing.T) {
 	if pr40.PRVerdict != "approve" {
 		t.Errorf("PR #40 verdict: got %q want approve", pr40.PRVerdict)
 	}
-	if pr40.Column() != "approved" {
-		t.Errorf("PR #40 with approve verdict should land in 'approved' column; got %q", pr40.Column())
+	// PR3: columnas 1-a-1 con Status. Issue #22 (fused con PR #40) tiene
+	// che:validated en el fixture → cae en "validated", no "approved".
+	if pr40.Column() != "validated" {
+		t.Errorf("PR #40 (status=validated) should land in 'validated' column; got %q", pr40.Column())
 	}
 }
 
@@ -282,8 +285,8 @@ func TestCombineEntities_IssueOnlyPreserved(t *testing.T) {
 // shapes (CheckRun + StatusContext) y estados intermedios.
 func TestCountChecks(t *testing.T) {
 	cases := []struct {
-		name                  string
-		checks                []ghCheck
+		name                       string
+		checks                     []ghCheck
 		wantOK, wantPend, wantFail int
 	}{
 		{
@@ -354,7 +357,7 @@ func TestCountChecks(t *testing.T) {
 			wantPend: 1,
 		},
 		{
-			name: "Empty → zero",
+			name:   "Empty → zero",
 			checks: nil,
 		},
 		{
@@ -402,9 +405,9 @@ func TestHumanAgo(t *testing.T) {
 	// Solo chequeamos el prefijo / forma; los valores exactos dependen del
 	// tiempo de corrida.
 	cases := []struct {
-		name     string
-		seconds  int
-		wantHas  string
+		name    string
+		seconds int
+		wantHas string
 	}{
 		{"3s", 3, "hace 3s"},
 		{"59s", 59, "hace 59s"},
@@ -437,5 +440,108 @@ func TestErrShort(t *testing.T) {
 	got := errShort(long)
 	if len(got) != 40 {
 		t.Errorf("errShort(long) len: got %d want 40 (got=%q)", len(got), got)
+	}
+}
+
+// TestApplyLabels_Che cubre el parsing de labels che:* (PR3): cada sufijo
+// del prefijo debe terminar en e.Status. che:locked es la excepción —
+// prende e.Locked y NO toca Status.
+func TestApplyLabels_Che(t *testing.T) {
+	cases := []struct {
+		name       string
+		ls         []ghLabel
+		wantStatus string
+		wantLocked bool
+	}{
+		{
+			name:       "che:idea → status idea",
+			ls:         []ghLabel{{Name: "che:idea"}},
+			wantStatus: "idea",
+		},
+		{
+			name:       "che:planning → status planning",
+			ls:         []ghLabel{{Name: "che:planning"}},
+			wantStatus: "planning",
+		},
+		{
+			name:       "che:closed → status closed",
+			ls:         []ghLabel{{Name: "che:closed"}},
+			wantStatus: "closed",
+		},
+		{
+			name:       "che:locked → Locked=true, Status vacío",
+			ls:         []ghLabel{{Name: "che:locked"}},
+			wantLocked: true,
+		},
+		{
+			name:       "che:executing + che:locked → status executing + locked",
+			ls:         []ghLabel{{Name: "che:executing"}, {Name: "che:locked"}},
+			wantStatus: "executing",
+			wantLocked: true,
+		},
+		{
+			name: "status:* legacy ya no impacta Status (post-PR1/PR2)",
+			ls:   []ghLabel{{Name: "status:plan"}},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var e Entity
+			applyLabels(&e, tc.ls)
+			if e.Status != tc.wantStatus {
+				t.Errorf("Status: got %q want %q", e.Status, tc.wantStatus)
+			}
+			if e.Locked != tc.wantLocked {
+				t.Errorf("Locked: got %v want %v", e.Locked, tc.wantLocked)
+			}
+		})
+	}
+}
+
+// TestApplyLabels_PlanValidatedNotShadowedByValidated: el switch debe
+// chequear plan-validated:* antes que validated:* — caso contrario un label
+// "plan-validated:approve" matchearía el case "validated:" y dejaría
+// PRVerdict="approve" / PlanVerdict="" (bug invertido). Es defensa contra
+// reordenar los cases del switch sin querer.
+func TestApplyLabels_PlanValidatedNotShadowedByValidated(t *testing.T) {
+	var e Entity
+	applyLabels(&e, []ghLabel{{Name: "plan-validated:approve"}})
+	if e.PlanVerdict != "approve" {
+		t.Errorf("PlanVerdict: got %q want approve", e.PlanVerdict)
+	}
+	if e.PRVerdict != "" {
+		t.Errorf("PRVerdict debería quedar vacío con label plan-validated:approve; got %q", e.PRVerdict)
+	}
+}
+
+// TestCombineEntities_ClosedIssuesIncluded simula el merge de issues open +
+// closed que hace refresh(). El caller real (refresh()) hace `append(open,
+// closed...)` antes de llamar a combineEntities — replicamos eso acá.
+func TestCombineEntities_ClosedIssuesIncluded(t *testing.T) {
+	openIssues := []ghIssue{
+		{Number: 7, Title: "open idea", Labels: []ghLabel{{Name: "ct:plan"}, {Name: "che:idea"}}},
+	}
+	closedIssues := []ghIssue{
+		{Number: 5, Title: "old done", State: "CLOSED", Labels: []ghLabel{{Name: "ct:plan"}, {Name: "che:closed"}}},
+	}
+	all := append([]ghIssue{}, openIssues...)
+	all = append(all, closedIssues...)
+
+	entities := combineEntities(all, nil)
+
+	var got5 *Entity
+	for i := range entities {
+		if entities[i].IssueNumber == 5 {
+			got5 = &entities[i]
+		}
+	}
+	if got5 == nil {
+		t.Fatalf("issue #5 closed no quedó en entities; got=%+v", entities)
+	}
+	if got5.Status != "closed" {
+		t.Errorf("issue #5 status: got %q want closed", got5.Status)
+	}
+	if got5.Column() != "closed" {
+		t.Errorf("issue #5 columna: got %q want closed", got5.Column())
 	}
 }

--- a/internal/dash/mock.go
+++ b/internal/dash/mock.go
@@ -1,8 +1,9 @@
 // Package dash — datos mock del Step 2, usados por MockSource (source.go).
 //
-// `mockEntities` devuelve una lista fija de 9 entidades que cubre las 6
-// columnas del board (backlog, exploring, plan, executing, validating,
-// approved) más algunos estados secundarios (locked, verdicts, checks).
+// `mockEntities` devuelve una lista fija de entidades que cubre las 9
+// columnas del board (idea, planning, plan, executing, executed, validating,
+// validated, closing, closed) más algunos estados secundarios (locked,
+// verdicts, checks).
 //
 // Se expone solo a través de MockSource — es internal (lowercase) para evitar
 // que código externo lo consuma directo y se salte la abstracción de Source.
@@ -15,10 +16,10 @@ package dash
 // modificar el resultado no afecte futuras llamadas — MockSource.Snapshot
 // se llama desde handlers concurrentes y queremos datos independientes.
 func mockEntities() []Entity {
-	// 3 bodies distintos asignados round-robin (i%3) a las 9 entidades —
-	// garantiza variedad visual en el tab "Issue" del drawer sin inventar
-	// copy por cada card. Cada uno copia el estilo de issues reales de che:
-	// Contexto / Solución propuesta / Aceptación.
+	// 3 bodies distintos asignados round-robin (i%3) — garantiza variedad
+	// visual en el tab "Issue" del drawer sin inventar copy por cada card.
+	// Cada uno copia el estilo de issues reales de che: Contexto / Solución
+	// propuesta / Aceptación.
 	bodies := [3]string{
 		`## Contexto
 Queremos que el dashboard muestre auto-refresh del board cada N segundos sin reload manual.
@@ -52,7 +53,7 @@ Wrap de cada paso en defer cleanup que quite el label che:locked sin importar el
 - [ ] tests unitarios del cleanup`,
 	}
 	e := []Entity{
-		// Backlog — issues idle.
+		// idea — issues idle (2 entidades para que la columna no quede sola).
 		{
 			Kind: KindIssue, IssueNumber: 61, IssueTitle: "pagination en /api/runs",
 			Type: "feature", Size: "m", Status: "idea",
@@ -61,47 +62,60 @@ Wrap de cada paso en defer cleanup que quite el label che:locked sin importar el
 			Kind: KindIssue, IssueNumber: 58, IssueTitle: "timeout configurable por flow",
 			Type: "mejora", Size: "s", Status: "idea",
 		},
-		{
-			Kind: KindIssue, IssueNumber: 50, IssueTitle: "retry en gh api",
-			Type: "fix", Size: "xs", Status: "idea",
-		},
 
-		// Exploring — issue corriendo `che explore`.
+		// planning — issue corriendo `che explore` (transient, hot).
 		{
 			Kind: KindIssue, IssueNumber: 7, IssueTitle: "che dash web local",
-			Type: "feature", Size: "l", Status: "idea",
+			Type: "feature", Size: "l", Status: "planning",
 			RunningFlow: "explore", RunIter: 1, RunMax: 3,
 		},
 
-		// Plan — explore terminó OK + plan-validated:approve.
+		// plan — explore terminó OK; una con plan-validated:approve y otra
+		// sin validar para mostrar las 2 variantes visuales.
 		{
 			Kind: KindIssue, IssueNumber: 38, IssueTitle: "rollback en che idea",
 			Type: "feature", Size: "m", Status: "plan",
 			PlanVerdict: "approve",
 		},
+		{
+			Kind: KindIssue, IssueNumber: 50, IssueTitle: "retry en gh api",
+			Type: "fix", Size: "xs", Status: "plan",
+		},
 
-		// Executing — issue+PR fusionados, status:executing, locked, iterate corriendo.
+		// executing — issue+PR fusionados, locked, execute corriendo (hot).
 		{
 			Kind: KindFused, IssueNumber: 33, IssueTitle: "refactor logger unificado",
 			PRNumber: 48, PRTitle: "refactor logger unificado",
 			Type: "mejora", Size: "l", Status: "executing",
 			Locked:      true,
-			RunningFlow: "iterate", RunIter: 2, RunMax: 5,
+			RunningFlow: "execute", RunIter: 2, RunMax: 5,
 			Branch: "feat/logger-unif", SHA: "3c12aa8",
 			LastAction: "execute → iterate #2 (hace 18s)",
-			NextAction: "iterate corriendo",
-			LoopSpec:   "iterate ↔ validate · run 2/5 · stop at approve",
+			NextAction: "execute corriendo",
+			LoopSpec:   "execute · run 2/5",
 		},
 
-		// Validating — el caso "selected" del mockup, con LogRuns populados.
+		// executed — execute terminó OK, esperando validate.
+		{
+			Kind: KindFused, IssueNumber: 29, IssueTitle: "timeout config por flow",
+			PRNumber: 44, PRTitle: "timeout config por flow",
+			Type: "mejora", Size: "s", Status: "executed",
+			ChecksOK:   5,
+			ChecksFail: 2,
+			Branch:     "feat/timeout-cfg", SHA: "ff4e9b2",
+			LastAction: "execute terminó OK (hace 2m)",
+			NextAction: "esperando validate",
+		},
+
+		// validating — el caso "selected" del mockup, transient (hot), con
+		// LogRuns populados para mostrar el drawer rico.
 		{
 			Kind: KindFused, IssueNumber: 42, IssueTitle: "fusion entidad issue+PR en dash",
 			PRNumber: 55, PRTitle: "fusion entidad issue+PR en dash",
-			Type: "feature", Size: "l", Status: "executed",
-			PRVerdict:     "changes-requested",
+			Type: "feature", Size: "l", Status: "validating",
 			ChecksOK:      8,
 			ChecksPending: 1,
-			RunningFlow:   "iterate", RunIter: 3, RunMax: 10,
+			RunningFlow:   "validate", RunIter: 3, RunMax: 10,
 			Branch: "feat/dash-fusion", SHA: "a8f3c21",
 			LastAction: "iterate #3 → validate (hace 42s)",
 			NextAction: "validate en ~18s",
@@ -132,36 +146,58 @@ Wrap de cada paso en defer cleanup que quite el label che:locked sin importar el
 			},
 		},
 
-		// Validating — needs-human, idle (no flow corriendo).
-		{
-			Kind: KindFused, IssueNumber: 29, IssueTitle: "timeout config por flow",
-			PRNumber: 44, PRTitle: "timeout config por flow",
-			Type: "mejora", Size: "s", Status: "executed",
-			PRVerdict:  "needs-human",
-			ChecksOK:   5,
-			ChecksFail: 2,
-			Branch:     "feat/timeout-cfg", SHA: "ff4e9b2",
-			LastAction: "validate run 2 → needs-human (hace 4m)",
-			NextAction: "esperando review humano",
-			LoopSpec:   "iterate ↔ validate · run 2/5 · stop at approve",
-		},
-
-		// Approved — listo para mergear.
+		// validated — 2 entidades cubren los 3 verdicts en uso (approve y
+		// changes-requested + iterate corriendo encima).
 		{
 			Kind: KindFused, IssueNumber: 22, IssueTitle: "listar ideas sin clasificar en TUI",
 			PRNumber: 40, PRTitle: "listar ideas sin clasificar en TUI",
-			Type: "feature", Size: "s", Status: "executed",
+			Type: "feature", Size: "s", Status: "validated",
 			PRVerdict: "approve",
 			ChecksOK:  9,
 			Branch:    "feat/list-unclassified", SHA: "77e210d",
 			LastAction: "validate run 2 → approve (hace 12m)",
-			NextAction: "esperando merge",
+			NextAction: "esperando close",
 			LoopSpec:   "iterate ↔ validate · run 2/5 · stop at approve",
+		},
+		{
+			Kind: KindFused, IssueNumber: 18, IssueTitle: "drawer pestaña Issue muestra body",
+			PRNumber: 36, PRTitle: "drawer pestaña Issue muestra body",
+			Type: "feature", Size: "m", Status: "validated",
+			PRVerdict:     "changes-requested",
+			ChecksOK:      6,
+			ChecksPending: 1,
+			RunningFlow:   "iterate", RunIter: 4, RunMax: 8,
+			Branch: "feat/drawer-issue-tab", SHA: "1d0e4b9",
+			LastAction: "validate run 4 → changes-requested (hace 3m)",
+			NextAction: "iterate aplicando feedback",
+			LoopSpec:   "iterate ↔ validate · run 4/8 · stop at approve",
+		},
+
+		// closing — close en curso (transient, hot).
+		{
+			Kind: KindFused, IssueNumber: 12, IssueTitle: "che close gates con verdict",
+			PRNumber: 28, PRTitle: "che close gates con verdict",
+			Type: "mejora", Size: "s", Status: "closing",
+			RunningFlow: "close", RunIter: 1, RunMax: 1,
+			Branch: "feat/close-gates", SHA: "9b2e7c1",
+			LastAction: "close iniciado (hace 12s)",
+			NextAction: "mergeando PR",
+		},
+
+		// closed — terminal, sin flow corriendo.
+		{
+			Kind: KindFused, IssueNumber: 5, IssueTitle: "logger unificado v0",
+			PRNumber: 9, PRTitle: "logger unificado v0",
+			Type: "mejora", Size: "m", Status: "closed",
+			PRVerdict: "approve",
+			ChecksOK:  10,
+			Branch:    "feat/logger-v0", SHA: "0a1b2c3",
+			LastAction: "close terminó OK (hace 2h)",
 		},
 	}
 	// Asignación round-robin de los 3 bodies. Mantener fuera del literal
-	// de arriba evita tener que repetir `IssueBody: bodies[N]` en cada entry
-	// y que alguien al agregar una 10ma se olvide de setearlo.
+	// de arriba evita repetir `IssueBody: bodies[N]` en cada entry y que
+	// alguien al agregar otra se olvide de setearlo.
 	for i := range e {
 		e[i].IssueBody = bodies[i%len(bodies)]
 	}

--- a/internal/dash/model.go
+++ b/internal/dash/model.go
@@ -1,9 +1,8 @@
 // Package dash — modelo de datos del dashboard. Define los tipos `Entity`,
 // `LogRun`, `LogEntry` que representan lo que se muestra en una card / drawer,
 // junto con el dispatcher `Column` que decide en qué columna del board cae una
-// entidad según sus labels reales (ct:plan, status:*, plan-validated:*,
-// validated:*, che:locked) más el estado efímero de los flows en curso
-// (RunningFlow, RunIter, RunMax).
+// entidad según su `Status` (mapeo 1-a-1 con los 9 estados che:* + default
+// "idea" para issues sin estado raro).
 //
 // Step 2: estos tipos los popula `mock.go` con datos hardcodeados; en pasos
 // posteriores los completará un poller que lea labels de gh api.
@@ -11,17 +10,19 @@ package dash
 
 // EntityKind distingue una entidad "issue suelto" (sin PR aún) de una
 // "fusionada" issue+PR (vinculados via close-keywords). El dispatcher de
-// columna usa esto para separar lo que está en el funnel pre-execute de lo
-// que ya tiene PR abierto.
+// columna ya NO usa Kind (solo Status decide la columna), pero el render
+// sigue diferenciándolo: KindFused muestra ref dual #issue → !PR, KindIssue
+// muestra solo #issue.
 type EntityKind int
 
 const (
 	// KindIssue: solo hay un issue, todavía no se abrió el PR. Cubre las
-	// columnas backlog / exploring / plan.
+	// columnas idea / planning / plan (pre-execute).
 	KindIssue EntityKind = iota
 	// KindFused: issue + PR vinculados (close-keywords). El render usa el
 	// número del PR como ref principal y deja el del issue en breadcrumb.
-	// Cubre executing / validating / approved.
+	// Cubre executing / executed / validating / validated / closing / closed.
+	// Validating y validated también pueden contener issues (validate de plan).
 	KindFused
 )
 
@@ -43,14 +44,18 @@ type Entity struct {
 	Branch      string // ej "feat/dash-fusion"
 	SHA         string // short SHA
 
-	Type        string // "feature" | "fix" | "mejora" | "ux" — vacío = desconocido
-	Size        string // "xs" | "s" | "m" | "l" | "xl" — vacío = desconocido
-	Status      string // "idea" | "plan" | "executing" | "executed" | "closed"
+	Type string // "feature" | "fix" | "mejora" | "ux" — vacío = desconocido
+	Size string // "xs" | "s" | "m" | "l" | "xl" — vacío = desconocido
+	// Status es el sufijo del label che:* (sin prefijo). Valores válidos:
+	// "idea", "planning", "plan", "executing", "executed", "validating",
+	// "validated", "closing", "closed". Vacío o desconocido cae a "idea"
+	// (default defensivo en Column()).
+	Status      string
 	PlanVerdict string // "approve" | "changes-requested" | "needs-human" — vacío = no validado
 	PRVerdict   string // idem, solo aplica si KindFused
 	Locked      bool   // che:locked
 
-	RunningFlow string // "explore" | "execute" | "iterate" | "validate" — vacío = idle
+	RunningFlow string // "explore" | "execute" | "iterate" | "validate" | "close" — vacío = idle
 	RunIter     int    // iteración actual (1-based)
 	RunMax      int    // max iteraciones del loop
 
@@ -85,40 +90,38 @@ type LogEntry struct {
 	Text  string
 }
 
-// Column resuelve a qué columna del Kanban va la entidad. Las reglas siguen
-// el funnel real de che: lo no fusionado vive en backlog/exploring/plan según
-// status + flow corriendo; lo fusionado vive en executing/validating/approved
-// según el verdict del PR.
+// Column resuelve a qué columna del Kanban va la entidad. Mapeo 1-a-1 con
+// `Status`: cada estado che:* tiene su propia columna. La diferencia entre
+// transient y terminal (planning/validating/closing vs plan/validated/closed)
+// se refleja a nivel UI vía el badge "hot" (animación pulsante) que se calcula
+// en groupByColumn al ver RunningFlow != "".
 //
-// Reglas en orden (la primera que matchea gana):
-//  1. Fusionada con PRVerdict=approve → "approved".
-//  2. Fusionada (cualquier otro o sin verdict) → "validating".
-//     Excepción: si Status=="executing", cae a "executing" (todavía no llegó al primer validate).
-//  3. Status=="executing" → "executing" (aplica a fused y a issue-only por defensa).
-//  4. Status=="plan" → "plan".
-//  5. Status=="idea" + RunningFlow=="explore" → "exploring".
-//  6. Default (incluye Status=="idea" idle, status vacío, status raro) → "backlog".
+// Default: "idea" (cualquier issue sin status raro o vacío). Antes era
+// "backlog" pero en el modelo de 9 estados ya no hay backlog separado de
+// idea — todo issue gestionado por che arranca como idea.
 func (e Entity) Column() string {
-	if e.Kind == KindFused {
-		if e.Status == "executing" {
-			return "executing"
-		}
-		if e.PRVerdict == "approve" {
-			return "approved"
-		}
-		return "validating"
-	}
 	switch e.Status {
-	case "executing":
-		return "executing"
+	case "idea":
+		return "idea"
+	case "planning":
+		return "planning"
 	case "plan":
 		return "plan"
-	case "idea":
-		if e.RunningFlow == "explore" {
-			return "exploring"
-		}
-		return "backlog"
+	case "executing":
+		return "executing"
+	case "executed":
+		return "executed"
+	case "validating":
+		return "validating"
+	case "validated":
+		return "validated"
+	case "closing":
+		return "closing"
+	case "closed":
+		return "closed"
 	default:
-		return "backlog"
+		// Status vacío o desconocido → idea (defensa, evita que entidades
+		// huérfanas desaparezcan del board).
+		return "idea"
 	}
 }

--- a/internal/dash/model_test.go
+++ b/internal/dash/model_test.go
@@ -2,10 +2,9 @@ package dash
 
 import "testing"
 
-// TestColumn cubre el dispatcher de columna del board. Cada caso refleja una
-// transición típica del funnel (idea idle → exploring → plan → executing →
-// validating → approved) más algunos edge cases (status raro, fused sin
-// verdict, fused con executing).
+// TestColumn cubre el dispatcher de columna del board. Mapeo 1-a-1 con
+// `Status` (PR3): cada estado che:* tiene su propia columna; status raro o
+// vacío cae a "idea" (default defensivo).
 func TestColumn(t *testing.T) {
 	cases := []struct {
 		name string
@@ -13,19 +12,19 @@ func TestColumn(t *testing.T) {
 		want string
 	}{
 		{
-			name: "issue idle, status idea → backlog",
+			name: "issue idle, status idea → idea",
 			in:   Entity{Kind: KindIssue, Status: "idea"},
-			want: "backlog",
+			want: "idea",
 		},
 		{
-			name: "issue idle, status vacío → backlog",
+			name: "issue idle, status vacío → idea (default)",
 			in:   Entity{Kind: KindIssue},
-			want: "backlog",
+			want: "idea",
 		},
 		{
-			name: "issue con explore corriendo → exploring",
-			in:   Entity{Kind: KindIssue, Status: "idea", RunningFlow: "explore", RunIter: 1, RunMax: 3},
-			want: "exploring",
+			name: "issue con explore corriendo, status planning → planning",
+			in:   Entity{Kind: KindIssue, Status: "planning", RunningFlow: "explore", RunIter: 1, RunMax: 3},
+			want: "planning",
 		},
 		{
 			name: "issue status plan → plan",
@@ -33,7 +32,7 @@ func TestColumn(t *testing.T) {
 			want: "plan",
 		},
 		{
-			name: "issue status plan + plan-validated:approve → plan",
+			name: "issue status plan + plan-validated:approve → plan (verdict no afecta columna)",
 			in:   Entity{Kind: KindIssue, Status: "plan", PlanVerdict: "approve"},
 			want: "plan",
 		},
@@ -43,29 +42,44 @@ func TestColumn(t *testing.T) {
 			want: "executing",
 		},
 		{
-			name: "fused executed sin verdict → validating",
+			name: "fused status executed → executed (no auto-validating)",
 			in:   Entity{Kind: KindFused, Status: "executed"},
+			want: "executed",
+		},
+		{
+			name: "fused status validating → validating",
+			in:   Entity{Kind: KindFused, Status: "validating"},
 			want: "validating",
 		},
 		{
-			name: "fused executed + verdict changes-requested → validating",
-			in:   Entity{Kind: KindFused, Status: "executed", PRVerdict: "changes-requested"},
-			want: "validating",
+			name: "fused status validated + verdict approve → validated",
+			in:   Entity{Kind: KindFused, Status: "validated", PRVerdict: "approve"},
+			want: "validated",
 		},
 		{
-			name: "fused executed + verdict needs-human → validating",
-			in:   Entity{Kind: KindFused, Status: "executed", PRVerdict: "needs-human"},
-			want: "validating",
+			name: "fused status validated + verdict changes-requested → validated (mismo bucket)",
+			in:   Entity{Kind: KindFused, Status: "validated", PRVerdict: "changes-requested"},
+			want: "validated",
 		},
 		{
-			name: "fused executed + verdict approve → approved",
-			in:   Entity{Kind: KindFused, Status: "executed", PRVerdict: "approve"},
-			want: "approved",
+			name: "fused status validated + verdict needs-human → validated",
+			in:   Entity{Kind: KindFused, Status: "validated", PRVerdict: "needs-human"},
+			want: "validated",
 		},
 		{
-			name: "issue con status raro → backlog (default)",
+			name: "fused status closing → closing",
+			in:   Entity{Kind: KindFused, Status: "closing"},
+			want: "closing",
+		},
+		{
+			name: "fused status closed → closed",
+			in:   Entity{Kind: KindFused, Status: "closed"},
+			want: "closed",
+		},
+		{
+			name: "issue con status raro → idea (default defensivo)",
 			in:   Entity{Kind: KindIssue, Status: "frob"},
-			want: "backlog",
+			want: "idea",
 		},
 	}
 	for _, tc := range cases {

--- a/internal/dash/server.go
+++ b/internal/dash/server.go
@@ -175,24 +175,41 @@ type drawerData struct {
 
 // columnData representa una columna del Kanban con sus entidades ya
 // filtradas. Hot dispara el badge pulsante (animación rosa) cuando hay
-// trabajo activo (RunningFlow != "" en alguna de las entidades).
+// trabajo activo en una columna transient (RunningFlow != "" en alguna
+// entidad de planning, executing, validating o closing).
 type columnData struct {
-	Key      string // "backlog" | "exploring" | "plan" | "executing" | "validating" | "approved"
+	Key      string // 1 de los 9: idea | planning | plan | executing | executed | validating | validated | closing | closed
 	Title    string
 	Hot      bool
 	Entities []Entity
 }
 
-// columnsOrder fija el orden left-to-right del board.
+// columnsOrder fija el orden left-to-right del board. 9 columnas reflejando
+// los 9 estados che:* (PR2). Las 4 transient (planning, executing,
+// validating, closing) se intercalan entre sus pares terminales. closed es
+// terminal y queda capada en el poller (ver ClosedCap en gh_source.go).
 var columnsOrder = []struct {
 	Key, Title string
 }{
-	{"backlog", "backlog"},
-	{"exploring", "exploring"},
+	{"idea", "idea"},
+	{"planning", "planning"},
 	{"plan", "plan"},
 	{"executing", "executing"},
+	{"executed", "executed"},
 	{"validating", "validating"},
-	{"approved", "approved"},
+	{"validated", "validated"},
+	{"closing", "closing"},
+	{"closed", "closed"},
+}
+
+// hotColumns es el set de columnas que pueden mostrar el badge hot (animación
+// pulsante). Son las 4 transient: cuando hay un flow corriendo sobre una
+// entidad en esa columna, el badge late para indicar trabajo en curso.
+var hotColumns = map[string]bool{
+	"planning":   true,
+	"executing":  true,
+	"validating": true,
+	"closing":    true,
 }
 
 // groupByColumn distribuye un slice de entidades en columnas según
@@ -203,7 +220,7 @@ func groupByColumn(entities []Entity) []columnData {
 	for _, e := range entities {
 		col := e.Column()
 		buckets[col] = append(buckets[col], e)
-		if e.RunningFlow != "" && (col == "exploring" || col == "executing" || col == "validating") {
+		if e.RunningFlow != "" && hotColumns[col] {
 			hot[col] = true
 		}
 	}
@@ -387,7 +404,7 @@ func (s *Server) buildMux() *http.ServeMux {
 	})
 
 	// Board partial para HTMX polling. Devuelve el chip de status (oob) + las
-	// 6 columnas. El wrapper `.dash-board` queda en el DOM y su innerHTML se
+	// 9 columnas. El wrapper `.dash-board` queda en el DOM y su innerHTML se
 	// swappea con el contenido de esta respuesta.
 	mux.HandleFunc("GET /board", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/internal/dash/server_test.go
+++ b/internal/dash/server_test.go
@@ -57,8 +57,20 @@ func TestDashboardHandler_Index(t *testing.T) {
 		t.Errorf("body missing Dracula bg hex")
 	}
 	// Step 2: rename mergeable → approved.
-	if !strings.Contains(got, ">approved<") {
-		t.Errorf("body missing column header 'approved'")
+	// PR3: 9 columnas (idea, planning, plan, executing, executed, validating,
+	// validated, closing, closed). "approved" desapareció como columna —
+	// ahora la columna es "validated".
+	if !strings.Contains(got, ">validated<") {
+		t.Errorf("body missing column header 'validated'")
+	}
+	if !strings.Contains(got, ">closed<") {
+		t.Errorf("body missing column header 'closed'")
+	}
+	if !strings.Contains(got, ">planning<") {
+		t.Errorf("body missing column header 'planning'")
+	}
+	if strings.Contains(got, ">approved<") {
+		t.Errorf("body still contains legacy column 'approved' (PR3 lo sustituye por 'validated')")
 	}
 	if strings.Contains(got, ">mergeable<") {
 		t.Errorf("body still contains old column 'mergeable'")
@@ -312,6 +324,55 @@ type fixedSource struct{ snap Snapshot }
 
 func (f *fixedSource) Snapshot() Snapshot { return f.snap }
 
+// TestColumnsOrder fija el contrato del orden left-to-right del board: 9
+// columnas reflejando los 9 estados che:* (PR3). Si alguien reordena el
+// slice o suma/quita una columna, el test rompe.
+func TestColumnsOrder(t *testing.T) {
+	want := []string{"idea", "planning", "plan", "executing", "executed", "validating", "validated", "closing", "closed"}
+	if len(columnsOrder) != len(want) {
+		t.Fatalf("columnsOrder len: got %d want %d", len(columnsOrder), len(want))
+	}
+	for i, c := range columnsOrder {
+		if c.Key != want[i] {
+			t.Errorf("columnsOrder[%d].Key: got %q want %q", i, c.Key, want[i])
+		}
+	}
+}
+
+// TestGroupByColumn_HotSemantics chequea que el badge "hot" prende para las
+// 4 columnas transient (planning/executing/validating/closing) cuando hay
+// una entidad con RunningFlow != "", y NO prende para las terminales (idea,
+// plan, executed, validated, closed).
+func TestGroupByColumn_HotSemantics(t *testing.T) {
+	entities := []Entity{
+		{Status: "planning", RunningFlow: "explore"},
+		{Status: "executing", RunningFlow: "execute"},
+		{Status: "validating", RunningFlow: "validate"},
+		{Status: "closing", RunningFlow: "close"},
+		// No-hot: status terminal aunque haya RunningFlow seteado (caso raro).
+		{Status: "validated", RunningFlow: "iterate"},
+		// No-hot: planning sin flow (transient pero idle).
+		{Status: "plan"},
+	}
+	got := groupByColumn(entities)
+	hotByKey := map[string]bool{}
+	for _, c := range got {
+		hotByKey[c.Key] = c.Hot
+	}
+	wantHot := []string{"planning", "executing", "validating", "closing"}
+	for _, k := range wantHot {
+		if !hotByKey[k] {
+			t.Errorf("columna %q debería estar hot", k)
+		}
+	}
+	wantNotHot := []string{"idea", "plan", "executed", "validated", "closed"}
+	for _, k := range wantNotHot {
+		if hotByKey[k] {
+			t.Errorf("columna %q NO debería estar hot", k)
+		}
+	}
+}
+
 // TestBoardHandler_MockSource: el endpoint /board devuelve status-chip (oob)
 // + columnas, listo para que HTMX swappee el innerHTML del wrapper.
 func TestBoardHandler_MockSource(t *testing.T) {
@@ -342,12 +403,17 @@ func TestBoardHandler_MockSource(t *testing.T) {
 	if !strings.Contains(got, "mock mode") {
 		t.Errorf("/board missing 'mock mode' chip text (MockSource)")
 	}
-	// Columnas presentes.
-	if !strings.Contains(got, `data-status="backlog"`) {
-		t.Errorf("/board missing column data-status=backlog")
+	// Columnas presentes (sample: idea, validated, closed). PR3 reemplaza
+	// las 6 columnas viejas (incluyendo "backlog" y "approved") por las 9
+	// che:* — chequeamos extremos + una del medio.
+	if !strings.Contains(got, `data-status="idea"`) {
+		t.Errorf("/board missing column data-status=idea")
 	}
-	if !strings.Contains(got, `data-status="approved"`) {
-		t.Errorf("/board missing column data-status=approved")
+	if !strings.Contains(got, `data-status="validated"`) {
+		t.Errorf("/board missing column data-status=validated")
+	}
+	if !strings.Contains(got, `data-status="closed"`) {
+		t.Errorf("/board missing column data-status=closed")
 	}
 	// El partial NO debería incluir el wrapper <div class="dash-board">,
 	// solo su contenido (chip + columnas). Ese wrapper es persistente.

--- a/internal/dash/templates/board.html.tmpl
+++ b/internal/dash/templates/board.html.tmpl
@@ -4,9 +4,10 @@
        - "board-partial": respuesta del endpoint /board. Incluye el chip
          de status (con hx-swap-oob="outerHTML" para que se actualice fuera
          del target del swap principal) + las columnas.
-       - "board-columns": las 6 columnas. Invocable desde dashboard.html.tmpl
-         en el render inicial (para no depender de un primer poll antes de
-         ver algo en la UI).
+       - "board-columns": las 9 columnas (idea, planning, plan, executing,
+         executed, validating, validated, closing, closed) reflejando los 9
+         estados che:* (PR3). Invocable desde dashboard.html.tmpl en el render
+         inicial (para no depender de un primer poll antes de ver algo en la UI).
 
      Recibe pageData: .Columns, .Snapshot, .PollInterval, .Repo. */}}
 

--- a/internal/dash/templates/dashboard.html.tmpl
+++ b/internal/dash/templates/dashboard.html.tmpl
@@ -140,20 +140,33 @@
   /* drawer-slot vacío no debe ocupar ancho ni huecos visuales. */
   #drawer-slot:empty { display: none; }
 
-  /* ==================== Board ==================== */
+  /* ==================== Board ====================
+     9 columnas (idea, planning, plan, executing, executed, validating,
+     validated, closing, closed) reflejando los 9 estados che:* (PR2/PR3).
+     Las 4 transient (planning/executing/validating/closing) se pintan en
+     orange; validated en green; closed muted. min-width fuerza scroll
+     horizontal en pantallas chicas — con 9 columnas el board no entra en
+     viewports angostos sin que las cards queden ilegibles. */
   .dash-board {
     display: grid;
-    grid-template-columns: repeat(6, 1fr);
+    grid-template-columns: repeat(9, 1fr);
     gap: 8px;
-    overflow: hidden;
+    overflow-x: auto;
+    overflow-y: hidden;
     min-width: 0;
+    /* min-width del contenido: 9 columnas con un piso razonable (~110px)
+       más gaps. Si el viewport es más chico, scrolleamos en X en vez de
+       comprimir las cards. */
+    /* Aplicado al contenedor interno via grid items: usamos min-width: 0
+       en .col + el grid template arriba; el scroll horizontal aparece en
+       .dash-board cuando los grid items no entran. */
   }
   .col {
     background: var(--panel);
     border-radius: 6px;
     display: flex;
     flex-direction: column;
-    min-width: 0;
+    min-width: 110px;
   }
   .col-hdr {
     padding: 8px 10px;
@@ -177,10 +190,13 @@
     animation: pulse 1.4s infinite;
   }
   @keyframes pulse { 50% { opacity: 0.55; } }
-  .col[data-status="exploring"] .col-hdr b,
+  /* Transient (los 4 *ing) en orange; validated en green; closed en muted. */
+  .col[data-status="planning"] .col-hdr b,
   .col[data-status="executing"] .col-hdr b,
-  .col[data-status="validating"] .col-hdr b { color: var(--orange); }
-  .col[data-status="approved"] .col-hdr b { color: var(--green); }
+  .col[data-status="validating"] .col-hdr b,
+  .col[data-status="closing"] .col-hdr b { color: var(--orange); }
+  .col[data-status="validated"] .col-hdr b { color: var(--green); }
+  .col[data-status="closed"] .col-hdr b { color: var(--muted); }
 
   .cards {
     padding: 6px;

--- a/internal/dash/testdata/issues.json
+++ b/internal/dash/testdata/issues.json
@@ -7,7 +7,7 @@
       {"name": "ct:plan"},
       {"name": "type:feature"},
       {"name": "size:l"},
-      {"name": "status:idea"}
+      {"name": "che:idea"}
     ]
   },
   {
@@ -18,7 +18,7 @@
       {"name": "ct:plan"},
       {"name": "type:feature"},
       {"name": "size:m"},
-      {"name": "status:plan"},
+      {"name": "che:plan"},
       {"name": "plan-validated:approve"}
     ]
   },
@@ -30,7 +30,7 @@
       {"name": "ct:plan"},
       {"name": "type:feature"},
       {"name": "size:m"},
-      {"name": "status:idea"}
+      {"name": "che:idea"}
     ]
   },
   {
@@ -41,7 +41,7 @@
       {"name": "ct:plan"},
       {"name": "type:mejora"},
       {"name": "size:l"},
-      {"name": "status:executing"},
+      {"name": "che:executing"},
       {"name": "che:locked"}
     ]
   },
@@ -54,7 +54,7 @@
       {"name": "ct:plan"},
       {"name": "type:feature"},
       {"name": "size:l"},
-      {"name": "status:executed"}
+      {"name": "che:executed"}
     ]
   },
   {
@@ -65,7 +65,7 @@
       {"name": "ct:plan"},
       {"name": "type:feature"},
       {"name": "size:s"},
-      {"name": "status:executed"}
+      {"name": "che:validated"}
     ]
   },
   {


### PR DESCRIPTION
## Summary

El dash web ahora renderiza 9 columnas reflejando la nueva maquina de estados (`idea / planning / plan / executing / executed / validating / validated / closing / closed`) con la columna `closed` limitada a los ultimos 20 issues (default `ClosedCap`).

- `model.Column()` es ahora 1-a-1 con `Status` (sin logica de Kind/PRVerdict). Default cae en `idea`.
- `server.columnsOrder` pasa a 9 entradas. Set `hotColumns` explicito para el badge pulsante (planning/executing/validating/closing).
- `gh_source.applyLabels` parsea prefix `che:*` (era `status:*`). Reordenado case `plan-validated:` antes de `validated:` para evitar shadowing (test de defensa agregado).
- Nueva goroutine en `refresh()` corre `fetchClosedIssues` con `--state closed --label che:closed --limit ClosedCap`. Se mergean con los open antes de `combineEntities`.
- Mock refactorizado a 12 entidades cubriendo cada columna.
- CSS `grid-template-columns: repeat(9, 1fr)` + `overflow-x: auto` + `min-width: 110px`/col para forzar scroll horizontal en viewports angostos.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l internal/dash/` vacio
- [x] Smoke `go run . dash --mock --no-open --port 7779` con counts esperados (2/1/2/1/1/1/2/1/1)
- [ ] Smoke `che dash` (no mock) en repo migrado: ver columna `closed` poblada y cappada

## TODOs

- `defaultClosedCap = 20` puede quedarse corto en repos de alto throughput. Si pasa, exponer como flag `--closed-cap`.

## Roadmap

PR 1/5 ✅ — labels API.
PR 2/5 ✅ — flows.
PR 3/5 ← (este).
PR 4/5 — modal en lugar de sidebar.
PR 5/5 — TUI copy + memory updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)