### PR TITLE
feat(#64): [#50 PR6a] internal/labels v2 con shim

### DIFF
--- a/internal/pipelinelabels/pipelinelabels.go
+++ b/internal/pipelinelabels/pipelinelabels.go
@@ -1,0 +1,284 @@
+// Package pipelinelabels genera y parsea los labels dinámicos derivados de
+// un pipeline declarativo (`internal/pipeline`). Es la versión "v2" del
+// modelo de labels: en lugar de la máquina de 9 estados hardcodeada de
+// `internal/labels`, acá los labels se derivan del pipeline activo.
+//
+// Coexiste a propósito con `internal/labels`: este paquete es un shim para
+// que el motor nuevo de pipelines (PRD #50, §6) pueda computar el set de
+// labels esperados sin que los flows existentes se enteren. Mientras dure
+// la migración, ambos paquetes conviven sin tocarse.
+//
+// Modelo (PRD §6 + §6.d):
+//
+//   - `che:state:<step>` — estado terminal del step. Ejemplo: `che:state:idea`,
+//     `che:state:explore`. Hay un solo `che:state:*` aplicado al issue raíz a
+//     la vez; cada transición lo reemplaza.
+//   - `che:state:applying:<step>` — lock optimista mientras el step corre.
+//     Reemplaza al `che:state:*` previo durante la ejecución y vuelve al
+//     terminal al terminar OK (o rolea atrás si falla).
+//   - `che:lock:<timestamp>:<pid>-<host>` — lock con heartbeat + TTL (PRD
+//     §6.d). Identifica al proceso dueño del lock para detectar staleness.
+//
+// Este paquete NO aplica labels a GitHub: sólo los genera y parsea. La
+// aplicación REST vive en `internal/labels` (que se reusará cuando el motor
+// nuevo wire-up este shim).
+package pipelinelabels
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/chichex/che/internal/pipeline"
+)
+
+// Prefijos canónicos. Mantener exportados para que callers (engine, dash,
+// drift detection) no inventen literales y para tests fuera del paquete.
+//
+// Importante: los prefijos llevan `:` final para que matchear "empieza con
+// PrefixState" no acepte por error otras familias (ej. `che:state-foo`).
+const (
+	// PrefixState identifica labels de estado terminal de un step.
+	// Forma: `che:state:<step>`.
+	PrefixState = "che:state:"
+
+	// PrefixApplying identifica labels de step en curso (lock optimista).
+	// Forma: `che:state:applying:<step>`. Notar que también empieza con
+	// PrefixState — el parser tiene que chequear este prefijo PRIMERO.
+	PrefixApplying = "che:state:applying:"
+
+	// PrefixLock identifica el lock con timestamp + pid + host (PRD §6.d).
+	// Forma: `che:lock:<unix-nano>:<pid>-<host>`.
+	PrefixLock = "che:lock:"
+)
+
+// Kind clasifica un label parseado. Los tres valores corresponden a las
+// tres familias generadas por este paquete.
+type Kind int
+
+const (
+	// KindUnknown es el zero value: el label no matchea ninguna familia
+	// conocida. El parser devuelve este kind junto con un error para que
+	// el caller distinga "no es nuestro" de "es nuestro pero malformado".
+	KindUnknown Kind = iota
+
+	// KindState = `che:state:<step>` (terminal).
+	KindState
+
+	// KindApplying = `che:state:applying:<step>` (transient).
+	KindApplying
+
+	// KindLock = `che:lock:<timestamp>:<pid>-<host>`.
+	KindLock
+)
+
+// String devuelve un nombre legible del kind para mensajes de error y logs.
+func (k Kind) String() string {
+	switch k {
+	case KindState:
+		return "state"
+	case KindApplying:
+		return "applying"
+	case KindLock:
+		return "lock"
+	default:
+		return "unknown"
+	}
+}
+
+// Parsed es el resultado de parsear un label. Los campos relevantes
+// dependen del Kind:
+//
+//   - KindState / KindApplying → Step.
+//   - KindLock → Timestamp, PID, Host.
+//
+// El zero value (Kind == KindUnknown) representa un label que no es de
+// este paquete; el parser sólo devuelve Parsed con Kind != KindUnknown si
+// no hubo error.
+type Parsed struct {
+	Kind Kind
+
+	// Step es el nombre del step para KindState/KindApplying. Vacío en
+	// KindLock.
+	Step string
+
+	// Timestamp es el instante en que se generó el lock (KindLock). Zero
+	// para los otros kinds.
+	Timestamp time.Time
+
+	// PID es el process ID dueño del lock (KindLock). 0 para los otros.
+	PID int
+
+	// Host es el hostname dueño del lock (KindLock). Vacío para los otros.
+	// Puede contener guiones (`-`), por eso el parser separa por el PRIMER
+	// `-` del segmento `<pid>-<host>` (PID es numérico — todo lo que viene
+	// después del primer `-` es host).
+	Host string
+}
+
+// StateLabel devuelve el label terminal de un step: `che:state:<step>`.
+//
+// No valida `step`: el paquete `pipeline` ya restringe los nombres a
+// `[a-z_][a-z0-9_]*` (ver Step.Name en pipeline.go); pasar un nombre con
+// `:` rompería el round-trip parser → caller responsable.
+func StateLabel(step string) string {
+	return PrefixState + step
+}
+
+// ApplyingLabel devuelve el label transient de un step en ejecución:
+// `che:state:applying:<step>`.
+func ApplyingLabel(step string) string {
+	return PrefixApplying + step
+}
+
+// Expected devuelve la lista plana de labels de estado esperados para un
+// pipeline: por cada step, su `che:state:<step>` y su
+// `che:state:applying:<step>`. NO incluye el lock (el lock es runtime, no
+// del pipeline; ver LockLabel).
+//
+// Orden: por step en el orden del pipeline; dentro de cada step primero el
+// terminal y luego el applying. Estable para que callers puedan compararlo
+// bit-perfect en tests/golden.
+//
+// Uso típico: `che pipeline ensure-labels` para precrear todos los labels
+// del repo de una sola, o drift detection comparando contra los labels
+// realmente declarados en el repo.
+func Expected(p pipeline.Pipeline) []string {
+	out := make([]string, 0, len(p.Steps)*2)
+	for _, s := range p.Steps {
+		out = append(out, StateLabel(s.Name), ApplyingLabel(s.Name))
+	}
+	return out
+}
+
+// LockLabel genera un label de lock fresco con timestamp, PID y hostname
+// del proceso actual. Forma: `che:lock:<unix-nano>:<pid>-<host>`.
+//
+// Timestamp en UnixNano garantiza que dos generaciones consecutivas no
+// colisionen incluso en máquinas con reloj de baja resolución (la sección
+// "tests del lock" del scope pide round-trip con timestamp distinto entre
+// llamadas seguidas — UnixNano es suficiente sin necesidad de sleep en el
+// test).
+//
+// Si os.Hostname() falla (poco común — readonly /etc/hostname o sandbox),
+// usamos `unknown-host` como fallback. El lock pierde su valor de
+// debugging pero sigue cumpliendo su rol de mutex; no abortamos toda la
+// run por un hostname.
+func LockLabel() string {
+	return LockLabelAt(time.Now(), os.Getpid(), hostnameOrUnknown())
+}
+
+// LockLabelAt es la versión inyectable de LockLabel: permite tests
+// determinísticos pasando timestamp, pid y host explícitos. No exportada
+// para evitar uso en producción — el caller productivo debe usar
+// LockLabel() para que el lock sea realmente único por proceso.
+//
+// Exportada con sufijo `At` para que el contrato (deterministic from
+// inputs) sea evidente al lector. Ver lock_test.go para ejemplos.
+func LockLabelAt(t time.Time, pid int, host string) string {
+	if host == "" {
+		host = "unknown-host"
+	}
+	return fmt.Sprintf("%s%d:%d-%s", PrefixLock, t.UnixNano(), pid, host)
+}
+
+// hostnameOrUnknown wrappea os.Hostname() con fallback. Extraído para que
+// tests no dependan del hostname real de la máquina.
+func hostnameOrUnknown() string {
+	h, err := os.Hostname()
+	if err != nil || h == "" {
+		return "unknown-host"
+	}
+	return h
+}
+
+// Parse identifica un label como una de las tres familias del paquete y
+// extrae sus campos.
+//
+// Returns:
+//   - Parsed{Kind: KindState|KindApplying, Step: "..."} si matchea un
+//     label de estado.
+//   - Parsed{Kind: KindLock, Timestamp/PID/Host} si matchea un lock.
+//   - Parsed{Kind: KindUnknown}, error no-nil si el label NO pertenece a
+//     este paquete o está malformado.
+//
+// El error distingue dos casos:
+//   - El label tiene un prefijo conocido pero no parsea (timestamp roto,
+//     pid no numérico, etc.) → devuelve un error descriptivo.
+//   - El label no tiene ninguno de nuestros prefijos → devuelve
+//     ErrNotPipelineLabel para que el caller pueda silenciar el "no es
+//     mío" sin hacer string match en el mensaje.
+//
+// Notar que el orden de chequeo es importante: PrefixApplying tiene que ir
+// ANTES que PrefixState porque toda string que empieza con PrefixApplying
+// también empieza con PrefixState (`che:state:applying:` ⊃ `che:state:`).
+func Parse(label string) (Parsed, error) {
+	switch {
+	case strings.HasPrefix(label, PrefixApplying):
+		step := strings.TrimPrefix(label, PrefixApplying)
+		if step == "" {
+			return Parsed{}, fmt.Errorf("pipelinelabels: applying label without step: %q", label)
+		}
+		return Parsed{Kind: KindApplying, Step: step}, nil
+
+	case strings.HasPrefix(label, PrefixState):
+		step := strings.TrimPrefix(label, PrefixState)
+		if step == "" {
+			return Parsed{}, fmt.Errorf("pipelinelabels: state label without step: %q", label)
+		}
+		return Parsed{Kind: KindState, Step: step}, nil
+
+	case strings.HasPrefix(label, PrefixLock):
+		return parseLock(label)
+	}
+	return Parsed{}, ErrNotPipelineLabel
+}
+
+// ErrNotPipelineLabel es el sentinel devuelto por Parse cuando el label no
+// matchea ninguno de los 3 prefijos del paquete. Permite que callers
+// detecten "no es mío" sin string-matching del mensaje:
+//
+//	if errors.Is(err, pipelinelabels.ErrNotPipelineLabel) { ... }
+var ErrNotPipelineLabel = errors.New("pipelinelabels: not a pipeline label")
+
+// parseLock extrae timestamp/pid/host de un label `che:lock:<ts>:<pid>-<host>`.
+//
+// Layout: PrefixLock + "<ts>:<pid>-<host>". Después de quitar el prefijo,
+// quedan 2 segmentos separados por `:` (timestamp, pid-host). El segmento
+// pid-host se separa por el PRIMER `-` (pid es numérico, host puede tener
+// guiones).
+func parseLock(label string) (Parsed, error) {
+	body := strings.TrimPrefix(label, PrefixLock)
+	colonIdx := strings.Index(body, ":")
+	if colonIdx <= 0 || colonIdx == len(body)-1 {
+		return Parsed{}, fmt.Errorf("pipelinelabels: malformed lock (expected che:lock:<ts>:<pid>-<host>): %q", label)
+	}
+	tsStr := body[:colonIdx]
+	pidHost := body[colonIdx+1:]
+
+	nanos, err := strconv.ParseInt(tsStr, 10, 64)
+	if err != nil {
+		return Parsed{}, fmt.Errorf("pipelinelabels: invalid lock timestamp %q in %q: %w", tsStr, label, err)
+	}
+
+	dashIdx := strings.Index(pidHost, "-")
+	if dashIdx <= 0 || dashIdx == len(pidHost)-1 {
+		return Parsed{}, fmt.Errorf("pipelinelabels: malformed lock pid-host (expected <pid>-<host>): %q", label)
+	}
+	pidStr := pidHost[:dashIdx]
+	host := pidHost[dashIdx+1:]
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil {
+		return Parsed{}, fmt.Errorf("pipelinelabels: invalid lock pid %q in %q: %w", pidStr, label, err)
+	}
+
+	return Parsed{
+		Kind:      KindLock,
+		Timestamp: time.Unix(0, nanos),
+		PID:       pid,
+		Host:      host,
+	}, nil
+}

