### PR TITLE
refactor(dash): modal con backdrop en lugar de drawer lateral (PR 4/5)

### DIFF
--- a/internal/dash/server.go
+++ b/internal/dash/server.go
@@ -6,7 +6,14 @@
 // `GET /board` devuelve las columnas + un chip de status via `hx-swap-oob` para
 // que el topbar refleje "OK / stale / connecting" sin recargar toda la página.
 //
-// Pasos siguientes: acciones reales en los botones del drawer y stream SSE de
+// Endpoints del detalle: `/drawer/{id}` y `/drawer/close` mantienen el path
+// `/drawer/*` por compat con tests/htmx attrs aunque ahora el partial
+// renderea un modal overlay (.modal-backdrop > .modal) en vez del sidebar
+// original. El filename del template también queda como drawer.html.tmpl —
+// solo cambia el wrapper exterior; las clases internas siguen con prefix
+// drawer-* (drawer-hdr, drawer-tabs, etc.).
+//
+// Pasos siguientes: acciones reales en los botones del modal y stream SSE de
 // logs en vivo.
 package dash
 
@@ -439,7 +446,9 @@ func (s *Server) buildMux() *http.ServeMux {
 		}
 	})
 
-	// Cierre del drawer. Body vacío deja #drawer-slot vacío y colapsa el grid.
+	// Cierre del modal. Body vacío deja #modal-slot vacío y desmonta el
+	// overlay. Path mantiene el prefijo /drawer/* por compat con tests y
+	// con los hx-get de los botones de cierre del partial.
 	mux.HandleFunc("GET /drawer/close", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.Header().Set("Cache-Control", "no-store")

--- a/internal/dash/server_test.go
+++ b/internal/dash/server_test.go
@@ -75,9 +75,11 @@ func TestDashboardHandler_Index(t *testing.T) {
 	if strings.Contains(got, ">mergeable<") {
 		t.Errorf("body still contains old column 'mergeable'")
 	}
-	// Step 2: drawer ya no va inline; solo el slot vacío.
-	if !strings.Contains(got, `id="drawer-slot"`) {
-		t.Errorf("body missing #drawer-slot")
+	// El detalle ahora se monta como modal overlay; el slot del modal vive
+	// vacío hasta que htmx swappee el partial. Antes era #drawer-slot
+	// (sidebar); el rename a #modal-slot acompaña al refactor del wrapper.
+	if !strings.Contains(got, `id="modal-slot"`) {
+		t.Errorf("body missing #modal-slot")
 	}
 	// Step 2: htmx + dash.js embedded.
 	if !strings.Contains(got, `src="/static/htmx.min.js"`) {
@@ -221,8 +223,11 @@ func TestStaticHandler_DashJS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read body: %v", err)
 	}
-	if !strings.Contains(string(body), "closeDrawer") {
-		t.Errorf("dash.js body missing closeDrawer fn")
+	// Tras el refactor a modal el cierre se llama closeModal (antes
+	// closeDrawer); el listener de htmx:afterSwap sigue presente como hook
+	// reservado para futuros usos sobre #modal-slot.
+	if !strings.Contains(string(body), "closeModal") {
+		t.Errorf("dash.js body missing closeModal fn")
 	}
 	if !strings.Contains(string(body), "htmx:afterSwap") {
 		t.Errorf("dash.js body missing htmx:afterSwap listener")

--- a/internal/dash/static/dash.js
+++ b/internal/dash/static/dash.js
@@ -1,33 +1,34 @@
 // dash.js — interacciones del dashboard que NO maneja htmx por sí solo.
-// Específicamente: sincronizar el atributo body[data-selected] con la card
-// activa (para el highlight CSS), y cerrar el drawer con Esc o click afuera.
+// Específicamente: cerrar el modal con Esc o click sobre el backdrop, y el
+// switcher de tabs (PR | Issue) del modal fused.
 //
-// El swap del drawer en sí lo hace htmx (hx-get="/drawer/{id}" sobre cada
-// card). Acá solo escuchamos eventos del body para mantener data-selected
-// alineado con lo que esté swappeado en #drawer-slot.
+// El swap del modal en sí lo hace htmx (hx-get="/drawer/{id}" sobre cada
+// card). Acá solo escuchamos eventos del body para reaccionar al modal
+// montado en #modal-slot.
 
 (function () {
   "use strict";
 
-  // closeDrawer vacía el slot y limpia el atributo de selección. Idempotente:
-  // si ya estaba cerrado no hace nada raro.
-  function closeDrawer() {
-    var slot = document.getElementById("drawer-slot");
+  // closeModal vacía el slot. Idempotente: si ya estaba cerrado no hace
+  // nada raro. El nombre conserva la semántica del flujo aunque el wrapper
+  // exterior pasó de "drawer" a "modal".
+  function closeModal() {
+    var slot = document.getElementById("modal-slot");
     if (slot) slot.innerHTML = "";
-    document.body.removeAttribute("data-selected");
   }
 
-  // Esc cierra el drawer. Listener global; barato.
+  // Esc cierra el modal. Listener global; barato.
   // "/" focusea el input de filter (si no estamos ya escribiendo en un input).
   document.addEventListener("keydown", function (e) {
     if (e.key === "Escape") {
-      // Si el foco está en un input (ej: filter), Escape lo blurrea; si no, cierra drawer.
+      // Si el foco está en un input (ej: filter), Escape lo blurrea; si no,
+      // cierra el modal.
       var t = e.target;
       if (t instanceof HTMLInputElement || t instanceof HTMLTextAreaElement) {
         t.blur();
         return;
       }
-      closeDrawer();
+      closeModal();
       return;
     }
     if (e.key === "/") {
@@ -42,39 +43,35 @@
     }
   });
 
-  // Tab switcher del drawer (PR / Issue). Delegado en body porque el drawer
-  // se swappea dinámicamente con htmx — no podemos bindear al botón directo
-  // sin re-bindear después de cada swap. stopPropagation evita que el click
-  // bubblee al handler de "click afuera" que cierra el drawer.
+  // Tab switcher del modal (PR / Issue). Delegado en body porque el modal se
+  // swappea dinámicamente con htmx — no podemos bindear al botón directo sin
+  // re-bindear después de cada swap. stopPropagation evita que el click
+  // bubblee al handler de "click backdrop" que cierra el modal.
   document.body.addEventListener("click", function (e) {
     var t = e.target;
     if (!(t instanceof Element)) return;
     var tabBtn = t.closest(".drawer-tabs .tab");
     if (!tabBtn) return;
     e.stopPropagation();
-    var drawer = tabBtn.closest(".drawer");
-    if (!drawer) return;
-    drawer.dataset.tab = tabBtn.dataset.tab || "pr";
+    // El wrapper con data-tab ahora es .modal (no .drawer); las clases
+    // internas drawer-* siguen igual.
+    var modal = tabBtn.closest(".modal");
+    if (!modal) return;
+    modal.dataset.tab = tabBtn.dataset.tab || "pr";
   });
 
-  // Click afuera cierra. Consideramos "afuera" todo lo que NO sea:
-  //   - una card (.card) — el click sobre otra card abre esa otra,
-  //     no debe cerrar primero.
-  //   - el drawer mismo (#drawer-slot) — clicks dentro del drawer
-  //     (botones, scroll, etc.) no deben cerrar.
-  //   - la topbar (.dash-top) — interacciones con filtros/toggle no
-  //     deben cerrar el drawer.
-  //
-  // Usamos `capture: false` (default) y dejamos que htmx procese sus
-  // hx-* primero; el handler de cierre solo dispara cuando el target no
-  // está dentro de las zonas "vivas".
-  document.addEventListener("click", function (e) {
+  // Click sobre el backdrop cierra el modal. Solo dispara si el target del
+  // click es directamente .modal-backdrop — clicks adentro de .modal (sobre
+  // el modal o cualquier hijo) no llegan acá porque el target es el hijo,
+  // no el backdrop. Esto es justo lo que queremos: solo el backdrop "vacío"
+  // cierra. No hace falta excluir explícitamente .card / .dash-top porque
+  // ninguno de esos coincide con .modal-backdrop como target.
+  document.body.addEventListener("click", function (e) {
     var t = e.target;
     if (!(t instanceof Element)) return;
-    if (t.closest(".card")) return;
-    if (t.closest("#drawer-slot")) return;
-    if (t.closest(".dash-top")) return;
-    closeDrawer();
+    if (t.classList && t.classList.contains("modal-backdrop")) {
+      closeModal();
+    }
   });
 
   // Countdown al próximo poll en el status-chip. El chip tiene data-last-ok-ms
@@ -98,23 +95,15 @@
     textEl.textContent = remaining > 0 ? "next in " + remaining + "s" : "polling…";
   }, 1000);
 
-  // Cuando htmx termina de swappear el drawer, sincronizamos data-selected
-  // con el id que vino del hx-trigger. Lo hacemos vía evento custom de htmx
-  // en vez de hx-on::after-request inline para que cards futuras (cuando el
-  // poller las re-renderice) no necesiten repetir el handler en cada tag.
+  // htmx:afterSwap — antes acá sincronizábamos body[data-selected] para
+  // pintar la card abierta. Sin highlight (con backdrop la selección visual
+  // sobra), el handler queda muy minimalista; lo dejamos por si en el futuro
+  // queremos engancharnos al swap del modal. Solo nos interesa cuando el
+  // target es #modal-slot.
   document.body.addEventListener("htmx:afterSwap", function (e) {
     if (!e.detail || !e.detail.target) return;
-    if (e.detail.target.id !== "drawer-slot") return;
-    var slot = e.detail.target;
-    // Si el swap dejó el slot vacío (caso /drawer/close) limpiamos selección.
-    if (!slot.innerHTML.trim()) {
-      document.body.removeAttribute("data-selected");
-      return;
-    }
-    // El partial de drawer setea data-entity en su root; lo levantamos.
-    var root = slot.querySelector("[data-entity]");
-    if (root && root.dataset.entity) {
-      document.body.dataset.selected = root.dataset.entity;
-    }
+    if (e.detail.target.id !== "modal-slot") return;
+    // No-op por ahora. Hook reservado para futuras integraciones (por
+    // ejemplo, focus management o analytics).
   });
 })();

--- a/internal/dash/templates/board.html.tmpl
+++ b/internal/dash/templates/board.html.tmpl
@@ -43,7 +43,7 @@
           <div class="card"
                data-entity="{{.IssueNumber}}"
                hx-get="/drawer/{{.IssueNumber}}"
-               hx-target="#drawer-slot"
+               hx-target="#modal-slot"
                hx-swap="innerHTML">
             {{if eq .Kind 1}}
               {{/* Fused: ref dual clickable (issue → PR). stopPropagation es

--- a/internal/dash/templates/dashboard.html.tmpl
+++ b/internal/dash/templates/dashboard.html.tmpl
@@ -123,10 +123,9 @@
   .status-chip.connecting { color: var(--muted); }
 
   /* ==================== Workspace layout ====================
-     Sin drawer abierto: una sola columna (board ocupa todo el ancho).
-     Con drawer: 1fr | 520px.
-     :has() está soportado por Safari/Chrome/Firefox modernos; el board sirve
-     como mockup local así que no nos preocupa IE/legacy. */
+     El board ocupa siempre todo el ancho; el detalle se muestra como modal
+     overlay sobre el board (ver bloque "Modal" más abajo) en vez de comprimir
+     la grilla con un sidebar. */
   .dash-workspace {
     flex: 1;
     display: grid;
@@ -134,11 +133,6 @@
     gap: 12px;
     min-height: 0;
   }
-  .dash-workspace:has(#drawer-slot .drawer) {
-    grid-template-columns: 1fr 520px;
-  }
-  /* drawer-slot vacío no debe ocupar ancho ni huecos visuales. */
-  #drawer-slot:empty { display: none; }
 
   /* ==================== Board ====================
      9 columnas (idea, planning, plan, executing, executed, validating,
@@ -219,9 +213,6 @@
     line-height: 1.4;
   }
   .card:hover { border-color: var(--border-muted); }
-  /* Highlight de la card seleccionada. body[data-selected] lo setea dash.js
-     después de que htmx swappea el drawer; el CSS hace el resto. */
-  body[data-selected] .card[data-entity] { /* placeholder para selectores específicos abajo */ }
 
   .card-breadcrumb {
     color: var(--muted);
@@ -281,24 +272,45 @@
   .card-breadcrumb .bc-size { color: var(--muted); }
   .card-breadcrumb .bc-sep  { color: var(--border-muted); margin: 0 2px; }
 
-  /* ==================== Drawer ==================== */
-  /* El drawer ahora puede tener tabs (fused) o ir directo al contenido
-     (issue-only). Usamos flex column en vez de grid fijo a 4 filas — el
-     pane-pr tiene su propio grid interno si hace falta, y el pane-issue
-     es una vista de body que puede scrollear. */
-  .drawer {
+  /* ==================== Modal ====================
+     El detalle de la entidad se muestra como modal overlay sobre el board
+     (no comprime la grilla). El backdrop semi-transparente cubre todo el
+     viewport; el modal queda centrado y tiene 90vw × 90vh con un tope de
+     1600px para no quedar gigantesco en monitores ultra wide. Cierre via
+     ESC o click sobre el backdrop (ver dash.js). */
+  .modal-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: 24px;
+  }
+  .modal {
+    width: 90vw;
+    height: 90vh;
+    max-width: 1600px;
     background: var(--panel);
-    border-radius: 6px;
+    border-radius: 8px;
     border: 1px solid var(--elevated);
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    min-height: 0;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
   }
-  /* Un pane del drawer ocupa todo el espacio restante y es su propio
+
+  /* ==================== Drawer ==================== */
+  /* "Drawer" hoy es el contenido interno del modal — el wrapper exterior es
+     .modal/.modal-backdrop pero las clases internas mantienen prefix
+     `drawer-` (drawer-hdr, drawer-meta, drawer-tabs, etc.) para minimizar
+     churn respecto a la versión sidebar. Puede tener tabs (fused) o ir
+     directo al contenido (issue-only). */
+  /* Un pane del modal ocupa todo el espacio restante y es su propio
      contenedor flex column para que el header quede fijo y los logs/body
      puedan scrollear. */
-  .drawer .pane {
+  .modal .pane {
     flex: 1;
     display: flex;
     flex-direction: column;
@@ -454,9 +466,10 @@
   }
 
   /* ==================== Drawer tabs (fused: PR | Issue) ====================
-     El toggle es via atributo data-tab en .drawer (pr|issue). Sin JS activo
-     el drawer arranca en "pr" (default en el template) — los selectores de
-     abajo ocultan el pane que no corresponde. */
+     El toggle es via atributo data-tab en .modal (pr|issue). Sin JS activo
+     el modal arranca en "pr" (default en el template) — los selectores de
+     abajo ocultan el pane que no corresponde. Las clases internas siguen
+     con prefix drawer-* para no churnear el resto del CSS. */
   .drawer-tabs {
     display: flex;
     gap: 4px;
@@ -475,13 +488,13 @@
     margin-bottom: -1px;
   }
   .drawer-tabs .tab:hover { color: var(--text); }
-  .drawer[data-tab="pr"] .tab-pr,
-  .drawer[data-tab="issue"] .tab-issue {
+  .modal[data-tab="pr"] .tab-pr,
+  .modal[data-tab="issue"] .tab-issue {
     color: var(--cyan);
     border-bottom-color: var(--cyan);
   }
-  .drawer[data-tab="pr"] .pane-issue { display: none; }
-  .drawer[data-tab="issue"] .pane-pr { display: none; }
+  .modal[data-tab="pr"] .pane-issue { display: none; }
+  .modal[data-tab="issue"] .pane-pr { display: none; }
 
   /* Cuerpo del tab Issue (y body al pie del issue-only). Scroll interno
      para que el body largo no rompa el alto del drawer. */
@@ -528,49 +541,18 @@
       {{template "board-columns" .}}
     </div>
 
-    <!-- ==== DRAWER (slot vacío al cargar; htmx lo llena al clickear una card) ==== -->
-    <div id="drawer-slot"></div>
+    <!-- ==== MODAL slot (vacío al cargar; htmx lo llena al clickear una card) ==== -->
+    {{/* El slot vive dentro del workspace por simplicidad, pero el modal
+         renderizado adentro tiene `position: fixed`, así que se posiciona
+         relativo al viewport (no al workspace). El slot vacío no ocupa
+         espacio porque su contenido es nada hasta que entra el partial. */}}
+    <div id="modal-slot"></div>
 
   </div>
 </div>
 
-<style>
-  /* Highlight de la card abierta. Generado dinámicamente por id no es
-     posible en CSS estático, así que usamos un selector de atributo
-     suficientemente específico. data-selected en body es seteado por
-     dash.js al recibir el htmx:afterSwap del drawer. */
-  body[data-selected] .card[data-entity] { /* base no-op, overridden vía JS abajo */ }
-</style>
-
 <script src="/static/htmx.min.js"></script>
 <script src="/static/dash.js"></script>
-<script>
-  // Highlight dinámico vía hoja de estilos inyectada cada vez que cambia
-  // body[data-selected]. Más simple que mantener una clase en la card.
-  (function () {
-    var styleEl = document.createElement("style");
-    document.head.appendChild(styleEl);
-    function syncHighlight() {
-      var sel = document.body.dataset.selected;
-      if (!sel) {
-        styleEl.textContent = "";
-        return;
-      }
-      // Escape básico — sel viene de un IssueNumber numérico, pero blindamos.
-      var safe = sel.replace(/[^0-9a-zA-Z_-]/g, "");
-      styleEl.textContent =
-        '.card[data-entity="' + safe + '"] {' +
-        '  border-color: var(--cyan);' +
-        '  box-shadow: 0 0 0 1px var(--cyan);' +
-        '}';
-    }
-    // MutationObserver sobre body[data-selected]. Más limpio que escuchar
-    // cada htmx:afterSwap y mantener dos handlers en sync.
-    var mo = new MutationObserver(syncHighlight);
-    mo.observe(document.body, { attributes: true, attributeFilter: ["data-selected"] });
-    syncHighlight();
-  })();
-</script>
 
 </body>
 </html>

--- a/internal/dash/templates/drawer.html.tmpl
+++ b/internal/dash/templates/drawer.html.tmpl
@@ -6,9 +6,12 @@
          issue original como contexto histórico.
        - Issue-only: vista única con el contenido actual + body al pie si lo hay.
 
-     Setea data-entity y data-tab en el root para que dash.js pueda sincronizar
-     body[data-selected] + togglear tabs delegando el click. */}}
-<div class="drawer" data-entity="{{.IssueNumber}}" data-tab="pr">
+     Wrapper externo: .modal-backdrop > .modal (overlay sobre el board, no
+     sidebar). Las clases internas mantienen prefix drawer-* para minimizar
+     churn — solo cambia el envoltorio. data-entity y data-tab viven en .modal
+     para que dash.js pueda togglear tabs delegando el click. */}}
+<div class="modal-backdrop">
+<div class="modal" data-entity="{{.IssueNumber}}" data-tab="pr">
 
   {{if eq .Kind 1}}
     {{/* ============= FUSED: tabs PR | Issue ============= */}}
@@ -27,7 +30,7 @@
           </div>
           <button class="drawer-close"
                   hx-get="/drawer/close"
-                  hx-target="#drawer-slot"
+                  hx-target="#modal-slot"
                   hx-swap="innerHTML"
                   title="cerrar (Esc)">×</button>
         </div>
@@ -111,7 +114,7 @@
           </div>
           <button class="drawer-close"
                   hx-get="/drawer/close"
-                  hx-target="#drawer-slot"
+                  hx-target="#modal-slot"
                   hx-swap="innerHTML"
                   title="cerrar (Esc)">×</button>
         </div>
@@ -137,7 +140,7 @@
         </div>
         <button class="drawer-close"
                 hx-get="/drawer/close"
-                hx-target="#drawer-slot"
+                hx-target="#modal-slot"
                 hx-swap="innerHTML"
                 title="cerrar (Esc)">×</button>
       </div>
@@ -206,4 +209,5 @@
     {{end}}
   {{end}}
 
+</div>
 </div>


### PR DESCRIPTION
## Summary

La card del board ahora abre un **modal centered** (90vw × 90vh, max-width 1600px) sobre un backdrop oscuro en vez del sidebar lateral de 520px que comprimia el board.

- ESC cierra (igual que antes).
- Click en el backdrop cierra.
- Click DENTRO del modal NO cierra.
- Quitado el highlight de la card seleccionada (no aplica con backdrop).

## Cambios estructurales

- `dashboard.html.tmpl`: workspace queda `1fr` siempre (eliminado el `:has()` que cambiaba a `1fr 520px`). Nuevo CSS `.modal-backdrop` / `.modal` con `position: fixed`.
- `drawer.html.tmpl`: wrapper raiz pasa a `.modal-backdrop > .modal`. Clases internas `drawer-*` intactas para reducir churn.
- `board.html.tmpl` + `drawer.html.tmpl`: `hx-target` apunta a `#modal-slot`.
- `dash.js`: `closeDrawer` → `closeModal`; click afuera reemplazado por `classList.contains('modal-backdrop')`; tab switcher busca `.modal` en vez de `.drawer`.
- `server.go`: endpoints `/drawer/{id}` y `/drawer/close` intactos por compat con tests; comentario aclara que renderean modal.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l internal/dash/` vacio
- [x] Smoke `dash --mock --no-open --port 7780`: `/drawer/42` devuelve `<div class="modal-backdrop"><div class="modal" data-entity="42" data-tab="pr">...`
- [ ] Smoke browser: ver modal abrir, ESC cerrar, click backdrop cerrar, click adentro NO cerrar
- [ ] Verificar que tabs PR/Issue siguen funcionando en fused

## Roadmap

PR 1/5 ✅ — labels API.
PR 2/5 ✅ — flows.
PR 3/5 ✅ — dash 9 columnas.
PR 4/5 ← (este).
PR 5/5 — TUI copy + memory updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)