### PR TITLE
chore(docs): cleanup status:* residual en comments + cmd descriptions (PR 5/5)

### DIFF
--- a/cmd/close.go
+++ b/cmd/close.go
@@ -31,7 +31,7 @@ var closeCmd = &cobra.Command{
      asociado y la branch local se limpian aparte. Usá --keep-branch para
      opt-out del delete.
   6. Cierra los issues asociados vía "Closes #N" del PR y les aplica la
-     transición de labels status:executed → status:closed.
+     transición de labels che:{executed|validated} → che:closing → che:closed.
 
 close REFUSE mergear si el PR tiene label validated:changes-requested o
 validated:needs-human (verdicts bloqueantes de che validate): exit 3.

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -15,13 +15,15 @@ var executeAgentFlag string
 
 var executeCmd = &cobra.Command{
 	Use:   "execute <issue-ref>",
-	Short: "ejecuta un issue en status:plan: worktree aislado + PR draft contra main",
-	Long: `execute toma la referencia a un issue ya explorado por 'che explore'
-(en status:plan, con ct:plan), parsea la sección "## Plan consolidado" de
-su body, abre un worktree aislado en .worktrees/issue-<N> sobre una branch
-exec/<N>-<slug>, invoca al agente para aplicar el plan, commitea los
-cambios, pushea la branch y abre/actualiza un PR draft contra main. Al
-terminar, transiciona el issue a status:executed.
+	Short: "ejecuta un issue en che:idea o che:plan: worktree aislado + PR draft contra main",
+	Long: `execute toma la referencia a un issue (con ct:plan) en che:idea o
+che:plan — explore es opcional. Si tiene plan consolidado en el body, lo
+parsea (sección "## Plan consolidado"); si no, el agente improvisa desde
+el body crudo. Abre un worktree aislado en .worktrees/issue-<N> sobre una
+branch exec/<N>-<slug>, invoca al agente para aplicar el plan, commitea
+los cambios, pushea la branch y abre/actualiza un PR draft contra main.
+Al terminar, transiciona el issue a che:executed (pasando por che:executing
+durante el run).
 
 Gate: execute NO corre si el issue tiene plan-validated:changes-requested
 o plan-validated:needs-human — esos labels los aplica 'che validate'

--- a/cmd/explore.go
+++ b/cmd/explore.go
@@ -21,7 +21,8 @@ artefactos:
   2. Un "plan consolidado" que se escribe en el body del issue — es lo
      que después lee 'che execute' al arrancar.
 
-Cuando termina, el issue transiciona de status:idea a status:plan.
+Cuando termina, el issue transiciona de che:idea a che:plan (pasando por
+che:planning durante el run).
 explore NO dispara validadores ni pausa el flow para input humano: la
 validación automática vive en 'che validate' como paso opt-in antes de
 ejecutar.

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -13,13 +13,15 @@ var validateValidatorsFlag string
 var validateCmd = &cobra.Command{
 	Use:   "validate <ref>",
 	Short: "valida un plan (issue) o un PR corriendo validadores (opus/codex/gemini) y postea findings como comments",
-	Long: `validate detecta automáticamente si <ref> apunta a un issue en status:plan
+	Long: `validate detecta automáticamente si <ref> apunta a un issue en che:plan
 o a un PR abierto, y despacha al modo correspondiente:
 
-  che validate 42       # issue en status:plan → valida el plan consolidado del body,
-                        #   postea comments en el issue y aplica plan-validated:*
-  che validate 7        # PR abierto → valida el diff, postea comments en el PR y
-                        #   aplica validated:*
+  che validate 42       # issue en che:plan → valida el plan consolidado del body,
+                        #   postea comments en el issue, aplica plan-validated:*
+                        #   y transiciona che:plan → che:validating → che:validated.
+  che validate 7        # PR abierto en che:executed → valida el diff, postea
+                        #   comments en el PR, aplica validated:* y transiciona
+                        #   che:executed → che:validating → che:validated.
 
 En ambos modos corren 1-3 validadores en paralelo (opus, codex, gemini);
 cada uno postea su análisis como un comment y al final se postea un comment

--- a/internal/flow/close/closing.go
+++ b/internal/flow/close/closing.go
@@ -316,7 +316,7 @@ func hasBlockingLabel(p validate.PullRequest) bool {
 //     merge: ese flag hace delete local también, que falla si la branch
 //     está checkouteada en un worktree y arrastra el exit code aunque el
 //     merge remoto haya ocurrido.
-//   - Cerrar issue asociado + transición de labels a status:closed.
+//   - Cerrar issue asociado + transición de labels a che:closed (vía che:closing).
 //   - Cleanup del worktree (ver shouldCleanupWorktree):
 //     · --keep-branch inhibe siempre, aunque el worktree sea propio del run.
 //     · happy path (merge OK): limpia el worktree asociado, sea propio o

--- a/internal/flow/validate/validate.go
+++ b/internal/flow/validate/validate.go
@@ -540,14 +540,14 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 	//     (typically porque alguien editó a mano o corrieron explore dos
 	//     veces). Acción del humano: limpiar el body.
 	//   - Plan parseado pero sin header real ni sub-secciones: el issue tiene
-	//     status:plan pero nunca se consolidó. Acción: correr explore.
+	//     che:plan pero nunca se consolidó. Acción: correr explore.
 	consolidated, parseErr := planpkg.Parse(issue.Body)
 	if parseErr != nil {
 		log.Error(fmt.Sprintf("no pude parsear el plan consolidado del issue #%d: %v", issue.Number, parseErr))
 		return ExitSemantic
 	}
 	if !planpkg.HasConsolidatedHeader(issue.Body) {
-		log.Error(fmt.Sprintf("issue #%d tiene status:plan pero no tiene plan consolidado en el body — corré `che explore %d`", issue.Number, issue.Number))
+		log.Error(fmt.Sprintf("issue #%d tiene che:plan pero no tiene plan consolidado en el body — corré `che explore %d`", issue.Number, issue.Number))
 		return ExitSemantic
 	}
 
@@ -853,7 +853,7 @@ func filterValidatable(raw []PullRequest) []Candidate {
 // el resto delegamos la validación a `gh pr view` / `gh issue view` (si el
 // ref es inválido, gh devuelve error y lo propagamos con contexto).
 //
-// `che validate` lo usa para ambos targets (issue en status:plan o PR); los
+// `che validate` lo usa para ambos targets (issue en che:plan o PR); los
 // flows PR-exclusive (iterate, close) siguen llamándolo — si el usuario
 // pasa un issue a esos, el preflight de `FetchPR` falla con un mensaje
 // claro.
@@ -1539,11 +1539,11 @@ PLAN CONSOLIDADO (parseado del body):
 // ---- list candidates (para TUI PR #6) ----
 
 // PlanCandidate es la vista mínima de un issue listo para validar como plan:
-// abierto, con status:plan, sin plan-validated:approve. La TUI lo consume
+// abierto, con che:plan, sin plan-validated:approve. La TUI lo consume
 // para poblar la lista "plans pending validation". Es un struct dedicado en
 // vez de reusar explore.Candidate porque el set de labels relevantes y los
 // filtros de exclusión son distintos (acá excluimos plan-validated:approve,
-// allá filtramos por ct:plan sin status).
+// allá filtramos por ct:plan sin che:*).
 type PlanCandidate struct {
 	Number int
 	Title  string

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -1,13 +1,13 @@
 // Package labels centraliza las constantes de los labels que che aplica sobre
 // issues de GitHub, y la máquina de transiciones entre estados. La idea es
-// tener un único lugar donde definir "qué es status:plan", "cómo se pasa de
-// status:plan a status:executing", etc., para que los distintos flows no
-// inventen strings distintas ni violen reglas de la máquina de estados.
+// tener un único lugar donde definir "qué es che:plan", "cómo se pasa de
+// che:plan a che:executing", etc., para que los distintos flows no inventen
+// strings distintas ni violen reglas de la máquina de estados.
 //
-// Coexiste con los helpers duplicados de `internal/flow/idea/idea.go` y
-// `internal/flow/explore/explore.go` durante la introducción de `execute`; la
-// deuda de extraer esos usos acá queda para un issue futuro (ver issue #6
-// "Fuera de alcance").
+// La máquina actual es de 9 estados con prefix `che:*`
+// (idea/planning/plan/executing/executed/validating/validated/closing/closed)
+// y reemplazó al modelo viejo `status:*` de 5 estados. El renombre in-place
+// de labels viejos vive en `cmd/migrate_labels.go`.
 package labels
 
 import (
@@ -251,7 +251,7 @@ func TransitionFor(from, to string) (Transition, error) {
 // existan en el repo antes de aplicar el edit: `gh issue edit --remove-label X`
 // falla con "not found" si X no está registrado en el repo — aunque el issue
 // no lo tenga aplicado. Esto cubre el caso de issues marcados con `ct:plan` a
-// mano que nunca pasaron por `che idea`, por lo que `status:idea` jamás se
+// mano que nunca pasaron por `che idea`, por lo que `che:idea` jamás se
 // creó en el repo.
 func Apply(ref, from, to string) error {
 	tr, err := TransitionFor(from, to)

--- a/internal/labels/lock.go
+++ b/internal/labels/lock.go
@@ -1,9 +1,10 @@
 // Package labels — archivo separado para el label "ortogonal" che:locked.
 //
-// A diferencia de los status:* que forman una máquina de estados (explore →
-// plan → executing → executed → closed), che:locked es un mutex simple on/off
-// aplicado al arrancar un flow y removido al terminar. No transiciona: el
-// flow lo aplica con Lock y lo saca con Unlock en un defer.
+// A diferencia de los che:* que forman una máquina de estados (idea →
+// planning → plan → executing → executed → validating → validated → closing
+// → closed), che:locked es un mutex simple on/off aplicado al arrancar un
+// flow y removido al terminar. No transiciona: el flow lo aplica con Lock y
+// lo saca con Unlock en un defer.
 //
 // El label sirve tanto para issues como para PRs: en la API REST de GitHub un
 // PR es un issue, así que el endpoint /repos/:o/:r/issues/:n/labels funciona


### PR DESCRIPTION
## Summary

Quinto y ultimo paso del refactor. Limpia las menciones residuales a `status:*` que quedaron en comentarios doc y descripciones largas de los subcomandos cobra:

- `cmd/close.go`, `cmd/execute.go`, `cmd/explore.go`, `cmd/validate.go`: `Long` descriptions actualizadas a la maquina `che:*` con mencion explicita de los transient states (planning/validating/closing).
- `internal/flow/close/closing.go`, `internal/flow/validate/validate.go`: comments doc + 1 mensaje de error visible al usuario.
- `internal/labels/labels.go`, `internal/labels/lock.go`: package docs describiendo la maquina de 9 estados `che:*`.

`cmd/execute.go` ademas refleja en la `Long` description que execute acepta `che:idea` o `che:plan` (skip explore valido), no solo `che:plan`.

Sin cambios funcionales. Las memorias del proyecto (`~/.claude/projects/...`) tambien se actualizaron en este step pero viven fuera del repo.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `gofmt -l` clean

## Roadmap

PR 1/5 ✅ — labels API.
PR 2/5 ✅ — flows.
PR 3/5 ✅ — dash 9 columnas.
PR 4/5 ✅ — modal.
PR 5/5 ← cierra el roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)