--- a/internal/pipelinelabels/pipelinelabels.go
+++ b/internal/pipelinelabels/pipelinelabels.go
@@ -172,12 +172,12 @@ func LockLabel() string {
 }
 
 // LockLabelAt es la versión inyectable de LockLabel: permite tests
-// determinísticos pasando timestamp, pid y host explícitos. No exportada
-// para evitar uso en producción — el caller productivo debe usar
-// LockLabel() para que el lock sea realmente único por proceso.
+// determinísticos pasando timestamp, pid y host explícitos. Exportada
+// (sufijo `At`) para que tests puedan inyectar inputs determinísticos;
+// en código productivo siempre usar LockLabel() para que el lock
+// identifique al proceso real.
 //
-// Exportada con sufijo `At` para que el contrato (deterministic from
-// inputs) sea evidente al lector. Ver lock_test.go para ejemplos.
+// Ver pipelinelabels_test.go (TestLockLabelAt_*) para ejemplos.
 func LockLabelAt(t time.Time, pid int, host string) string {
 	if host == "" {
 		host = "unknown-host"

--- a/internal/pipelinelabels/pipelinelabels_test.go
+++ b/internal/pipelinelabels/pipelinelabels_test.go
@@ -1,0 +1,309 @@
+package pipelinelabels
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chichex/che/internal/pipeline"
+)
+
+// TestExpected_DefaultGolden es el golden bit-perfect de Expected() sobre
+// pipeline.Default(). Si Default() cambia (se agrega/saca un step en
+// internal/pipeline), este test falla — es la señal de que hay que
+// regenerar la lista esperada arriba.
+//
+// Mantenemos el golden inline (no en testdata/) porque es chico y porque
+// queremos que el diff del PR muestre el cambio sin abrir un archivo
+// aparte. Si el set crece a >20 entries lo movemos a testdata.
+func TestExpected_DefaultGolden(t *testing.T) {
+	got := Expected(pipeline.Default())
+
+	want := []string{
+		"che:state:idea",
+		"che:state:applying:idea",
+		"che:state:explore",
+		"che:state:applying:explore",
+		"che:state:validate_issue",
+		"che:state:applying:validate_issue",
+		"che:state:execute",
+		"che:state:applying:execute",
+		"che:state:validate_pr",
+		"che:state:applying:validate_pr",
+		"che:state:close",
+		"che:state:applying:close",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Expected(Default()) drift\n--- got ---\n%v\n--- want ---\n%v", got, want)
+	}
+}
+
+// TestExpected_OrderAndPairing chequea las dos invariantes estructurales
+// de Expected: orden por step (mismo orden que pipeline.Steps) y pairing
+// (state precede a applying dentro de cada step). Es defensa contra un
+// refactor que reordene el slice y rompa callers que asumen el orden.
+func TestExpected_OrderAndPairing(t *testing.T) {
+	p := pipeline.Pipeline{
+		Version: pipeline.CurrentVersion,
+		Steps: []pipeline.Step{
+			{Name: "alpha", Agents: []string{"claude-opus"}},
+			{Name: "beta", Agents: []string{"claude-opus"}},
+			{Name: "gamma", Agents: []string{"claude-opus"}},
+		},
+	}
+	got := Expected(p)
+	want := []string{
+		"che:state:alpha",
+		"che:state:applying:alpha",
+		"che:state:beta",
+		"che:state:applying:beta",
+		"che:state:gamma",
+		"che:state:applying:gamma",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Expected drift\n got: %v\nwant: %v", got, want)
+	}
+}
+
+// TestExpected_EmptyPipeline confirma que Expected sobre un pipeline sin
+// steps devuelve el slice vacío (no nil panics). El loader de pipeline ya
+// rechaza pipelines vacíos en producción, pero el contrato de Expected
+// debe ser robusto.
+func TestExpected_EmptyPipeline(t *testing.T) {
+	p := pipeline.Pipeline{Version: pipeline.CurrentVersion}
+	got := Expected(p)
+	if len(got) != 0 {
+		t.Errorf("Expected(empty) = %v, want empty slice", got)
+	}
+}
+
+// TestParse_StateRoundTrip: generar `che:state:<step>` con StateLabel y
+// parsearlo de vuelta debe devolver el mismo step name.
+func TestParse_StateRoundTrip(t *testing.T) {
+	cases := []string{"idea", "explore", "validate_issue", "execute", "validate_pr", "close"}
+	for _, step := range cases {
+		t.Run(step, func(t *testing.T) {
+			label := StateLabel(step)
+			got, err := Parse(label)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", label, err)
+			}
+			if got.Kind != KindState {
+				t.Errorf("Kind = %s, want state", got.Kind)
+			}
+			if got.Step != step {
+				t.Errorf("Step = %q, want %q", got.Step, step)
+			}
+		})
+	}
+}
+
+// TestParse_ApplyingRoundTrip: generar `che:state:applying:<step>` y
+// parsearlo de vuelta. Crucial porque el prefijo applying es superset
+// del state — si el orden de checks en Parse se invierte, este test
+// rompe primero.
+func TestParse_ApplyingRoundTrip(t *testing.T) {
+	cases := []string{"idea", "explore", "validate_issue", "execute", "validate_pr", "close"}
+	for _, step := range cases {
+		t.Run(step, func(t *testing.T) {
+			label := ApplyingLabel(step)
+			got, err := Parse(label)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", label, err)
+			}
+			if got.Kind != KindApplying {
+				t.Errorf("Kind = %s, want applying (Parse priorizó PrefixState antes que PrefixApplying?)", got.Kind)
+			}
+			if got.Step != step {
+				t.Errorf("Step = %q, want %q", got.Step, step)
+			}
+		})
+	}
+}
+
+// TestParse_LockRoundTrip: generar un lock con LockLabelAt (inputs fijos)
+// y parsearlo de vuelta debe recuperar timestamp, pid y host exactos.
+func TestParse_LockRoundTrip(t *testing.T) {
+	// Truncar a nanosegundo: time.Unix(0, nanos) recupera con precisión
+	// nano pero el input puede tener monotonic clock que se pierde en el
+	// round-trip. Usar UnixNano explícitamente.
+	when := time.Unix(0, time.Now().UnixNano())
+	label := LockLabelAt(when, 4242, "build-host-01")
+
+	got, err := Parse(label)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", label, err)
+	}
+	if got.Kind != KindLock {
+		t.Errorf("Kind = %s, want lock", got.Kind)
+	}
+	if !got.Timestamp.Equal(when) {
+		t.Errorf("Timestamp = %v, want %v", got.Timestamp, when)
+	}
+	if got.PID != 4242 {
+		t.Errorf("PID = %d, want 4242", got.PID)
+	}
+	if got.Host != "build-host-01" {
+		t.Errorf("Host = %q, want %q", got.Host, "build-host-01")
+	}
+}
+
+// TestParse_LockHostWithDashes blinda el caso donde el hostname tiene
+// guiones. El parser separa <pid>-<host> por el PRIMER `-` (pid es
+// numérico) — un host como "my-machine-name" debe preservarse entero.
+func TestParse_LockHostWithDashes(t *testing.T) {
+	when := time.Unix(0, 1700000000000000000)
+	label := LockLabelAt(when, 99, "my-machine-name")
+
+	got, err := Parse(label)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", label, err)
+	}
+	if got.Host != "my-machine-name" {
+		t.Errorf("Host = %q, want %q (parser cortó por el wrong dash)", got.Host, "my-machine-name")
+	}
+	if got.PID != 99 {
+		t.Errorf("PID = %d, want 99", got.PID)
+	}
+}
+
+// TestLockLabel_DistinctOnConsecutiveCalls cubre la garantía pedida en
+// el scope: dos generaciones consecutivas devuelven labels distintos
+// (timestamp avanza). UnixNano evita necesitar sleep en el test.
+func TestLockLabel_DistinctOnConsecutiveCalls(t *testing.T) {
+	a := LockLabel()
+	b := LockLabel()
+	if a == b {
+		t.Errorf("LockLabel() returned identical labels on consecutive calls\n  a: %s\n  b: %s", a, b)
+	}
+	// Sanity: ambos deben parsear como locks (no estamos generando otra
+	// cosa por accidente).
+	for i, lab := range []string{a, b} {
+		p, err := Parse(lab)
+		if err != nil {
+			t.Errorf("Parse(call %d, %q): %v", i, lab, err)
+			continue
+		}
+		if p.Kind != KindLock {
+			t.Errorf("call %d: kind = %s, want lock", i, p.Kind)
+		}
+	}
+}
+
+// TestLockLabel_UsesCurrentProcess verifica que LockLabel() captura el PID
+// del proceso actual. Es la diferencia entre LockLabel y LockLabelAt: el
+// "real" tiene que identificar quién está sosteniendo el lock.
+func TestLockLabel_UsesCurrentProcess(t *testing.T) {
+	label := LockLabel()
+	p, err := Parse(label)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", label, err)
+	}
+	if p.PID <= 0 {
+		t.Errorf("PID = %d, want >0 (os.Getpid())", p.PID)
+	}
+	if p.Host == "" {
+		t.Errorf("Host empty — LockLabel debería caer al hostname real o al fallback unknown-host")
+	}
+	// El timestamp debe estar dentro de una ventana razonable (último
+	// minuto), descartando bugs como pasar 0 sin querer.
+	delta := time.Since(p.Timestamp)
+	if delta < 0 || delta > time.Minute {
+		t.Errorf("Timestamp delta = %v, want within [0, 1m] (lock recién generado)", delta)
+	}
+}
+
+// TestParse_NotPipelineLabel: cualquier string que no tenga uno de los 3
+// prefijos canónicos debe devolver ErrNotPipelineLabel exactly. Cubre el
+// caso "el caller le pasa un label random del repo" (ej. ct:plan,
+// validated:approve, bug, etc.).
+func TestParse_NotPipelineLabel(t *testing.T) {
+	cases := []string{
+		"",
+		"bug",
+		"ct:plan",
+		"validated:approve",
+		"che:plan",          // label viejo de internal/labels
+		"che:idea",          // ídem
+		"che:locked",        // ídem (mutex viejo)
+		"che:state",         // sin prefijo completo (no termina con `:`)
+		"che:state-foo",     // similar pero con guion
+		"che:lock",          // sin sufijo
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			_, err := Parse(in)
+			if !errors.Is(err, ErrNotPipelineLabel) {
+				t.Errorf("Parse(%q) error = %v, want ErrNotPipelineLabel", in, err)
+			}
+		})
+	}
+}
+
+// TestParse_MalformedKnownPrefix: labels que tienen un prefijo conocido
+// pero el resto está roto NO deben devolver ErrNotPipelineLabel — son
+// nuestros pero malformados. Importante para drift detection: queremos
+// distinguir "no es mío" de "es mío y está corrupto en el repo".
+func TestParse_MalformedKnownPrefix(t *testing.T) {
+	cases := []struct {
+		name  string
+		label string
+	}{
+		{"empty state step", "che:state:"},
+		{"empty applying step", "che:state:applying:"},
+		{"lock without colon", "che:lock:abc"},
+		{"lock empty pid-host", "che:lock:123:"},
+		{"lock non-numeric ts", "che:lock:notanumber:99-host"},
+		{"lock without dash in pid-host", "che:lock:123:nohostpart"},
+		{"lock non-numeric pid", "che:lock:123:abc-host"},
+		{"lock empty host", "che:lock:123:99-"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := Parse(c.label)
+			if err == nil {
+				t.Fatalf("Parse(%q) no error, want malformed error", c.label)
+			}
+			if errors.Is(err, ErrNotPipelineLabel) {
+				t.Errorf("Parse(%q) = ErrNotPipelineLabel, want a malformed-label error", c.label)
+			}
+			if !strings.Contains(err.Error(), "pipelinelabels:") {
+				t.Errorf("Parse(%q) error = %q, want prefixed with 'pipelinelabels:'", c.label, err.Error())
+			}
+		})
+	}
+}
+
+// TestKindString cubre el helper String() de Kind para que mensajes de
+// error/log sean legibles. Trivial pero evita un drift silencioso si
+// alguien agrega un Kind nuevo y olvida actualizar el switch.
+func TestKindString(t *testing.T) {
+	cases := map[Kind]string{
+		KindUnknown:  "unknown",
+		KindState:    "state",
+		KindApplying: "applying",
+		KindLock:     "lock",
+	}
+	for k, want := range cases {
+		if got := k.String(); got != want {
+			t.Errorf("Kind(%d).String() = %q, want %q", k, got, want)
+		}
+	}
+}
+
+// TestLockLabelAt_FallbackHost: pasar host vacío a LockLabelAt no debe
+// generar un label malformado — el helper inyecta `unknown-host` como
+// hace LockLabel cuando os.Hostname falla.
+func TestLockLabelAt_FallbackHost(t *testing.T) {
+	label := LockLabelAt(time.Unix(0, 1), 1, "")
+	p, err := Parse(label)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", label, err)
+	}
+	if p.Host != "unknown-host" {
+		t.Errorf("Host = %q, want unknown-host", p.Host)
+	}
+}


