### PR TITLE
fix(dash): spinner durante el primer poll para evitar 'no hay nada'

### DIFF
--- a/internal/dash/server_test.go
+++ b/internal/dash/server_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // newTestServer es el helper de todos los tests: MockSource + repo ficticio +
@@ -107,8 +108,8 @@ func TestDashboardHandler_Index(t *testing.T) {
 	if !strings.Contains(got, `hx-get="/board"`) {
 		t.Errorf("body missing hx-get=\"/board\" on the dash-board wrapper")
 	}
-	if !strings.Contains(got, `hx-trigger="every 15s"`) {
-		t.Errorf("body missing hx-trigger for 15s default poll")
+	if !strings.Contains(got, `hx-trigger="load delay:200ms, every 15s"`) {
+		t.Errorf("body missing hx-trigger 'load delay:200ms, every 15s' (primer poll inmediato + ticker)")
 	}
 }
 
@@ -424,5 +425,62 @@ func TestBoardHandler_MockSource(t *testing.T) {
 	// solo su contenido (chip + columnas). Ese wrapper es persistente.
 	if strings.Contains(got, `class="dash-board"`) {
 		t.Errorf("/board should not include the .dash-board wrapper; got: %s", got)
+	}
+}
+
+// TestBoardLoading_FirstPollPending chequea que cuando el snapshot todavía
+// no tuvo primer poll exitoso (LastOK zero) y NO estamos en mock, el render
+// del board incluye el spinner de "loading" en lugar de las 9 columnas
+// vacías. Evita el bug visual donde el board parece "no hay nada en el
+// repo" durante los primeros segundos antes del primer gh poll.
+func TestBoardLoading_FirstPollPending(t *testing.T) {
+	src := &fixedSource{snap: Snapshot{
+		// LastOK zero (sin primer poll), Mock false, Stale false.
+	}}
+	srv := httptest.NewServer(NewServer(src, "owner/repo", 15))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	got := string(body)
+
+	if !strings.Contains(got, `class="board-loading"`) {
+		t.Errorf("/ missing board-loading wrapper while LastOK is zero")
+	}
+	if !strings.Contains(got, `class="spinner"`) {
+		t.Errorf("/ missing spinner while LastOK is zero")
+	}
+	// Las columnas NO deberían renderizarse mientras se muestra el spinner.
+	if strings.Contains(got, `data-status="idea"`) {
+		t.Errorf("/ should not render columns while LastOK is zero (got data-status=idea)")
+	}
+}
+
+// TestBoardLoading_AfterFirstPoll chequea que una vez que LastOK ya no es
+// zero (primer poll OK), el render muestra las 9 columnas y NO el spinner.
+func TestBoardLoading_AfterFirstPoll(t *testing.T) {
+	src := &fixedSource{snap: Snapshot{
+		LastOK: time.Now(),
+	}}
+	srv := httptest.NewServer(NewServer(src, "owner/repo", 15))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	got := string(body)
+
+	if strings.Contains(got, `class="board-loading"`) {
+		t.Errorf("/ should NOT include board-loading after first poll OK")
+	}
+	if !strings.Contains(got, `data-status="idea"`) {
+		t.Errorf("/ should render columns after first poll OK")
 	}
 }

--- a/internal/dash/templates/board.html.tmpl
+++ b/internal/dash/templates/board.html.tmpl
@@ -34,7 +34,25 @@
   </div>
 {{end}}
 
+{{define "board-loading"}}
+  {{/* Loading state: se muestra mientras el primer poll de gh no termina.
+       El wrapper .dash-board ya tiene grid-template-columns repeat(9,1fr);
+       este overlay rompe el grid con grid-column: 1 / -1 para ocupar el
+       ancho completo. */}}
+  <div class="board-loading">
+    <div class="spinner" aria-hidden="true"></div>
+    <div class="board-loading-text">cargando issues y PRs del repo…</div>
+    <div class="board-loading-sub">primer poll a <code>gh</code> en curso</div>
+  </div>
+{{end}}
+
 {{define "board-columns"}}
+  {{/* Si todavía no hubo primer poll exitoso (LastOK.IsZero) y no estamos
+       en mock mode, mostrar spinner en vez de las 9 columnas vacías —
+       evita que se vea "no hay nada" durante los primeros segundos. */}}
+  {{if and (not .Snapshot.Mock) .Snapshot.LastOK.IsZero (not .Snapshot.Stale)}}
+    {{template "board-loading" .}}
+  {{else}}
   {{range .Columns}}
     <div class="col" data-status="{{.Key}}">
       <div class="col-hdr"><b>{{.Title}}</b><span class="count{{if .Hot}} hot{{end}}">{{len .Entities}}</span></div>
@@ -83,6 +101,7 @@
         {{end}}
       </div>
     </div>
+  {{end}}
   {{end}}
 {{end}}
 

--- a/internal/dash/templates/dashboard.html.tmpl
+++ b/internal/dash/templates/dashboard.html.tmpl
@@ -130,6 +130,7 @@
     flex: 1;
     display: grid;
     grid-template-columns: 1fr;
+    grid-template-rows: 1fr;
     gap: 12px;
     min-height: 0;
   }
