### PR TITLE
feat(tui): startup checks — stale labels + version + locks colgados

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,15 +10,27 @@ import (
 
 var Version = "dev"
 
+// noChecks deshabilita los chequeos secundarios del arranque de la TUI
+// (labels viejos / versión / locks colgados). Lo expone --no-checks
+// en root para que el usuario pueda saltearlos manualmente cuando no
+// quiere ruido o sabe que gh va a fallar (offline, sin auth, etc.).
+var noChecks bool
+
 var rootCmd = &cobra.Command{
 	Use:     "che",
 	Short:   "che - workflow estandarizado para trabajar con agentes de IA sobre issues de GitHub",
 	Long:    `che estandariza el embudo idea → explore → execute → close para reducir el miss rate de agentes de IA, usando GitHub como único estado.`,
 	Version: Version,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Sin args → abre la TUI interactiva.
-		return tui.Run(Version)
+		// Sin args → abre la TUI interactiva. --no-checks deshabilita
+		// los chequeos del arranque.
+		return tui.Run(Version, !noChecks)
 	},
+}
+
+func init() {
+	rootCmd.PersistentFlags().BoolVar(&noChecks, "no-checks", false,
+		"deshabilita los chequeos del arranque de la TUI (labels viejos / versión / locks)")
 }
 
 func Execute() {

--- a/internal/startup/checks.go
+++ b/internal/startup/checks.go
@@ -1,0 +1,346 @@
+package startup
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Nombres canónicos de los chequeos. Se usan tanto como ID para
+// IsSkipped/MarkSkipped como key para identificar resultados.
+const (
+	CheckMigrateLabels = "migrate-labels"
+	CheckVersion       = "version"
+	CheckLocks         = "locks"
+)
+
+// oldStatusLabels enumera los labels del modelo viejo `status:*` que
+// `che migrate-labels` renombra a `che:*`. Si encontramos cualquiera
+// de estos en el repo, el check de labels triggerea.
+//
+// Importante: estos strings viven duplicados con cmd/migrate_labels.go
+// a propósito — son input de migración, no constantes runtime, y el
+// paquete startup no debería depender del paquete cmd (ciclo de
+// imports y acoplamiento innecesario).
+var oldStatusLabels = []string{
+	"status:idea",
+	"status:plan",
+	"status:executing",
+	"status:executed",
+	"status:closed",
+}
+
+// staleLockThreshold es el umbral por encima del cual consideramos que
+// un che:locked está "colgado". Una hora cubre con margen el peor caso
+// real (ejecutar un agente largo) sin warnar por flows en curso.
+const staleLockThreshold = time.Hour
+
+// LockedItem describe un issue/PR lockeado que el check de locks
+// devuelve. Reutiliza el mismo shape que internal/labels.LockedRef pero
+// duplicado acá para no acoplar paquetes (el paquete startup no debería
+// depender de labels y viceversa).
+type LockedItem struct {
+	Number    int
+	Title     string
+	IsPR      bool
+	UpdatedAt time.Time
+}
+
+// Result describe el resultado de UN chequeo. Triggered=true significa
+// "encontramos algo que mostrar al usuario"; en false el banner ignora
+// este resultado completamente. Si Err != nil el check falló (ej. gh
+// sin auth) y la TUI también lo ignora — los chequeos son secundarios.
+type Result struct {
+	Name      string
+	Triggered bool
+	Err       error
+
+	// Campos específicos por tipo de chequeo. Solo se leen cuando
+	// Triggered==true. Mantenemos el shape plano (sin interface{}) para
+	// que el render de la TUI no tenga que hacer type asserts.
+
+	// migrate-labels:
+	OldLabels []string
+
+	// version:
+	CurrentVersion string
+	LatestVersion  string
+
+	// locks:
+	Locks []LockedItem
+}
+
+// Runner es la abstracción inyectable para correr `gh`. En producción
+// usa exec.CommandContext; los tests inyectan una implementación que
+// devuelve outputs scripted sin tocar la red ni el filesystem.
+type Runner interface {
+	Run(ctx context.Context, name string, args ...string) ([]byte, error)
+}
+
+// execRunner es la implementación default que ejecuta procesos reales
+// con exec.CommandContext. Respeta el ctx para timeouts.
+type execRunner struct{}
+
+func (execRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return out, fmt.Errorf("%s %s: %s", name, strings.Join(args, " "), strings.TrimSpace(string(ee.Stderr)))
+		}
+		return out, err
+	}
+	return out, nil
+}
+
+// Options agrupa lo que necesita RunChecks: el repo donde estamos
+// (para IsSkipped, y como guard de "estoy en un repo git"), la versión
+// actual del binario, el runner inyectable, y un timeout total. Con
+// Runner=nil usa el runner default (exec real).
+type Options struct {
+	RepoRoot       string
+	CurrentVersion string
+	Runner         Runner
+	Timeout        time.Duration
+}
+
+// RunChecks ejecuta los 3 chequeos en paralelo, respeta el timeout
+// total (los que no completan a tiempo se marcan como no-triggered y
+// se siguen), y devuelve los resultados en orden canónico
+// (migrate-labels, version, locks). Skipea silenciosamente los
+// chequeos marcados como "nunca para este repo" en el persistence
+// file. Si no hay `.git/`, devuelve nil sin correr nada.
+func RunChecks(ctx context.Context, opts Options) []Result {
+	if !HasGitDir(opts.RepoRoot) {
+		return nil
+	}
+	runner := opts.Runner
+	if runner == nil {
+		runner = execRunner{}
+	}
+	timeout := opts.Timeout
+	if timeout <= 0 {
+		timeout = 3 * time.Second
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	type job struct {
+		name string
+		fn   func(context.Context, Runner) Result
+	}
+	jobs := []job{
+		{CheckMigrateLabels, checkMigrateLabels},
+		{CheckVersion, func(ctx context.Context, r Runner) Result {
+			return checkVersion(ctx, r, opts.CurrentVersion)
+		}},
+		{CheckLocks, checkLocks},
+	}
+
+	results := make([]Result, len(jobs))
+	done := make(chan struct{}, len(jobs))
+
+	for i, j := range jobs {
+		i, j := i, j
+		// Skip persisted: marcamos como no-triggered sin correr la
+		// función. El array preserva el orden por índice.
+		if IsSkipped(opts.RepoRoot, j.name) {
+			results[i] = Result{Name: j.name}
+			done <- struct{}{}
+			continue
+		}
+		go func() {
+			defer func() {
+				// Cualquier panic en un check secundario no debe romper
+				// la TUI: capturamos y marcamos como error silencioso.
+				if r := recover(); r != nil {
+					results[i] = Result{Name: j.name, Err: fmt.Errorf("panic: %v", r)}
+				}
+				done <- struct{}{}
+			}()
+			results[i] = j.fn(ctx, runner)
+		}()
+	}
+
+	// Esperar a todos o al timeout. Si el timeout se dispara, los
+	// goroutines siguen corriendo en background — bonito pero no
+	// crítico: exec.CommandContext mata el subproceso cuando el ctx
+	// se cancela, así que no hay leak de procesos. La goroutine en
+	// sí puede completar tarde, pero como el array ya quedó con su
+	// zero value (Result{}, no triggered), su escritura tardía no
+	// afecta a la UI (que ya leyó el snapshot).
+	for i := 0; i < len(jobs); i++ {
+		select {
+		case <-done:
+		case <-ctx.Done():
+			// Timeout: devolvemos lo que tengamos (los slots no
+			// completos quedan como Result{} = no triggered).
+			return results
+		}
+	}
+	return results
+}
+
+// ---- Implementaciones de cada chequeo ----
+
+// checkMigrateLabels lista los labels del repo con `gh label list
+// --search "status:"` y filtra exact-match contra los 5 status:* del
+// modelo viejo. Si encuentra ≥1, triggerea.
+func checkMigrateLabels(ctx context.Context, runner Runner) Result {
+	res := Result{Name: CheckMigrateLabels}
+	out, err := runner.Run(ctx, "gh", "label", "list",
+		"--search", "status:",
+		"--json", "name",
+		"--limit", "100",
+	)
+	if err != nil {
+		res.Err = err
+		return res
+	}
+	var list []struct {
+		Name string `json:"name"`
+	}
+	if jerr := json.Unmarshal(out, &list); jerr != nil {
+		res.Err = jerr
+		return res
+	}
+	old := map[string]bool{}
+	for _, n := range oldStatusLabels {
+		old[n] = true
+	}
+	var found []string
+	seen := map[string]bool{}
+	for _, l := range list {
+		if old[l.Name] && !seen[l.Name] {
+			found = append(found, l.Name)
+			seen[l.Name] = true
+		}
+	}
+	sort.Strings(found)
+	if len(found) > 0 {
+		res.Triggered = true
+		res.OldLabels = found
+	}
+	return res
+}
+
+// checkVersion compara la versión del binario contra la última release
+// publicada en GitHub. Skipea si CurrentVersion=="dev" (build local).
+// Compara como strings tras normalizar el prefijo "v" para tolerar
+// tags con o sin él.
+func checkVersion(ctx context.Context, runner Runner, current string) Result {
+	res := Result{Name: CheckVersion, CurrentVersion: current}
+	if current == "" || current == "dev" {
+		// Build local: nunca triggereamos.
+		return res
+	}
+	out, err := runner.Run(ctx, "gh", "release", "view",
+		"--repo", "chichex/che",
+		"--json", "tagName",
+		"--jq", ".tagName",
+	)
+	if err != nil {
+		res.Err = err
+		return res
+	}
+	latest := strings.TrimSpace(string(out))
+	res.LatestVersion = latest
+	if latest == "" {
+		// Respuesta vacía: no triggereamos.
+		return res
+	}
+	if normalizeVersion(current) != normalizeVersion(latest) {
+		res.Triggered = true
+	}
+	return res
+}
+
+// normalizeVersion saca el prefijo "v" para comparar tags. Duplicado a
+// propósito desde cmd/upgrade.go — no queremos que el paquete startup
+// dependa de cmd.
+func normalizeVersion(v string) string {
+	return strings.TrimPrefix(strings.TrimSpace(v), "v")
+}
+
+// checkLocks lista issues/PRs con label che:locked en el repo actual y
+// filtra los que llevan más de staleLockThreshold sin actualizarse. Si
+// encuentra ≥1, triggerea con la lista para mostrar.
+//
+// Acota la búsqueda al repo actual via `repo:owner/name` query (gh
+// search issues no acepta --repo). Si no podemos resolver el repo
+// (ej. fuera de un repo git, o gh no auth), degrada silenciosamente
+// y reporta error sin triggerear.
+func checkLocks(ctx context.Context, runner Runner) Result {
+	res := Result{Name: CheckLocks}
+	nwo, err := runner.Run(ctx, "gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner")
+	if err != nil {
+		res.Err = err
+		return res
+	}
+	repo := strings.TrimSpace(string(nwo))
+	if repo == "" {
+		res.Err = errors.New("nameWithOwner vacío")
+		return res
+	}
+	out, err := runner.Run(ctx, "gh", "search", "issues",
+		"repo:"+repo,
+		"label:che:locked",
+		"state:open",
+		"--json", "number,title,updatedAt,isPullRequest",
+		"--limit", "100",
+	)
+	if err != nil {
+		res.Err = err
+		return res
+	}
+	var raw []struct {
+		Number        int    `json:"number"`
+		Title         string `json:"title"`
+		UpdatedAt     string `json:"updatedAt"`
+		IsPullRequest bool   `json:"isPullRequest"`
+	}
+	if jerr := json.Unmarshal(out, &raw); jerr != nil {
+		res.Err = jerr
+		return res
+	}
+	now := time.Now()
+	var stale []LockedItem
+	for _, r := range raw {
+		t, perr := time.Parse(time.RFC3339, r.UpdatedAt)
+		if perr != nil {
+			// Fecha rota: la ignoramos. No queremos romper el check.
+			continue
+		}
+		if now.Sub(t) <= staleLockThreshold {
+			continue
+		}
+		stale = append(stale, LockedItem{
+			Number:    r.Number,
+			Title:     r.Title,
+			IsPR:      r.IsPullRequest,
+			UpdatedAt: t,
+		})
+	}
+	if len(stale) > 0 {
+		res.Triggered = true
+		res.Locks = stale
+	}
+	return res
+}
+
+// AnyTriggered devuelve true si al menos un Result en results está
+// triggered. Helper para el caller (la TUI) — evita filtrar en la mano.
+func AnyTriggered(results []Result) bool {
+	for _, r := range results {
+		if r.Triggered {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/startup/checks_test.go
+++ b/internal/startup/checks_test.go
@@ -1,0 +1,346 @@
+package startup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeRunner es un Runner inyectable para tests. Cada call matchea por
+// un substring del comando completo (name + args concatenados con
+// espacios). Si no matchea ningún script, devuelve un error explícito —
+// los tests fallan loudly si invocan algo no scripted.
+type fakeRunner struct {
+	mu      sync.Mutex
+	scripts []fakeScript
+	calls   []string
+	// blockUntil bloquea TODAS las calls hasta que este channel se
+	// cierre. Útil para simular timeouts.
+	blockUntil <-chan struct{}
+}
+
+type fakeScript struct {
+	matchSubstr string
+	stdout      []byte
+	err         error
+}
+
+func (f *fakeRunner) Run(ctx context.Context, name string, args ...string) ([]byte, error) {
+	full := name + " " + strings.Join(args, " ")
+	f.mu.Lock()
+	f.calls = append(f.calls, full)
+	scripts := append([]fakeScript(nil), f.scripts...)
+	block := f.blockUntil
+	f.mu.Unlock()
+
+	if block != nil {
+		select {
+		case <-block:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	for _, s := range scripts {
+		if strings.Contains(full, s.matchSubstr) {
+			return s.stdout, s.err
+		}
+	}
+	return nil, fmt.Errorf("fakeRunner: no matcher for %q", full)
+}
+
+func TestCheckMigrateLabels_DetectaLabelsViejos(t *testing.T) {
+	r := &fakeRunner{
+		scripts: []fakeScript{{
+			matchSubstr: "label list",
+			stdout: []byte(`[
+				{"name":"status:idea"},
+				{"name":"status:plan"},
+				{"name":"status:foobar"}
+			]`),
+		}},
+	}
+	res := checkMigrateLabels(context.Background(), r)
+	if !res.Triggered {
+		t.Fatalf("debería triggerear con status:idea presente")
+	}
+	if len(res.OldLabels) != 2 {
+		t.Errorf("debería encontrar 2 (idea, plan), got %v", res.OldLabels)
+	}
+}
+
+func TestCheckMigrateLabels_NoTriggereaSinLabelsViejos(t *testing.T) {
+	r := &fakeRunner{
+		scripts: []fakeScript{{
+			matchSubstr: "label list",
+			stdout:      []byte(`[]`),
+		}},
+	}
+	res := checkMigrateLabels(context.Background(), r)
+	if res.Triggered {
+		t.Errorf("no debería triggerear con lista vacía")
+	}
+	if res.Err != nil {
+		t.Errorf("no debería haber error, got %v", res.Err)
+	}
+}
+
+func TestCheckMigrateLabels_GhFallaEsSilencioso(t *testing.T) {
+	r := &fakeRunner{
+		scripts: []fakeScript{{
+			matchSubstr: "label list",
+			err:         errors.New("gh: not authenticated"),
+		}},
+	}
+	res := checkMigrateLabels(context.Background(), r)
+	if res.Triggered {
+		t.Errorf("error de gh no debería triggerear el check")
+	}
+	if res.Err == nil {
+		t.Errorf("Err debería propagarse para que el caller pueda loggear")
+	}
+}
+
+func TestCheckVersion_SkipDev(t *testing.T) {
+	r := &fakeRunner{}
+	res := checkVersion(context.Background(), r, "dev")
+	if res.Triggered {
+		t.Errorf("dev nunca debería triggerear (build local)")
+	}
+	if len(r.calls) != 0 {
+		t.Errorf("dev no debería llamar a gh, got calls=%v", r.calls)
+	}
+}
+
+func TestCheckVersion_SkipVersionVacia(t *testing.T) {
+	r := &fakeRunner{}
+	res := checkVersion(context.Background(), r, "")
+	if res.Triggered {
+		t.Errorf("version vacía no debería triggerear")
+	}
+	if len(r.calls) != 0 {
+		t.Errorf("version vacía no debería llamar a gh")
+	}
+}
+
+func TestCheckVersion_TriggereaSiHayMasNueva(t *testing.T) {
+	r := &fakeRunner{
+		scripts: []fakeScript{{
+			matchSubstr: "release view",
+			stdout:      []byte("v0.0.50\n"),
+		}},
+	}
+	res := checkVersion(context.Background(), r, "0.0.49")
+	if !res.Triggered {
+		t.Errorf("0.0.49 vs v0.0.50 debería triggerear")
+	}
+	if res.LatestVersion != "v0.0.50" {
+		t.Errorf("LatestVersion mal: got %q", res.LatestVersion)
+	}
+}
+
+func TestCheckVersion_NoTriggereaSiCoinciden(t *testing.T) {
+	r := &fakeRunner{
+		scripts: []fakeScript{{
+			matchSubstr: "release view",
+			stdout:      []byte("v0.0.49"),
+		}},
+	}
+	res := checkVersion(context.Background(), r, "0.0.49")
+	if res.Triggered {
+		t.Errorf("0.0.49 == v0.0.49 (normalizado) no debería triggerear")
+	}
+}
+
+func TestCheckVersion_GhFallaEsSilencioso(t *testing.T) {
+	r := &fakeRunner{
+		scripts: []fakeScript{{
+			matchSubstr: "release view",
+			err:         errors.New("gh: rate limited"),
+		}},
+	}
+	res := checkVersion(context.Background(), r, "0.0.49")
+	if res.Triggered {
+		t.Errorf("error de gh no debería triggerear el check")
+	}
+}
+
+func TestCheckLocks_FiltraPorAntiguedad(t *testing.T) {
+	old := time.Now().Add(-2 * time.Hour).UTC().Format(time.RFC3339)
+	recent := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	body := fmt.Sprintf(`[
+		{"number":42,"title":"viejo","updatedAt":%q,"isPullRequest":false},
+		{"number":55,"title":"reciente","updatedAt":%q,"isPullRequest":true}
+	]`, old, recent)
+	r := &fakeRunner{
+		scripts: []fakeScript{
+			{matchSubstr: "repo view", stdout: []byte("chichex/che\n")},
+			{matchSubstr: "search issues", stdout: []byte(body)},
+		},
+	}
+	res := checkLocks(context.Background(), r)
+	if !res.Triggered {
+		t.Fatalf("debería triggerear (1 stale)")
+	}
+	if len(res.Locks) != 1 {
+		t.Fatalf("debería haber 1 lock stale, got %d", len(res.Locks))
+	}
+	if res.Locks[0].Number != 42 {
+		t.Errorf("debería ser #42 (el viejo), got #%d", res.Locks[0].Number)
+	}
+}
+
+func TestCheckLocks_NoTriggereaSinStale(t *testing.T) {
+	recent := time.Now().Add(-10 * time.Minute).UTC().Format(time.RFC3339)
+	body := fmt.Sprintf(`[
+		{"number":42,"title":"reciente","updatedAt":%q,"isPullRequest":false}
+	]`, recent)
+	r := &fakeRunner{
+		scripts: []fakeScript{
+			{matchSubstr: "repo view", stdout: []byte("chichex/che")},
+			{matchSubstr: "search issues", stdout: []byte(body)},
+		},
+	}
+	res := checkLocks(context.Background(), r)
+	if res.Triggered {
+		t.Errorf("locks recientes no deberían triggerear")
+	}
+}
+
+func TestCheckLocks_GhFallaEsSilencioso(t *testing.T) {
+	r := &fakeRunner{
+		scripts: []fakeScript{
+			{matchSubstr: "repo view", stdout: []byte("chichex/che")},
+			{matchSubstr: "search issues", err: errors.New("gh down")},
+		},
+	}
+	res := checkLocks(context.Background(), r)
+	if res.Triggered {
+		t.Errorf("error de gh no debería triggerear")
+	}
+}
+
+func TestCheckLocks_FallaEnRepoView(t *testing.T) {
+	r := &fakeRunner{
+		scripts: []fakeScript{
+			{matchSubstr: "repo view", err: errors.New("gh: no auth")},
+		},
+	}
+	res := checkLocks(context.Background(), r)
+	if res.Triggered {
+		t.Errorf("falla en repo view no debería triggerear")
+	}
+	if res.Err == nil {
+		t.Errorf("Err debería propagarse")
+	}
+}
+
+func TestRunChecks_OrdenCanonico(t *testing.T) {
+	repo := makeRepo(t)
+	r := &fakeRunner{
+		scripts: []fakeScript{
+			{matchSubstr: "label list", stdout: []byte(`[]`)},
+			{matchSubstr: "release view", stdout: []byte("v0.0.49")},
+			{matchSubstr: "repo view", stdout: []byte("chichex/che")},
+			{matchSubstr: "search issues", stdout: []byte(`[]`)},
+		},
+	}
+	results := RunChecks(context.Background(), Options{
+		RepoRoot:       repo,
+		CurrentVersion: "0.0.49",
+		Runner:         r,
+		Timeout:        2 * time.Second,
+	})
+	if len(results) != 3 {
+		t.Fatalf("esperaba 3 resultados, got %d", len(results))
+	}
+	wantNames := []string{CheckMigrateLabels, CheckVersion, CheckLocks}
+	for i, name := range wantNames {
+		if results[i].Name != name {
+			t.Errorf("results[%d].Name: got %q, want %q", i, results[i].Name, name)
+		}
+	}
+}
+
+func TestRunChecks_SinGitDirDevuelveNil(t *testing.T) {
+	dir := t.TempDir() // sin .git
+	results := RunChecks(context.Background(), Options{
+		RepoRoot:       dir,
+		CurrentVersion: "0.0.49",
+		Runner:         &fakeRunner{},
+	})
+	if results != nil {
+		t.Errorf("sin .git debería devolver nil, got %v", results)
+	}
+}
+
+func TestRunChecks_RespetaSkipped(t *testing.T) {
+	repo := makeRepo(t)
+	if err := MarkSkipped(repo, CheckVersion); err != nil {
+		t.Fatalf("MarkSkipped: %v", err)
+	}
+	r := &fakeRunner{
+		scripts: []fakeScript{
+			{matchSubstr: "label list", stdout: []byte(`[]`)},
+			{matchSubstr: "repo view", stdout: []byte("chichex/che")},
+			{matchSubstr: "search issues", stdout: []byte(`[]`)},
+		},
+	}
+	results := RunChecks(context.Background(), Options{
+		RepoRoot:       repo,
+		CurrentVersion: "0.0.49",
+		Runner:         r,
+		Timeout:        2 * time.Second,
+	})
+	// Buscamos que la call al check de version no se haya hecho.
+	for _, c := range r.calls {
+		if strings.Contains(c, "release view") {
+			t.Errorf("version skipeado no debería llamar a 'release view': %v", r.calls)
+		}
+	}
+	// El slot de version sigue ahí pero como no-triggered.
+	for _, res := range results {
+		if res.Name == CheckVersion && res.Triggered {
+			t.Errorf("check skipeado no debería triggerear")
+		}
+	}
+}
+
+func TestRunChecks_TimeoutNoRompe(t *testing.T) {
+	repo := makeRepo(t)
+	block := make(chan struct{})
+	defer close(block)
+	r := &fakeRunner{blockUntil: block}
+	results := RunChecks(context.Background(), Options{
+		RepoRoot:       repo,
+		CurrentVersion: "0.0.49",
+		Runner:         r,
+		Timeout:        50 * time.Millisecond,
+	})
+	// Esperamos retornar dentro del timeout sin panic. Los resultados
+	// pueden estar vacíos o parciales — lo importante es que no rompa.
+	if len(results) != 3 {
+		t.Errorf("debería devolver 3 slots aunque haya timeout, got %d", len(results))
+	}
+	for _, res := range results {
+		if res.Triggered {
+			t.Errorf("nada debería triggerear si todo timeouteó: %+v", res)
+		}
+	}
+}
+
+func TestAnyTriggered(t *testing.T) {
+	if AnyTriggered(nil) {
+		t.Errorf("nil no debería triggerear")
+	}
+	if AnyTriggered([]Result{{Triggered: false}, {Triggered: false}}) {
+		t.Errorf("ningún triggered → false")
+	}
+	if !AnyTriggered([]Result{{Triggered: false}, {Triggered: true}}) {
+		t.Errorf("uno triggered → true")
+	}
+}

--- a/internal/startup/persistence.go
+++ b/internal/startup/persistence.go
@@ -1,0 +1,109 @@
+// Package startup implementa los chequeos secundarios que la TUI corre
+// antes de mostrar el menú principal: labels viejos sin migrar, versión
+// desactualizada y locks colgados.
+//
+// El paquete es "secundario" en el sentido de que jamás debe romper la
+// TUI: cualquier fallo (gh sin red, sin auth, repo no inicializado) se
+// degrada a "este check no triggerea" en silencio. La TUI sigue siendo
+// usable aunque los chequeos exploten.
+package startup
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// skipFileName es el nombre del archivo que persiste qué chequeos se
+// skipean para siempre en este repo. Vive en `.git/` para quedar fuera
+// del tracking sin necesidad de tocar `.gitignore`.
+const skipFileName = "che-skip-checks"
+
+// IsSkipped devuelve true si el chequeo `checkName` está marcado como
+// "nunca para este repo" en el archivo `.git/che-skip-checks` del repo
+// dado. `repoRoot` es el path absoluto del working dir del repo (donde
+// vive `.git/`); si no existe `.git/` o el archivo, devuelve false sin
+// error — no encontramos persistencia, asumimos que no está skipeado.
+func IsSkipped(repoRoot, checkName string) bool {
+	if repoRoot == "" || checkName == "" {
+		return false
+	}
+	path := skipFilePath(repoRoot)
+	f, err := os.Open(path)
+	if err != nil {
+		// Sin archivo (o sin permisos) → no skipeado. No queremos romper
+		// la TUI por un check secundario.
+		return false
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if line == checkName {
+			return true
+		}
+	}
+	return false
+}
+
+// MarkSkipped agrega `checkName` al archivo `.git/che-skip-checks` del
+// repo. Idempotente: si el chequeo ya está, no duplica la línea. Si el
+// archivo no existe, lo crea. Si `.git/` no existe (estamos fuera de un
+// repo git) devuelve un error explícito — el caller debería no haber
+// llegado hasta acá.
+func MarkSkipped(repoRoot, checkName string) error {
+	if repoRoot == "" {
+		return errors.New("repoRoot vacío")
+	}
+	if checkName == "" {
+		return errors.New("checkName vacío")
+	}
+	gitDir := filepath.Join(repoRoot, ".git")
+	if info, err := os.Stat(gitDir); err != nil || !info.IsDir() {
+		return errors.New(".git no existe en " + repoRoot)
+	}
+
+	// Si ya está, no-op.
+	if IsSkipped(repoRoot, checkName) {
+		return nil
+	}
+
+	path := skipFilePath(repoRoot)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(checkName + "\n"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// skipFilePath devuelve el path absoluto del archivo de persistencia
+// (`<repoRoot>/.git/che-skip-checks`).
+func skipFilePath(repoRoot string) string {
+	return filepath.Join(repoRoot, ".git", skipFileName)
+}
+
+// HasGitDir devuelve true si `repoRoot` contiene un directorio `.git/`.
+// Sirve como guard para los callers (ej. la TUI) que necesitan saber si
+// estamos dentro de un repo git antes de correr chequeos. Tolerante:
+// devuelve false en cualquier error de stat (sin permisos, etc.).
+func HasGitDir(repoRoot string) bool {
+	if repoRoot == "" {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(repoRoot, ".git"))
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}

--- a/internal/startup/persistence_test.go
+++ b/internal/startup/persistence_test.go
@@ -1,0 +1,140 @@
+package startup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// makeRepo crea un tmpdir con un `.git/` adentro y devuelve el path.
+// Útil para los tests que necesitan un "repo válido".
+func makeRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, ".git"), 0o700); err != nil {
+		t.Fatalf("creando .git: %v", err)
+	}
+	return dir
+}
+
+func TestIsSkipped_ArchivoNoExiste(t *testing.T) {
+	repo := makeRepo(t)
+	if IsSkipped(repo, "version") {
+		t.Errorf("archivo inexistente no debería marcar nada skipeado")
+	}
+}
+
+func TestIsSkipped_ChequeoMarcado(t *testing.T) {
+	repo := makeRepo(t)
+	if err := MarkSkipped(repo, "version"); err != nil {
+		t.Fatalf("MarkSkipped: %v", err)
+	}
+	if !IsSkipped(repo, "version") {
+		t.Errorf("version debería aparecer skipeado")
+	}
+	if IsSkipped(repo, "locks") {
+		t.Errorf("locks no debería estar skipeado todavía")
+	}
+}
+
+func TestMarkSkipped_Idempotente(t *testing.T) {
+	repo := makeRepo(t)
+	if err := MarkSkipped(repo, "version"); err != nil {
+		t.Fatalf("MarkSkipped 1: %v", err)
+	}
+	if err := MarkSkipped(repo, "version"); err != nil {
+		t.Fatalf("MarkSkipped 2: %v", err)
+	}
+	// Lectura debe seguir devolviendo true (no se duplicó la línea de
+	// forma que rompa el parser).
+	if !IsSkipped(repo, "version") {
+		t.Errorf("debería seguir skipeado tras dos MarkSkipped")
+	}
+	// Verificamos que el archivo solo tiene una línea relevante.
+	data, err := os.ReadFile(filepath.Join(repo, ".git", skipFileName))
+	if err != nil {
+		t.Fatalf("leyendo archivo: %v", err)
+	}
+	count := 0
+	for _, line := range splitLines(string(data)) {
+		if line == "version" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("la línea 'version' debería aparecer 1 vez, got %d", count)
+	}
+}
+
+func TestMarkSkipped_VariosChequeos(t *testing.T) {
+	repo := makeRepo(t)
+	if err := MarkSkipped(repo, "migrate-labels"); err != nil {
+		t.Fatalf("mark migrate: %v", err)
+	}
+	if err := MarkSkipped(repo, "version"); err != nil {
+		t.Fatalf("mark version: %v", err)
+	}
+	if !IsSkipped(repo, "migrate-labels") || !IsSkipped(repo, "version") {
+		t.Errorf("ambos deberían estar skipeados")
+	}
+	if IsSkipped(repo, "locks") {
+		t.Errorf("locks no debería estar skipeado")
+	}
+}
+
+func TestMarkSkipped_SinGit(t *testing.T) {
+	dir := t.TempDir() // sin `.git`
+	err := MarkSkipped(dir, "version")
+	if err == nil {
+		t.Errorf("MarkSkipped sin .git debería devolver error")
+	}
+}
+
+func TestIsSkipped_ToleraComentariosYBlancos(t *testing.T) {
+	repo := makeRepo(t)
+	path := filepath.Join(repo, ".git", skipFileName)
+	body := "# comentario\n\nversion\n  \nlocks\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if !IsSkipped(repo, "version") {
+		t.Errorf("version debería estar skipeado")
+	}
+	if !IsSkipped(repo, "locks") {
+		t.Errorf("locks debería estar skipeado")
+	}
+	if IsSkipped(repo, "comentario") {
+		t.Errorf("comentario no debería contar como skip")
+	}
+}
+
+func TestHasGitDir(t *testing.T) {
+	repo := makeRepo(t)
+	if !HasGitDir(repo) {
+		t.Errorf("repo con .git debería devolver true")
+	}
+	if HasGitDir(t.TempDir()) {
+		t.Errorf("dir sin .git debería devolver false")
+	}
+	if HasGitDir("") {
+		t.Errorf("path vacío debería devolver false")
+	}
+}
+
+// splitLines parte un string por '\n' sin importar trailing newline.
+func splitLines(s string) []string {
+	var out []string
+	cur := ""
+	for _, r := range s {
+		if r == '\n' {
+			out = append(out, cur)
+			cur = ""
+			continue
+		}
+		cur += string(r)
+	}
+	if cur != "" {
+		out = append(out, cur)
+	}
+	return out
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -28,12 +28,16 @@ import (
 	"github.com/chichex/che/internal/flow/validate"
 	"github.com/chichex/che/internal/labels"
 	"github.com/chichex/che/internal/output"
+	"github.com/chichex/che/internal/startup"
 )
 
 type screen int
 
 const (
 	screenMenu screen = iota
+	screenStartupChecksLoading
+	screenStartupChecks
+	screenStartupChecksRunning
 	screenIdeaInput
 	screenIdeaRunning
 	screenExploreLoading
@@ -289,6 +293,19 @@ type Model struct {
 	// paralelo). El menú lo usa para mostrar "Última: <flow> #<ref> …"
 	// y pre-posicionar el cursor en el próximo paso sugerido.
 	lastAction *lastAction
+
+	// startupChecks guarda el subset de Results que triggerearon en el
+	// arranque. La pantalla screenStartupChecks itera sobre ellos uno
+	// por uno (startupCursor avanza con cada respuesta del usuario).
+	// Una vez vacío o consumido, la TUI transiciona a screenMenu.
+	//
+	// repoRoot es el path absoluto del cwd al arranque — lo usamos
+	// para MarkSkipped sin re-detectar (evita inconsistencias si el
+	// usuario cambia de directorio en otra terminal mientras la TUI
+	// está abierta).
+	startupChecks   []startup.Result
+	startupCursor   int
+	startupRepoRoot string
 }
 
 // lastAction captura qué hizo el usuario por última vez en esta sesión.
@@ -321,7 +338,27 @@ const (
 // el binario (ej. "0.0.8"). El repo y la branch se detectan en el momento.
 // ctx es el context raíz (cancelable por señal); si es nil, se usa
 // context.Background() — los tests de snapshot del model no lo necesitan.
+//
+// Equivalente a NewWithOptions con runStartupChecks=true. Mantenemos la
+// firma para callers viejos / tests; el toggle real vive en NewWithOptions.
 func New(version string, ctx context.Context) Model {
+	return NewWithOptions(version, ctx, Options{RunStartupChecks: true})
+}
+
+// Options agrupa los toggles del arranque del modelo. Se introduce para
+// soportar el flag --no-checks de root.go sin romper la firma de New.
+type Options struct {
+	// RunStartupChecks=true arranca la TUI corriendo los chequeos
+	// secundarios (labels viejos / versión / locks colgados) antes de
+	// mostrar el menú. En false va directo al menú — usado por tests y
+	// por el flag --no-checks.
+	RunStartupChecks bool
+}
+
+// NewWithOptions construye el modelo inicial respetando los toggles
+// del arranque. El comportamiento por defecto (sin opts) es equivalente
+// a New: arranca corriendo los chequeos.
+func NewWithOptions(version string, ctx context.Context, opts Options) Model {
 	ta := textarea.New()
 	ta.Placeholder = "Contame la idea — puede ser multilínea. Ctrl+D para enviar, Esc para cancelar."
 	ta.CharLimit = 5000
@@ -331,15 +368,33 @@ func New(version string, ctx context.Context) Model {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	return Model{
-		screen:   screenMenu,
-		cursor:   0,
-		textarea: ta,
-		version:  version,
-		repo:     detectRepo(),
-		branch:   detectBranch(),
-		ctx:      ctx,
+	repoRoot := detectRepoRoot()
+	initial := screenMenu
+	if opts.RunStartupChecks && startup.HasGitDir(repoRoot) {
+		initial = screenStartupChecksLoading
 	}
+	return Model{
+		screen:          initial,
+		cursor:          0,
+		textarea:        ta,
+		version:         version,
+		repo:            detectRepo(),
+		branch:          detectBranch(),
+		ctx:             ctx,
+		startupRepoRoot: repoRoot,
+	}
+}
+
+// detectRepoRoot devuelve el path absoluto del root del repo git
+// activo (la salida de `git rev-parse --show-toplevel`). Si no estamos
+// en un repo o git no está, devuelve "" — el caller usa eso como
+// guard para skipear los chequeos.
+func detectRepoRoot() string {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 func detectRepo() string {
@@ -366,7 +421,17 @@ func detectBranch() string {
 	return strings.TrimSpace(string(out))
 }
 
-func (m Model) Init() tea.Cmd { return nil }
+// Init dispara el comando de arranque correspondiente. Si la TUI
+// arranca en screenStartupChecksLoading, lanzamos los chequeos en
+// background y esperamos su respuesta. En cualquier otra screen
+// (incluyendo screenMenu cuando RunStartupChecks=false), no hacemos
+// nada — la TUI espera la primera tecla del usuario.
+func (m Model) Init() tea.Cmd {
+	if m.screen == screenStartupChecksLoading {
+		return runStartupChecksCmd(m.ctx, m.version, m.startupRepoRoot)
+	}
+	return nil
+}
 
 // ---- mensajes que fluyen desde el flow hacia el Update ----
 
@@ -458,6 +523,23 @@ type locksLoadedMsg struct {
 type unlockDoneMsg struct {
 	ref string
 	err error
+}
+
+// startupChecksLoadedMsg llega tras correr startup.RunChecks en
+// background. results es la lista cruda (incluye entries no
+// triggereadas) — el handler filtra y decide si mostrar la pantalla de
+// checks o saltar directo al menú.
+type startupChecksLoadedMsg struct {
+	results []startup.Result
+}
+
+// startupActionDoneMsg llega tras ejecutar la acción "sí" de un check
+// (correr `che migrate-labels` o `che upgrade`). out es el output
+// combinado a mostrar al usuario; err es nil si todo OK.
+type startupActionDoneMsg struct {
+	checkName string
+	out       string
+	err       error
 }
 
 type tickMsg time.Time
@@ -639,6 +721,46 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.screen = screenLocksSelect
 		return m, nil
 
+	case startupChecksLoadedMsg:
+		// Filtramos solo los triggered y los marcamos como pendientes.
+		// Si no hay nada triggered, salteamos directo al menú — política
+		// de cero ruido en happy path.
+		var triggered []startup.Result
+		for _, r := range msg.results {
+			if r.Triggered {
+				triggered = append(triggered, r)
+			}
+		}
+		if len(triggered) == 0 {
+			m.screen = screenMenu
+			return m, nil
+		}
+		m.startupChecks = triggered
+		m.startupCursor = 0
+		m.screen = screenStartupChecks
+		return m, nil
+
+	case startupActionDoneMsg:
+		// Mostramos el output en pantalla de resultado para que el
+		// usuario vea qué pasó. Avanzamos el cursor — handleResultKey
+		// se encarga de volver a screenStartupChecks si quedan más
+		// checks pendientes, o al menú si era el último.
+		m.runLog = nil
+		var lines []string
+		if msg.err != nil {
+			lines = append(lines, "error: "+msg.err.Error())
+		}
+		lines = append(lines, splitNonEmpty(msg.out)...)
+		m.resultLines = lines
+		if msg.err != nil {
+			m.resultKind = resultError
+		} else {
+			m.resultKind = resultSuccess
+		}
+		m.startupCursor++
+		m.screen = screenResult
+		return m, nil
+
 	case unlockDoneMsg:
 		if msg.err != nil {
 			m.screen = screenResult
@@ -703,6 +825,16 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch m.screen {
 	case screenMenu:
 		return m.handleMenuKey(msg)
+	case screenStartupChecks:
+		return m.handleStartupChecksKey(msg)
+	case screenStartupChecksLoading, screenStartupChecksRunning:
+		// Loading / running de chequeos secundarios: solo Ctrl+C cierra
+		// para no abandonar a medio dispatch. El usuario espera unos
+		// segundos.
+		if msg.String() == "ctrl+c" {
+			return m, tea.Quit
+		}
+		return m, nil
 	case screenIdeaInput:
 		return m.handleIdeaInputKey(msg)
 	case screenIdeaRunning, screenExploreRunning, screenExploreLoading, screenExecuteRunning, screenExecuteLoading,
@@ -743,6 +875,124 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleResultKey(msg)
 	}
 	return m, nil
+}
+
+// handleStartupChecksKey procesa la respuesta del usuario al check
+// activo. Las opciones son:
+//   - s: ejecutar la acción del check (ej. correr `che migrate-labels`).
+//   - n: skipear este check por esta vez (queda pendiente para la
+//     próxima invocación).
+//   - N: marcar este check como skipeado para siempre en este repo
+//     (persistido en `.git/che-skip-checks`).
+//   - esc: salir de la pantalla de chequeos sin acción (equivalente a
+//     "n" para todos los pendientes — pasamos al menú).
+//   - ctrl+c: salir de la TUI completa.
+func (m Model) handleStartupChecksKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.startupCursor >= len(m.startupChecks) {
+		// Sanity: si llegamos sin pendientes, transicionamos al menú.
+		m.screen = screenMenu
+		return m, nil
+	}
+	current := m.startupChecks[m.startupCursor]
+	k := msg.String()
+	switch k {
+	case "ctrl+c":
+		return m, tea.Quit
+	case "esc":
+		m.screen = screenMenu
+		m.startupChecks = nil
+		return m, nil
+	case "s":
+		return m.runStartupAction(current)
+	case "n":
+		return m.advanceStartupChecks()
+	case "N":
+		// Persistir y avanzar. El error de MarkSkipped no rompe la
+		// UI — loggeamos por debajo (output ya descartado al transition)
+		// y seguimos. Bajo carga normal MarkSkipped no falla porque ya
+		// chequeamos `.git/` al arrancar.
+		_ = startup.MarkSkipped(m.startupRepoRoot, current.Name)
+		return m.advanceStartupChecks()
+	}
+	return m, nil
+}
+
+// advanceStartupChecks avanza el cursor al próximo check pendiente. Si
+// no quedan, transiciona al menú.
+func (m Model) advanceStartupChecks() (tea.Model, tea.Cmd) {
+	m.startupCursor++
+	if m.startupCursor >= len(m.startupChecks) {
+		m.screen = screenMenu
+		m.startupChecks = nil
+		m.startupCursor = 0
+		return m, nil
+	}
+	return m, nil
+}
+
+// runStartupAction ejecuta la acción "sí" de un check. El comportamiento
+// depende del check:
+//   - migrate-labels: exec `che migrate-labels` en subprocess y muestra
+//     el output en la pantalla de result al terminar todos los checks.
+//   - version: exec `che upgrade` en subprocess.
+//   - locks: navega a la pantalla "Ver locks" del TUI (no auto-unlock).
+//
+// Para los dos primeros casos pasamos por screenStartupChecksRunning
+// mientras corre; el done msg avanza al próximo check.
+func (m Model) runStartupAction(c startup.Result) (tea.Model, tea.Cmd) {
+	switch c.Name {
+	case startup.CheckLocks:
+		// Atajo directo a la pantalla de locks: el usuario decide cuál
+		// desbloquear. Removemos los chequeos pendientes — no queremos
+		// volver a la pantalla de chequeos cuando termine de unlockear.
+		m.startupChecks = nil
+		m.startupCursor = 0
+		m.screen = screenLocksLoading
+		m.locks = nil
+		m.locksCursor = 0
+		m.locksErr = nil
+		return m, loadLocksCmd()
+	case startup.CheckMigrateLabels:
+		m.screen = screenStartupChecksRunning
+		return m, runCheCmd(c.Name, "migrate-labels")
+	case startup.CheckVersion:
+		m.screen = screenStartupChecksRunning
+		return m, runCheCmd(c.Name, "upgrade")
+	}
+	// Check desconocido: no-op, avanzamos.
+	return m.advanceStartupChecks()
+}
+
+// runCheCmd ejecuta el binario actual de `che` con los args dados como
+// subcomando. Devuelve un startupActionDoneMsg con el output combinado
+// (stdout+stderr) y el error si lo hubo.
+func runCheCmd(checkName string, args ...string) tea.Cmd {
+	return func() tea.Msg {
+		exe, err := os.Executable()
+		if err != nil {
+			return startupActionDoneMsg{checkName: checkName, err: err}
+		}
+		cmd := exec.Command(exe, args...)
+		out, err := cmd.CombinedOutput()
+		return startupActionDoneMsg{
+			checkName: checkName,
+			out:       string(out),
+			err:       err,
+		}
+	}
+}
+
+// runStartupChecksCmd corre los chequeos secundarios en background y
+// los devuelve como un solo mensaje. Respeta el ctx raíz para que un
+// shutdown externo cancele las requests a `gh`.
+func runStartupChecksCmd(ctx context.Context, version, repoRoot string) tea.Cmd {
+	return func() tea.Msg {
+		results := startup.RunChecks(ctx, startup.Options{
+			RepoRoot:       repoRoot,
+			CurrentVersion: version,
+		})
+		return startupChecksLoadedMsg{results: results}
+	}
 }
 
 func (m Model) handleMenuKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -1490,7 +1740,21 @@ func (m Model) handleResultKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if msg.String() == "ctrl+c" {
 		return m, tea.Quit
 	}
-	m.screen = screenMenu
+	// Si estamos en medio del flow de chequeos secundarios y todavía
+	// quedan checks pendientes, volvemos a la pantalla de chequeos en
+	// vez de saltar al menú. Esto cubre el caso donde el usuario pidió
+	// "sí" sobre el primer check (ej. migrate-labels), vio el output, y
+	// queremos seguir con el siguiente (ej. version) sin que tenga que
+	// re-arrancar la TUI.
+	nextScreen := screenMenu
+	if m.startupCursor < len(m.startupChecks) {
+		nextScreen = screenStartupChecks
+	} else {
+		// Limpiamos también el estado de chequeos al salir definitivamente.
+		m.startupChecks = nil
+		m.startupCursor = 0
+	}
+	m.screen = nextScreen
 	m.resultLines = nil
 	m.runLog = nil
 	m.exploreNew = nil
@@ -1590,6 +1854,12 @@ func (m Model) View() string {
 	switch m.screen {
 	case screenMenu:
 		return renderMenu(m)
+	case screenStartupChecksLoading:
+		return renderStartupChecksLoading(m)
+	case screenStartupChecks:
+		return renderStartupChecks(m)
+	case screenStartupChecksRunning:
+		return renderStartupChecksRunning(m)
 	case screenIdeaInput:
 		return renderIdeaInput(m)
 	case screenIdeaRunning:
@@ -1656,6 +1926,105 @@ func (m Model) View() string {
 		return renderResult(m)
 	}
 	return ""
+}
+
+// ---- startup checks renders ----
+
+// renderStartupChecksLoading muestra una pantalla minimal mientras
+// corren los chequeos secundarios. Aparece pocos cientos de ms en el
+// happy path; si timeoutea (3s) no rompe la TUI — pasamos al menú con
+// los resultados parciales (que usualmente serán "todo no triggered").
+func renderStartupChecksLoading(_ Model) string {
+	var sb strings.Builder
+	sb.WriteString(titleStyle.Render("che — chequeos rápidos"))
+	sb.WriteString("\n")
+	sb.WriteString(subtitleStyle.Render("Verificando labels, versión y locks…"))
+	sb.WriteString("\n")
+	sb.WriteString(hintStyle.Render("Ctrl+C cancela"))
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+// renderStartupChecks rendea el banner del check activo. Muestra el
+// total de checks pendientes en el header (1/N) y el mensaje formateado
+// del check actual con sus 3 opciones.
+func renderStartupChecks(m Model) string {
+	var sb strings.Builder
+	sb.WriteString(titleStyle.Render("che — chequeos rápidos"))
+	sb.WriteString("\n")
+
+	total := len(m.startupChecks)
+	if total == 0 || m.startupCursor >= total {
+		// Sanity: no debería pasar (Update ya transicionó al menú).
+		sb.WriteString(subtitleStyle.Render("Todo en orden — entrando al menú…"))
+		sb.WriteString("\n")
+		return sb.String()
+	}
+
+	current := m.startupChecks[m.startupCursor]
+	sb.WriteString(subtitleStyle.Render(fmt.Sprintf(
+		"Encontramos %d cosa(s) para revisar antes de empezar (%d / %d)",
+		total, m.startupCursor+1, total,
+	)))
+	sb.WriteString("\n\n")
+
+	// Mensaje del check.
+	msg := formatStartupCheckMessage(current)
+	sb.WriteString("  " + lipgloss.NewStyle().Foreground(colorText).Render(msg) + "\n\n")
+
+	// Opciones.
+	hint := "[s] sí · [n] no esta vez · [N] nunca para este repo · [esc] saltar todos · [Ctrl+C] sale"
+	sb.WriteString(hintStyle.Render(hint))
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+// formatStartupCheckMessage arma el texto a mostrar para un check
+// triggered, con el emoji + descripción + acción sugerida según el
+// tipo. Mantenemos los emojis del spec del feature para coherencia
+// visual con el header de la TUI.
+func formatStartupCheckMessage(c startup.Result) string {
+	switch c.Name {
+	case startup.CheckMigrateLabels:
+		return fmt.Sprintf(
+			"🏷  Labels viejos sin migrar: %d (%s). Correr `che migrate-labels`?",
+			len(c.OldLabels), strings.Join(c.OldLabels, ", "),
+		)
+	case startup.CheckVersion:
+		return fmt.Sprintf(
+			"📦 che desactualizado: tenés %s, hay %s. Correr `che upgrade`?",
+			c.CurrentVersion, c.LatestVersion,
+		)
+	case startup.CheckLocks:
+		refs := make([]string, 0, len(c.Locks))
+		for _, l := range c.Locks {
+			refs = append(refs, fmt.Sprintf("#%d", l.Number))
+		}
+		return fmt.Sprintf(
+			"🔒 %d issues/PRs con che:locked > 1h: %s. Pueden estar colgados — abrir la pantalla de locks para desbloquearlos?",
+			len(c.Locks), strings.Join(refs, ", "),
+		)
+	}
+	return fmt.Sprintf("Check desconocido: %s", c.Name)
+}
+
+// renderStartupChecksRunning muestra una pantalla minimal mientras se
+// ejecuta la acción de un check (típicamente `che migrate-labels` o
+// `che upgrade`). El subprocess captura su propio output que se
+// muestra después en screenResult.
+func renderStartupChecksRunning(m Model) string {
+	var sb strings.Builder
+	current := ""
+	if m.startupCursor < len(m.startupChecks) {
+		current = m.startupChecks[m.startupCursor].Name
+	}
+	sb.WriteString(titleStyle.Render("che — corriendo acción"))
+	sb.WriteString("\n")
+	sb.WriteString(subtitleStyle.Render(fmt.Sprintf("Ejecutando acción para check: %s", current)))
+	sb.WriteString("\n")
+	sb.WriteString(hintStyle.Render("Esto puede tardar unos segundos"))
+	sb.WriteString("\n")
+	return sb.String()
 }
 
 // ---- locks renders ----
@@ -2494,7 +2863,9 @@ func renderIterateSelect(m Model) string {
 }
 
 // Run lanza el TUI y bloquea hasta que el usuario cierre. version se muestra
-// en el header del menú (típicamente cmd.Version).
+// en el header del menú (típicamente cmd.Version). runStartupChecks=true
+// arranca corriendo los chequeos secundarios; en false va directo al menú
+// (usado por --no-checks de root.go).
 //
 // Instala signal.NotifyContext(SIGINT, SIGTERM) sobre context.Background().
 // tea.WithoutSignalHandler desactiva el handler default de bubbletea — el
@@ -2503,11 +2874,12 @@ func renderIterateSelect(m Model) string {
 // tea.KeyMsg); las señales reales vienen de `kill -INT/TERM <pid>` fuera
 // de la TUI. Una goroutine convierte el ctx.Done() a shutdownMsg para que
 // el Update cancele la corrida activa y espere al cleanup antes de tea.Quit.
-func Run(version string) error {
+func Run(version string, runStartupChecks bool) error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	p := tea.NewProgram(New(version, ctx), tea.WithAltScreen(), tea.WithoutSignalHandler())
+	model := NewWithOptions(version, ctx, Options{RunStartupChecks: runStartupChecks})
+	p := tea.NewProgram(model, tea.WithAltScreen(), tea.WithoutSignalHandler())
 
 	go func() {
 		<-ctx.Done()

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -7,6 +7,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/chichex/che/internal/flow/validate"
+	"github.com/chichex/che/internal/startup"
 )
 
 // key arma un KeyMsg a partir del string que el Update espera via
@@ -138,10 +139,10 @@ func TestValidateItemAt_PlanVsPR(t *testing.T) {
 		},
 	}
 	cases := []struct {
-		idx       int
-		wantNum   int
-		wantURL   string
-		wantIsPR  bool
+		idx      int
+		wantNum  int
+		wantURL  string
+		wantIsPR bool
 	}{
 		{0, 42, "u1", false},
 		{1, 43, "u2", false},
@@ -262,9 +263,9 @@ func TestIterateItemAt_PlanVsPR(t *testing.T) {
 
 func TestMaybeAdvanceIterate_AmbasVaciasEmptyState(t *testing.T) {
 	m := Model{
-		screen:              screenIterateLoading,
-		iteratePlansLoaded:  true,
-		iteratePRsLoaded:    true,
+		screen:             screenIterateLoading,
+		iteratePlansLoaded: true,
+		iteratePRsLoaded:   true,
 	}
 	out, _ := m.maybeAdvanceIterate()
 	got := out.(Model)
@@ -604,6 +605,182 @@ func TestRenderMenu_IdeaSinRefNoImprimeHash(t *testing.T) {
 	// Idea sin ref no debería imprimir "#" (el único "#" del menú es en el item de ref).
 	if strings.Contains(out, "#") {
 		t.Errorf("idea sin ref no debería imprimir '#': %s", out)
+	}
+}
+
+// ---- startup checks: arranque y dispatch ----
+
+// Sin checks triggered, transicionamos directo al menú (cero ruido en
+// happy path).
+func TestStartupChecksLoaded_SinTriggeredVaAlMenu(t *testing.T) {
+	m := Model{screen: screenStartupChecksLoading}
+	out, _ := m.Update(startupChecksLoadedMsg{
+		results: []startup.Result{
+			{Name: startup.CheckMigrateLabels, Triggered: false},
+			{Name: startup.CheckVersion, Triggered: false},
+			{Name: startup.CheckLocks, Triggered: false},
+		},
+	})
+	got := out.(Model)
+	if got.screen != screenMenu {
+		t.Errorf("sin checks triggered debería ir al menú, got %v", got.screen)
+	}
+	if len(got.startupChecks) != 0 {
+		t.Errorf("startupChecks debería quedar vacío, got %d", len(got.startupChecks))
+	}
+}
+
+// Con al menos un check triggered, mostramos la pantalla y filtramos
+// los no-triggered.
+func TestStartupChecksLoaded_FiltreaSoloTriggered(t *testing.T) {
+	m := Model{screen: screenStartupChecksLoading}
+	out, _ := m.Update(startupChecksLoadedMsg{
+		results: []startup.Result{
+			{Name: startup.CheckMigrateLabels, Triggered: true, OldLabels: []string{"status:idea"}},
+			{Name: startup.CheckVersion, Triggered: false},
+			{Name: startup.CheckLocks, Triggered: true, Locks: []startup.LockedItem{{Number: 42}}},
+		},
+	})
+	got := out.(Model)
+	if got.screen != screenStartupChecks {
+		t.Fatalf("debería ir a screenStartupChecks, got %v", got.screen)
+	}
+	if len(got.startupChecks) != 2 {
+		t.Errorf("debería filtrar a los 2 triggered, got %d", len(got.startupChecks))
+	}
+	if got.startupCursor != 0 {
+		t.Errorf("cursor debería arrancar en 0, got %d", got.startupCursor)
+	}
+}
+
+// "n" avanza al próximo check sin persistir nada.
+func TestStartupChecksKey_NoEstaVez(t *testing.T) {
+	m := Model{
+		screen:        screenStartupChecks,
+		startupChecks: []startup.Result{{Name: startup.CheckVersion, Triggered: true}},
+		startupCursor: 0,
+	}
+	m = step(m, "n")
+	// Sin más checks: vuelve al menú.
+	if m.screen != screenMenu {
+		t.Errorf("después del último check 'n' debería ir al menú, got %v", m.screen)
+	}
+}
+
+// "esc" sale de la pantalla de chequeos.
+func TestStartupChecksKey_EscSaltaTodos(t *testing.T) {
+	m := Model{
+		screen: screenStartupChecks,
+		startupChecks: []startup.Result{
+			{Name: startup.CheckVersion, Triggered: true},
+			{Name: startup.CheckLocks, Triggered: true},
+		},
+	}
+	m = step(m, "esc")
+	if m.screen != screenMenu {
+		t.Errorf("esc debería ir al menú, got %v", m.screen)
+	}
+	if len(m.startupChecks) != 0 {
+		t.Errorf("esc debería limpiar la lista, got %d", len(m.startupChecks))
+	}
+}
+
+// "n" sobre 2 checks avanza primero al segundo, después al menú.
+func TestStartupChecksKey_NoAvanzaSecuencial(t *testing.T) {
+	m := Model{
+		screen: screenStartupChecks,
+		startupChecks: []startup.Result{
+			{Name: startup.CheckMigrateLabels, Triggered: true},
+			{Name: startup.CheckVersion, Triggered: true},
+		},
+	}
+	m = step(m, "n")
+	if m.screen != screenStartupChecks {
+		t.Errorf("después de 1 'n' con 2 checks, debería seguir en checks, got %v", m.screen)
+	}
+	if m.startupCursor != 1 {
+		t.Errorf("cursor debería ser 1, got %d", m.startupCursor)
+	}
+	m = step(m, "n")
+	if m.screen != screenMenu {
+		t.Errorf("después del 2do 'n' debería ir al menú, got %v", m.screen)
+	}
+}
+
+// "s" sobre el check de locks salta directo a screenLocksLoading.
+func TestStartupChecksKey_SiLocksSaltaAPantallaDeLocks(t *testing.T) {
+	m := Model{
+		screen: screenStartupChecks,
+		startupChecks: []startup.Result{
+			{Name: startup.CheckLocks, Triggered: true, Locks: []startup.LockedItem{{Number: 42}}},
+		},
+	}
+	out, _ := m.handleStartupChecksKey(key("s"))
+	got := out.(Model)
+	if got.screen != screenLocksLoading {
+		t.Errorf("'s' sobre locks debería ir a screenLocksLoading, got %v", got.screen)
+	}
+}
+
+func TestRenderStartupChecks_IncluyeMensajeYOpciones(t *testing.T) {
+	m := Model{
+		startupChecks: []startup.Result{{
+			Name:           startup.CheckVersion,
+			Triggered:      true,
+			CurrentVersion: "0.0.49",
+			LatestVersion:  "v0.0.50",
+		}},
+	}
+	out := renderStartupChecks(m)
+	if !strings.Contains(out, "0.0.49") || !strings.Contains(out, "v0.0.50") {
+		t.Errorf("debería incluir versiones: %s", out)
+	}
+	if !strings.Contains(out, "[s]") || !strings.Contains(out, "[N]") {
+		t.Errorf("debería incluir opciones [s]/[N]: %s", out)
+	}
+	if !strings.Contains(out, "che upgrade") {
+		t.Errorf("debería sugerir 'che upgrade': %s", out)
+	}
+}
+
+func TestFormatStartupCheckMessage_PorTipo(t *testing.T) {
+	cases := []struct {
+		name string
+		c    startup.Result
+		want string
+	}{
+		{
+			"migrate-labels",
+			startup.Result{Name: startup.CheckMigrateLabels, OldLabels: []string{"status:idea", "status:plan"}},
+			"migrate-labels",
+		},
+		{
+			"version",
+			startup.Result{Name: startup.CheckVersion, CurrentVersion: "0.0.1", LatestVersion: "v0.0.2"},
+			"upgrade",
+		},
+		{
+			"locks",
+			startup.Result{Name: startup.CheckLocks, Locks: []startup.LockedItem{{Number: 42}, {Number: 7}}},
+			"#42",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := formatStartupCheckMessage(c.c)
+			if !strings.Contains(got, c.want) {
+				t.Errorf("mensaje no incluye %q: %s", c.want, got)
+			}
+		})
+	}
+}
+
+// NewWithOptions con RunStartupChecks=false debe arrancar directo en el
+// menú, sin pasar por screenStartupChecksLoading.
+func TestNewWithOptions_NoChecksArrancaEnMenu(t *testing.T) {
+	m := NewWithOptions("0.0.1", nil, Options{RunStartupChecks: false})
+	if m.screen != screenMenu {
+		t.Errorf("con RunStartupChecks=false debería arrancar en menú, got %v", m.screen)
 	}
 }
 


### PR DESCRIPTION
## Summary

Cuando arranca la TUI (`che` sin args), corre 3 checks en paralelo y muestra banner si alguno triggerea. **Cero ruido en happy path**: si todo OK pasa directo al menu principal.

### Checks
1. **Labels viejos** `status:*` sin migrar → propone `che migrate-labels`.
2. **Version desactualizada** vs latest GH release → propone `che upgrade`. Skip si `Version == "dev"`.
3. **Locks colgados** (issues/PRs con `che:locked` > 1h) → propone navegar a screen "Ver locks" (no desbloquea automaticamente; el humano decide). Scope acotado al repo actual.

### UX por check
`[s] si · [n] no esta vez · [N] nunca para este repo`

Persistencia "Nunca" en `.git/che-skip-checks` (per-repo, fuera del tracking).

### Robustez
- Timeout total 3s para los 3 checks paralelos (`context.WithTimeout`).
- gh falla → ese check skipea silencioso, NO rompe la TUI.
- `recover()` por goroutine.
- `exec.CommandContext` cancela subprocess gh al timeout.
- Si `.git` no existe (fuera de repo), todos los checks se skipean.

### Opt-out
Flag `--no-checks` en `cmd/root.go`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` (24 tests nuevos en `internal/startup`, 9 en `internal/tui`)
- [x] `go vet ./...`
- [x] `gofmt -l internal/startup/ internal/tui/ cmd/root.go` vacio
- [x] Smoke `--no-checks` flag aparece en `--help`
- [ ] Smoke en repo con `status:*` viejos: verificar banner + accion migrate-labels
- [ ] Smoke en repo con `che:locked` > 1h: verificar banner + nav a Ver locks
- [ ] Smoke con version mock distinta: verificar banner + accion upgrade

## Decisiones puntuales

- Acciones "si" exec via `os.Executable()` — no se puede importar `cmd` desde `tui` por import cycle.
- `checkLocks` acota al repo actual via `gh repo view --json nameWithOwner` + query `repo:owner/name` (vs spec literal "todos los repos") para evitar ruido cross-repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)