### PR DESCRIPTION
Implementa #64.

Closes #64

## Implementado

Nuevo paquete `internal/pipelinelabels/` que coexiste con el viejo `internal/labels/` sin tocarlo. Genera el set de labels esperados (`che:state:<step>`, `che:state:applying:<step>`, `che:lock:<ts>:<pid>-<host>`) a partir de un `pipeline.Pipeline`.

API publica:
- Constantes `PrefixState`, `PrefixApplying`, `PrefixLock`
- `StateLabel(step)`, `ApplyingLabel(step)` — generadores
- `Expected(p pipeline.Pipeline) []string` — lista plana `[state, applying]` por step en orden
- `LockLabel()` — runtime: `che:lock:<unix-nano>:<pid>-<host>`
- `LockLabelAt(t, pid, host)` — version inyectable para tests
- `Parse(label)` con `Parsed{Kind, Step, Timestamp, PID, Host}` y enum `KindUnknown/KindState/KindApplying/KindLock`
- Sentinel `ErrNotPipelineLabel` para distinguir "no es mio" vs "es mio pero malformado"

## Tests (16 verdes)

- Golden bit-perfect: `Expected(pipeline.Default())` → 12 labels esperados
- `Parse_StateRoundTrip` + `Parse_ApplyingRoundTrip` (orden de checks load-bearing)
- `Parse_LockRoundTrip` + `Parse_LockHostWithDashes` (split por primer `-`)
- `LockLabel_DistinctOnConsecutiveCalls` — UnixNano garantiza uniqueness sin sleep
- `Parse_NotPipelineLabel` (10 strings incluyendo labels viejos `che:plan`/`che:idea`/`che:locked`) → coexistencia
- `Parse_MalformedKnownPrefix` (8 casos) → error descriptivo
- `LockLabelAt_FallbackHost`, `KindString`

`go build ./...`, `go vet`, `go test ./...` full suite verde — incluyendo el guard `TestNoHardcodedLabelsOutsideThisPackage` (los nuevos literales no son superset substring de los viejos).

## Decisiones de diseño

- **Nombre del paquete**: `internal/pipelinelabels/` (no `internal/labels/v2`) — evita nesting raro y conflicto futuro de imports.
- **Lock format**: `che:lock:<unix-nano>:<pid>-<host>` — UnixNano (no RFC3339) porque RFC tiene `:` que rompe el separator y UnixNano da uniqueness sin sleep en tests. `<pid>-<host>` con guion: `os.Hostname()` puede devolver `my-machine.local` (con guiones), parseo por primer `-` para extraer pid.
- **Orden de checks en `Parse()`**: applying primero (es superset de state). Test dedicado lo blinda.
- **Lock NO está en `Expected()`**: lock es runtime, no estructura del pipeline. Función separada.