@@ -148,6 +149,7 @@
     overflow-x: auto;
     overflow-y: hidden;
     min-width: 0;
+    min-height: 0;
     /* min-width del contenido: 9 columnas con un piso razonable (~110px)
        más gaps. Si el viewport es más chico, scrolleamos en X en vez de
        comprimir las cards. */
@@ -161,6 +163,8 @@
     display: flex;
     flex-direction: column;
     min-width: 110px;
+    min-height: 0;
+    overflow: hidden;
   }
   .col-hdr {
     padding: 8px 10px;
@@ -169,6 +173,7 @@
     justify-content: space-between;
     align-items: center;
     font-size: 11px;
+    flex-shrink: 0;
   }
   .col-hdr b { text-transform: uppercase; letter-spacing: 0.5px; color: var(--text); }
   .col-hdr .count {
@@ -184,6 +189,48 @@
     animation: pulse 1.4s infinite;
   }
   @keyframes pulse { 50% { opacity: 0.55; } }
+
+  /* ==================== Board loading state ====================
+     Se muestra dentro de .dash-board cuando aún no hubo primer poll
+     exitoso (Snapshot.LastOK.IsZero). Rompe el grid con
+     grid-column: 1 / -1 para ocupar las 9 columnas y centra spinner +
+     mensaje. Se reemplaza por las columnas reales en el primer
+     /board exitoso (HTMX swap a 200ms del page load). */
+  .board-loading {
+    grid-column: 1 / -1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    padding: 60px 20px;
+    color: var(--muted);
+    text-align: center;
+  }
+  .board-loading-text {
+    color: var(--text);
+    font-size: 13px;
+  }
+  .board-loading-sub {
+    color: var(--muted);
+    font-size: 11px;
+  }
+  .board-loading code {
+    background: var(--elevated);
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-family: inherit;
+    font-size: 10px;
+  }
+  .spinner {
+    width: 28px;
+    height: 28px;
+    border: 3px solid var(--elevated);
+    border-top-color: var(--cyan);
+    border-radius: 50%;
+    animation: spin 0.9s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
   /* Transient (los 4 *ing) en orange; validated en green; closed en muted. */
   .col[data-status="planning"] .col-hdr b,
   .col[data-status="executing"] .col-hdr b,
@@ -533,10 +580,13 @@
     <!-- ==== BOARD ==== -->
     {{/* El wrapper persiste; HTMX hace polling cada PollInterval segundos y
          swappea solo el innerHTML con la respuesta de /board (que trae el
-         status-chip via hx-swap-oob + las columnas). */}}
+         status-chip via hx-swap-oob + las columnas). El trigger "load
+         delay:200ms" pide /board apenas la página carga (no esperar el
+         primer ticker de PollInterval segundos para reemplazar el spinner
+         inicial). */}}
     <div class="dash-board"
          hx-get="/board"
-         hx-trigger="every {{.PollInterval}}s"
+         hx-trigger="load delay:200ms, every {{.PollInterval}}s"
          hx-swap="innerHTML">
       {{template "board-columns" .}}
     </div>


### PR DESCRIPTION
## Bug

Cuando arranca \`che dash\` el board se ve vacio durante varios segundos: las 9 columnas aparecen sin nada y de repente se llenan. Parece que el repo no tiene issues/PRs.

## Causa raíz

\`go gs.Run(ctx)\` arranca el poller en background y \`Run()\` retorna inmediatamente para abrir el HTTP server. Hay una race: el browser hace GET / antes de que el primer \`refresh()\` termine y ve \`Snapshot()\` con \`LastOK.IsZero()\` + entidades vacías. El status chip pequeño dice "connecting…" pero las 9 columnas vacías parecen "no hay nada en el repo".

## Fix

1. **HTMX trigger inmediato**: \`hx-trigger="every Xs"\` → \`hx-trigger="load delay:200ms, every Xs"\`. El primer poll a \`/board\` ocurre 200ms después del page load (no esperar el primer ticker de 15s).

2. **Spinner en el board**: mientras \`Snapshot.LastOK.IsZero()\` y no es mock/stale, render incluye un spinner CSS centrado con texto "cargando issues y PRs del repo…" en lugar de las 9 columnas vacías. Se reemplaza por las columnas reales en el primer \`/board\` exitoso.

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./internal/dash/...\` (2 tests nuevos: \`TestBoardLoading_FirstPollPending\` y \`TestBoardLoading_AfterFirstPoll\`)
- [x] \`gofmt -l\` clean
- [ ] Smoke en repo real: arrancar \`che dash\`, ver spinner brevemente, después llegan las cards
- [ ] Smoke con \`--mock\`: NO debería ver spinner (Mock setea LastOK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)