### PR TITLE
feat(#61): [#50 PR5a] Spec formal del parser de markers + tests

### DIFF
--- a/EXEC_NOTES.md
+++ b/EXEC_NOTES.md
@@ -1,39 +1,58 @@
-# PR5b — Engine core: notas de ejecución
+# PR5a — Spec formal del parser de markers + tests: notas de ejecución
 
 ## Estado del PR
 
-Cubre todo lo que el scope de #53 pide:
+Cubre el scope completo de #61:
 
-- **Invocación del agente** vía `engine.Invoker` (interface). 1 agente por step para PR5b — multi-agente + aggregator quedan para PR5c, pero `Step.Agents []string` ya tiene el shape multi.
-- **Parser de markers** (`engine.ParseMarker` + `engine.ParseStreamMarker`). Regex case-sensitive del PRD §3.c, sólo última línea no vacía, soporte text + stream-json.
-- **Distinción error técnico → stop**. `Invoker.Invoke` que devuelve `error != nil` mapea a `StopReasonTechnicalError`.
-- **Default sin marker → next**. Output exitoso sin marker reconocido se trata como `[next]`.
-- **Validación step destino**. `[goto: foo]` con `foo` no en pipeline → `StopReasonUnknownStep`.
-- **Cap global de 20 transiciones**. `MaxTransitions = 20`, no configurable. Stop con `StopReasonLoopCap` al alcanzarlo.
+- **Paquete puro `internal/markerparser`** — string in, marker out. Sin dependencias del engine ni del agent. Importable por cualquier paquete que necesite interpretar el output de un agente.
+- **API pública decidida**:
+  - `Marker` struct + `Kind` enum (`None`, `Next`, `Goto`, `Stop`).
+  - `Parse(text) (Marker, bool)` — recorre el output completo, aplica la regex sobre la última línea no-vacía.
+  - `ParseLastLine(line) (Marker, bool)` — versión single-line (caller ya tiene la línea aislada).
+  - `ParseStreamJSON(stream) (Marker, bool)` — recorre NDJSON del `claude --output-format stream-json --verbose`, encuentra el último evento `result` y aplica `Parse` sobre `.result`.
+- **Regex canónica del PRD §3.c**: `^\s*\[(next|stop|goto:\s*([a-z_][a-z0-9_]*))\]\s*$`. Case-sensitive estricta. Step destino con identificador go-like.
+- **Default sin marker → caller resuelve**. El parser nunca devuelve `Next` por default — siempre devuelve `(None, false)` cuando no encontró marker. El motor (que sabe si la invocación falló o no) aplica el default `[next]` o `[stop]`.
+- **Tests exhaustivos** (21 tests + 71 subtests, 92 asserts):
+  - Markers válidos: `[next]`, `[stop]`, `[goto: foo]`, sin/con espacios después de `goto:`, identificadores con underscores y números.
+  - Whitespace tolerance: leading, trailing, newlines, tabs, mezclas.
+  - Case-sensitive: `[Next]`, `[NEXT]`, `[Stop]`, `[STOP]`, `[Goto: foo]`, `[GOTO: foo]`, `[goto: FOO]`, `[goto: Foo]` — todos rechazados.
+  - Última línea no vacía: marker en línea intermedia ignorado, marker mezclado con prosa rechazado, marker con prosa antes en última línea aceptado.
+  - Step destino inválido: `[goto: 123foo]`, `[goto: 1step]`, `[goto:]`, `[goto: ]`, `[goto:  ]`, `[goto: step-name]`, `[goto: step.name]`, `[goto: step name]` — todos rechazados.
+  - Brackets rotos / vacíos: `[]`, `[foo]`, `[next ]`, `[next\n]`, `[next][stop]`, `[next]extra`.
+  - Empty/whitespace-only string → `(None, false)`.
+  - `ParseLastLine` no acepta multilínea (regex anclada con `^...$`).
+  - Stream-JSON: último `result` gana, ignora líneas no-JSON, ignora JSON inválido, stream vacío, stream sin event `result`, result con texto vacío, result multilinea, result con case-mismatch.
+  - `Kind.String()` para todos los valores + valor desconocido.
 
-Tests: 33 (16 engine + 17 marker). Toda la suite del repo (`go test ./...`) verde.
+## Compatibilidad con PR5b (engine)
+
+El parser ya estaba implementado dentro de `internal/engine/marker.go` (PR5b lo incluyó como anticipo porque PR5a no estaba mergeado todavía — ver el `EXEC_NOTES.md` original). PR5a hace el split limpio:
+
+1. **Lógica del parser** vive ahora 100% en `internal/markerparser` — sólo en un lugar.
+2. **`internal/engine/marker.go`** quedó como un thin shim: type aliases (`MarkerKind = markerparser.Kind`, `Marker = markerparser.Marker`, constantes `MarkerNext` etc.) + dos funciones que delegan (`ParseMarker → markerparser.Parse`, `ParseStreamMarker → markerparser.ParseStreamJSON`).
+3. **`engine.go` y `engine_test.go` no tocados**: siguen importando los símbolos legacy (`MarkerNext`, `ParseMarker`, …) y todo sigue compilando + tests siguen verdes.
+4. El antiguo `internal/engine/marker_test.go` se mantuvo intacto: como sólo usa la API pública, sigue funcionando contra el shim. Los tests duplicados son aceptables como red de regresión adicional; un follow-up trivial puede borrarlos cuando se quiera reducir la suite.
 
 ## Decisiones / desviaciones
 
-### 1. Parser incluido en este PR (era PR5a)
+### 1. `ParseLastLine` además de `Parse`
 
-El issue lista PR5a (spec formal del parser de markers) como dependencia, pero PR5a no estaba mergeado al momento de ejecutar #53. Como el scope explícito de PR5b también dice "parser" y el parser no es trivial de separar del engine sin duplicar tipos, lo incluí en `internal/engine/marker.go`. Si más adelante PR5a se mergea con un paquete separado (ej. `internal/markerparse`), un follow-up trivial reemplaza las llamadas internas y elimina `marker.go`.
+El issue pide la API `Parse` + `ParseLastLine` + `ParseStreamJSON`. La spec dice que `ParseLastLine` "parsea una sola linea, devuelve el marker + true si matcheó". La firma que elegí es `ParseLastLine(line string) (Marker, bool)` — alineada con `Parse` para que sea fácil de componer. Internamente `Parse` la llama después de extraer la última línea no-vacía.
 
-### 2. Tipos `Pipeline`/`Step` definidos localmente (no `internal/pipeline`)
+### 2. `ParseStreamJSON` no dispara default
 
-PR2 (`internal/pipeline`: types + Default) tampoco está en main todavía. Para que este PR sea self-contained y testeable sin esperar PR2, definí versiones minimales de `Pipeline` y `Step` dentro del paquete `engine`. Cuando PR2 merguea, un follow-up wirea `engine.RunPipeline` para consumir `pipeline.Pipeline` directamente — el shape es compatible (`Step{Name, Agents}` matchea el subset que el motor necesita).
+El issue dice: "Si el ultimo output no es texto, default Next". Decidí que el parser **no** aplica ese default — devuelve `(Marker{None}, false)` y el motor (que ya sabe si la invocación fue técnicamente exitosa) decide si lo trata como `Next` o `Stop`. Es coherente con `Parse`/`ParseLastLine` (mismo patrón) y mantiene el parser puro de toda lógica de control de flujo.
 
-### 3. `Invoker` como interface, no acoplado a `internal/agent` ni a PR1
+### 3. `Kind` zero-value es `None`, no `Next`
 
-PR1 (`internal/agentregistry`) no está en main. El motor define una `Invoker` interface chica (`Invoke(ctx, agent, input) (output, format, err)`) para no acoplarse al CLI de claude ni al registry. La implementación concreta que resuelve agente → binario via `agentregistry` y dispatcha al `internal/agent.Run` actual queda para un follow-up (probablemente cuando se haga el wireup CLI en PR4 o como parte del entry runner de PR5d).
+El zero-value del enum es `None`. Si un caller hace `var m Marker` el resultado es "sin marker", no "next" — esto fuerza al caller a decidir explícitamente qué default aplicar.
 
-### 4. `Options.EntryStep` ya soportado
+### 4. Step destino inválido → no matchea (vs. error explícito + stop)
 
-El scope formal de PR5b no incluye el flag `--from` (eso va en PR5d), pero el motor expone `Options.EntryStep` para que los tests del motor puedan empezar desde el medio del pipeline sin reconstruir todo. PR5d sólo tiene que cablear ese campo desde el CLI — sin cambios al motor.
+El issue dice: "Step destino inválido → error explícito + `[stop]` con razón". Esa lógica vive en el motor (`engine.RunPipeline` ya valida que el step destino exista y emite `StopReasonUnknownStep`). El parser sólo dice "qué pidió el agente". Casos como `[goto: 123foo]` (regex no matchea por dígito al inicio) se reportan como `(None, false)` — el caller decide cómo escalarlo. Esto es coherente con la spec del issue: "el parser puro" (string in, marker out).
 
 ## Pendientes (intencionalmente fuera de scope)
 
-- **Multi-agente + aggregator** — PR5c. El motor actual invoca `step.Agents[0]`.
-- **Entry agent + flag `--from`** — PR5d. El motor soporta `EntryStep` interno; falta el CLI y la corrida del entry agent antes del primer step.
-- **Cancelación parcial (SIGTERM + grace + SIGKILL)** — PR5c, junto con multi-agente.
-- **Wiring real con `internal/agent.Run`** — follow-up cuando PR1 + PR2 estén en main. Por ahora el motor funciona con cualquier `Invoker`, lo cual es suficiente para el wireup del comando `che pipeline simulate` (PR4) que usa un dry-run invoker.
+- **Borrar `internal/engine/marker_test.go`** — los tests duplicados pasan por el shim, pero podrían borrarse como cleanup. No urgente: redundancia barata.
+- **Migrar callers internos de `engine.MarkerXxx` a `markerparser.Xxx`** — el shim funciona, no hay urgencia. Cuando se haga PR4 / PR5d y se toque el motor, se aprovecha para limpiar.
+- **Soporte para markers fuera del último output** — la spec del PRD dice "última línea no vacía", el parser cumple. Si en el futuro queremos parsear el último marker de cualquier línea (no sólo la última), sería un nuevo helper, no un cambio a `Parse`.

--- a/internal/engine/marker.go
+++ b/internal/engine/marker.go
@@ -9,181 +9,48 @@
 // transiciones por corrida. Multi-agente + aggregator + cancelación parcial
 // viven en PR5c; entry agent + `--from` en PR5d.
 //
-// El package se diseñó self-contained sobre interfaces (`Invoker`) y tipos
-// minimales (`Pipeline`/`Step`) para que se pueda mergear antes que PR1
-// (`internal/agentregistry`) y PR2 (`internal/pipeline`). Cuando esos PRs
-// estén en main, un follow-up wirea `engine.Run` para consumir
-// `pipeline.Pipeline` directamente y resolver agentes via `agentregistry`.
+// PR5a (mergeado en este árbol) extrajo el parser de markers a un paquete
+// puro `internal/markerparser`. Este archivo conserva los nombres del PR5b
+// original (`MarkerKind`, `MarkerNext`, `ParseMarker`, …) como aliases /
+// thin wrappers para no romper los tests del motor ni los callers internos
+// — la lógica de parsing vive una sola vez, en `markerparser`.
 package engine
 
 import (
-	"encoding/json"
-	"regexp"
-	"strings"
+	"github.com/chichex/che/internal/markerparser"
 )
 
 // MarkerKind enumera los 3 tipos de control de flujo que un agente puede
-// emitir al final de su output. PRD §3.c define la spec formal del parser.
-type MarkerKind int
+// emitir. Es alias de markerparser.Kind — se mantiene el nombre antiguo
+// para los callers ya escritos en este paquete (engine.go, engine_test.go).
+type MarkerKind = markerparser.Kind
 
+// Constantes-alias que apuntan a los valores de markerparser. Mantener los
+// nombres "MarkerXxx" en engine evita renombrar el motor cuando el parser
+// se extrajo a su propio paquete (PR5a). Los callers nuevos deberían usar
+// directamente markerparser.Next / markerparser.Stop / etc.
 const (
-	// MarkerNone indica que el output no terminó con un marker reconocido.
-	// El motor lo trata como [next] cuando la invocación fue técnicamente
-	// exitosa (PRD §3.b paso 5: "Si no hay marker → asume [next]").
-	MarkerNone MarkerKind = iota
-
-	// MarkerNext: avanzar al siguiente step. También es el default cuando
-	// la invocación terminó bien y no se encontró marker.
-	MarkerNext
-
-	// MarkerGoto: saltar al step nombrado en Goto. Si el step no existe
-	// en el pipeline, el motor convierte esto en MarkerStop con razón
-	// "step destino desconocido" (PRD §3.c "Step destino inválido").
-	MarkerGoto
-
-	// MarkerStop: parar el pipeline. che marca la entity como blocked y
-	// notifica al humano. También se aplica automáticamente cuando la
-	// invocación del agente falla técnicamente (PRD §3.b paso 4).
-	MarkerStop
+	MarkerNone = markerparser.None
+	MarkerNext = markerparser.Next
+	MarkerGoto = markerparser.Goto
+	MarkerStop = markerparser.Stop
 )
 
-// String facilita el logging y los test failures.
-func (m MarkerKind) String() string {
-	switch m {
-	case MarkerNone:
-		return "none"
-	case MarkerNext:
-		return "next"
-	case MarkerGoto:
-		return "goto"
-	case MarkerStop:
-		return "stop"
-	}
-	return "unknown"
-}
+// Marker es el resultado parseado del output de un agente. Alias de
+// markerparser.Marker; los campos (Kind, Goto) y la semántica son
+// idénticos.
+type Marker = markerparser.Marker
 
-// Marker es el resultado parseado del output de un agente. Goto sólo se
-// llena cuando Kind == MarkerGoto.
-type Marker struct {
-	Kind MarkerKind
-	// Goto es el nombre del step destino cuando Kind == MarkerGoto. El
-	// nombre ya viene normalizado (sin espacios alrededor del ":"). Para
-	// los otros Kinds queda vacío.
-	Goto string
-}
-
-// markerRe es la regex canónica del PRD §3.c.
-//
-//   - ancla a línea completa (^...$): el marker tiene que ocupar la línea
-//     entera, sin prosa antes ni después (whitespace permitido).
-//   - case-sensitive: `[Next]` / `[GOTO: x]` NO matchean. Sin (?i).
-//   - el step destino respeta el fragmento `[a-z_][a-z0-9_]*` — el mismo
-//     que valida el name de Step en `internal/pipeline`.
-//   - el `\s*` después de `goto:` permite tanto `[goto:foo]` como
-//     `[goto: foo]`. Trailing whitespace después del `]` se tolera porque
-//     editores agregan trailing spaces sin que el agente se entere.
-var markerRe = regexp.MustCompile(`^\s*\[(next|stop|goto:\s*([a-z_][a-z0-9_]*))\]\s*$`)
-
-// ParseMarker busca un marker en la última línea no-vacía del output.
-// Devuelve (Marker{MarkerNone}, false) si no encuentra marker. Trailing
-// newlines/whitespace se ignoran. Markers en líneas intermedias se
-// ignoran — el parser sólo mira la última línea no vacía (PRD §3.c
-// "Markers en líneas intermedias se ignoran").
-//
-// El segundo return distingue "no había marker" de "hay un marker pero es
-// MarkerStop": MarkerStop es un marker válido y devuelve true.
+// ParseMarker delega en markerparser.Parse. Se conserva el nombre con
+// prefijo "Marker" porque el motor lo usa internamente y porque hay tests
+// existentes que importan el símbolo desde este paquete. PR5a movió la
+// implementación al paquete puro `internal/markerparser`.
 func ParseMarker(output string) (Marker, bool) {
-	last, ok := lastNonEmptyLine(output)
-	if !ok {
-		return Marker{Kind: MarkerNone}, false
-	}
-	m := markerRe.FindStringSubmatch(last)
-	if m == nil {
-		return Marker{Kind: MarkerNone}, false
-	}
-	// m[1] es el grupo principal (next | stop | goto:...).
-	// m[2] es el step destino cuando es un goto.
-	switch {
-	case m[1] == "next":
-		return Marker{Kind: MarkerNext}, true
-	case m[1] == "stop":
-		return Marker{Kind: MarkerStop}, true
-	default:
-		// goto: el match garantiza m[2] no vacío.
-		return Marker{Kind: MarkerGoto, Goto: m[2]}, true
-	}
+	return markerparser.Parse(output)
 }
 
-// lastNonEmptyLine devuelve la última línea de s que tiene al menos un
-// caracter no-whitespace. ok=false si el output entero está vacío o sólo
-// tiene whitespace.
-func lastNonEmptyLine(s string) (string, bool) {
-	// Recorrer hacia atrás es marginalmente más rápido que split + reverse,
-	// y evita una alocación de slice cuando hay millones de líneas (caso
-	// extremo del stream-json del executor).
-	end := len(s)
-	for end > 0 {
-		// encontrar el inicio de la línea actual
-		start := strings.LastIndexByte(s[:end], '\n')
-		// start == -1 → no hay newline antes; la línea va desde 0
-		// start >= 0  → la línea va desde start+1
-		var line string
-		if start == -1 {
-			line = s[:end]
-		} else {
-			line = s[start+1 : end]
-		}
-		if strings.TrimSpace(line) != "" {
-			return line, true
-		}
-		if start == -1 {
-			return "", false
-		}
-		end = start
-	}
-	return "", false
-}
-
-// ParseStreamMarker busca un marker en el stream-json de claude (formato
-// `--output-format stream-json --verbose`). Recorre los eventos NDJSON y
-// se queda con el último evento `result`. Aplica ParseMarker sobre el
-// campo `result` (que claude usa para el texto final del asistente).
-//
-// PRD §3.c "OutputStreamJSON": "para agentes que ejecutan via streaming
-// (executors con tool use), che parsea el último evento `result` del
-// stream y aplica la regex al campo `text`. Si el último output no es
-// texto (LLM cerró con tool_use sin response final), default [next]".
-//
-// Implementación: el evento `result` de claude trae el texto en el campo
-// `result` (no `text` — la PRD lo simplifica para el lector). Si el
-// stream no tiene ningún evento `result` con campo string, devolvemos
-// (Marker{MarkerNone}, false) y el caller aplica el default [next].
-//
-// Líneas que no parsean como JSON se ignoran (no fallan el parser). Esto
-// es importante porque los fakes de e2e a veces escriben texto plano al
-// stdout — y porque claude con --verbose puede emitir headers no-JSON.
+// ParseStreamMarker delega en markerparser.ParseStreamJSON. Mismo motivo
+// que ParseMarker: nombre legacy del PR5b, lógica en el paquete puro.
 func ParseStreamMarker(stream string) (Marker, bool) {
-	var lastResultText string
-	var foundResult bool
-	for _, line := range strings.Split(stream, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" || !strings.HasPrefix(trimmed, "{") {
-			continue
-		}
-		var ev struct {
-			Type   string `json:"type"`
-			Result string `json:"result"`
-		}
-		if err := json.Unmarshal([]byte(trimmed), &ev); err != nil {
-			continue
-		}
-		if ev.Type == "result" {
-			lastResultText = ev.Result
-			foundResult = true
-		}
-	}
-	if !foundResult || lastResultText == "" {
-		return Marker{Kind: MarkerNone}, false
-	}
-	return ParseMarker(lastResultText)
+	return markerparser.ParseStreamJSON(stream)
 }

--- a/internal/markerparser/markerparser.go
+++ b/internal/markerparser/markerparser.go
@@ -1,0 +1,222 @@
+// Package markerparser implementa el parser puro de los markers de control
+// de flujo que los agentes de che emiten al final de su output (PRD #50
+// §3.c). Los 3 markers son:
+//
+//   - [next]              avanzar al siguiente step del pipeline (default
+//     implícito si la invocación terminó bien y no hay marker reconocido).
+//   - [goto: <step_name>] saltar al step nombrado. <step_name> debe matchear
+//     el fragmento `[a-z_][a-z0-9_]*` (mismo identificador que valida el
+//     name de Step en `internal/pipeline`).
+//   - [stop]              parar el pipeline. che marca la entity como
+//     blocked y notifica al humano.
+//
+// El paquete es **puro**: string in, marker out. No depende de `internal/
+// engine` ni de `internal/agent` — al revés, esos paquetes lo consumen. La
+// validación de que el step destino de `[goto: X]` exista en el pipeline
+// vive en el motor (no acá): el parser sólo dice "qué pidió el agente"; el
+// motor decide qué hacer si el destino no es alcanzable.
+//
+// API pública:
+//
+//   - Parse(text)           recorre el output completo del agente y aplica la
+//     regex sobre la última línea no vacía. Devuelve (Marker, ok).
+//   - ParseLastLine(line)   parsea una sola línea sin la lógica de "buscar la
+//     última no-vacía". Útil cuando el caller ya tiene la línea aislada.
+//   - ParseStreamJSON(s)    parser dedicado al stream-json --verbose de claude
+//     (executors con tool use). Encuentra el último evento `result` y aplica
+//     Parse sobre su campo `result`.
+//
+// Ninguno de los tres aplica un *default* `[next]` cuando no encuentra un
+// marker — ese fallback es responsabilidad del caller (motor) porque depende
+// de si la invocación fue técnicamente exitosa o falló. Ver PRD §3.b paso 5.
+package markerparser
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+)
+
+// Kind enumera los 3 tipos de control de flujo que un agente puede emitir.
+// Una cuarta variante None se reserva para "no se encontró marker" — el
+// caller decide si reemplazarla por Next (invocación exitosa) o Stop (error
+// técnico).
+type Kind int
+
+const (
+	// None indica que el output no terminó con un marker reconocido.
+	// Caller decide el default según el outcome de la invocación.
+	None Kind = iota
+
+	// Next: avanzar al siguiente step.
+	Next
+
+	// Goto: saltar al step nombrado en Marker.Goto. La existencia del
+	// step en el pipeline NO es responsabilidad del parser — el motor la
+	// chequea.
+	Goto
+
+	// Stop: parar el pipeline.
+	Stop
+)
+
+// String facilita el logging y los test failures.
+func (k Kind) String() string {
+	switch k {
+	case None:
+		return "none"
+	case Next:
+		return "next"
+	case Goto:
+		return "goto"
+	case Stop:
+		return "stop"
+	}
+	return "unknown"
+}
+
+// Marker es el resultado parseado del output de un agente.
+type Marker struct {
+	// Kind es el tipo de marker. Cuando es None significa que el parser no
+	// encontró un marker válido; los demás son los 3 markers del PRD.
+	Kind Kind
+	// Goto es el nombre del step destino cuando Kind == Goto. Viene
+	// normalizado (sin espacios alrededor del ":"). Vacío para los otros
+	// Kinds.
+	Goto string
+}
+
+// markerRe es la regex canónica del PRD §3.c.
+//
+//   - Anclada a línea completa (^...$): el marker tiene que ocupar la línea
+//     entera, sin prosa antes ni después (whitespace permitido).
+//   - Case-sensitive: `[Next]` / `[GOTO: x]` NO matchean. Sin (?i).
+//   - Step destino respeta `[a-z_][a-z0-9_]*` — el mismo fragmento que valida
+//     el name de Step en `internal/pipeline`.
+//   - El `\s*` después de `goto:` permite tanto `[goto:foo]` como
+//     `[goto: foo]`. Trailing whitespace después del `]` se tolera porque
+//     algunos editores agregan trailing spaces sin que el agente se entere.
+var markerRe = regexp.MustCompile(`^\s*\[(next|stop|goto:\s*([a-z_][a-z0-9_]*))\]\s*$`)
+
+// Parse busca un marker en la última línea no-vacía del output. Trailing
+// newlines/whitespace se ignoran. Markers en líneas intermedias se ignoran
+// — sólo se mira la última línea no vacía (PRD §3.c).
+//
+// Retorno:
+//   - Marker{Kind: None}, false si no encontró marker (output vacío,
+//     output sólo whitespace, última línea no matchea la regex).
+//   - (m, true) si encontró un marker válido. Para Goto, m.Goto contiene
+//     el step destino sin espacios.
+//
+// El segundo return distingue "no había marker" de "había Stop": Stop es un
+// marker válido y devuelve true.
+func Parse(text string) (Marker, bool) {
+	last, ok := lastNonEmptyLine(text)
+	if !ok {
+		return Marker{Kind: None}, false
+	}
+	return ParseLastLine(last)
+}
+
+// ParseLastLine aplica la regex a una sola línea, sin lógica de "buscar la
+// última no-vacía". Útil cuando el caller ya tiene la línea aislada (e.g.
+// el invoker streamea línea por línea y quiere reportar el marker apenas
+// llega).
+//
+// Whitespace al inicio/fin de la línea se tolera (mismo comportamiento que
+// Parse). Línea vacía o sólo whitespace → (Marker{None}, false).
+func ParseLastLine(line string) (Marker, bool) {
+	m := markerRe.FindStringSubmatch(line)
+	if m == nil {
+		return Marker{Kind: None}, false
+	}
+	// m[1] es el grupo principal (next | stop | goto:...).
+	// m[2] es el step destino cuando es un goto.
+	switch {
+	case m[1] == "next":
+		return Marker{Kind: Next}, true
+	case m[1] == "stop":
+		return Marker{Kind: Stop}, true
+	default:
+		// goto: el match garantiza m[2] no vacío.
+		return Marker{Kind: Goto, Goto: m[2]}, true
+	}
+}
+
+// lastNonEmptyLine devuelve la última línea de s que tiene al menos un
+// caracter no-whitespace. ok=false si el input entero está vacío o sólo
+// tiene whitespace.
+//
+// Recorre el string hacia atrás (no Split) para evitar la alocación del
+// slice intermedio cuando hay muchas líneas — el stream-json del executor
+// puede traer miles.
+func lastNonEmptyLine(s string) (string, bool) {
+	end := len(s)
+	for end > 0 {
+		start := strings.LastIndexByte(s[:end], '\n')
+		var line string
+		if start == -1 {
+			line = s[:end]
+		} else {
+			line = s[start+1 : end]
+		}
+		if strings.TrimSpace(line) != "" {
+			return line, true
+		}
+		if start == -1 {
+			return "", false
+		}
+		end = start
+	}
+	return "", false
+}
+
+// ParseStreamJSON busca un marker en el stream-json de claude (formato
+// `--output-format stream-json --verbose`, el que usan los executors con
+// tool use). Recorre los eventos NDJSON y se queda con el ÚLTIMO evento
+// `result`, aplicando Parse sobre su campo `result`.
+//
+// PRD §3.c "OutputStreamJSON":
+//
+//	"para agentes que ejecutan via streaming, che parsea el último evento
+//	`result` del stream y aplica la regex al campo de texto. Si el último
+//	output no es texto (LLM cerró con tool_use sin response final),
+//	default [next] (resolver en el caller)."
+//
+// Notas de implementación:
+//
+//   - El evento `result` de claude trae el texto del asistente en el campo
+//     `result` (sí, el campo se llama igual que el tipo). Mantenemos el
+//     nombre para no inventar un mapping propio.
+//   - Líneas que no parsean como JSON se ignoran (no fallan el parser).
+//     Esto es importante porque algunos fakes de e2e o headers de
+//     `claude --verbose` escriben texto plano al stdout.
+//   - Si hay múltiples eventos `result` (caso raro), gana el último —
+//     porque el stream cierra con su outcome final.
+//   - Si no hay ningún evento `result` con texto no vacío, devolvemos
+//     (Marker{None}, false) y el caller aplica el default [next].
+func ParseStreamJSON(stream string) (Marker, bool) {
+	var lastResultText string
+	var foundResult bool
+	for _, line := range strings.Split(stream, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || !strings.HasPrefix(trimmed, "{") {
+			continue
+		}
+		var ev struct {
+			Type   string `json:"type"`
+			Result string `json:"result"`
+		}
+		if err := json.Unmarshal([]byte(trimmed), &ev); err != nil {
+			continue
+		}
+		if ev.Type == "result" {
+			lastResultText = ev.Result
+			foundResult = true
+		}
+	}
+	if !foundResult || lastResultText == "" {
+		return Marker{Kind: None}, false
+	}
+	return Parse(lastResultText)
+}

--- a/internal/markerparser/markerparser_test.go
+++ b/internal/markerparser/markerparser_test.go
@@ -1,0 +1,486 @@
+package markerparser
+
+import (
+	"strings"
+	"testing"
+)
+
+// -----------------------------------------------------------------------------
+// Parse — markers válidos
+// -----------------------------------------------------------------------------
+
+func TestParse_BasicMarkers(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		want   Marker
+		wantOk bool
+	}{
+		{"next solo", "[next]", Marker{Kind: Next}, true},
+		{"stop solo", "[stop]", Marker{Kind: Stop}, true},
+		{"goto sin espacio", "[goto:foo]", Marker{Kind: Goto, Goto: "foo"}, true},
+		{"goto con espacio", "[goto: foo]", Marker{Kind: Goto, Goto: "foo"}, true},
+		{"goto con underscores", "[goto: validate_pr]", Marker{Kind: Goto, Goto: "validate_pr"}, true},
+		{"goto numérico interno", "[goto: step_2_check]", Marker{Kind: Goto, Goto: "step_2_check"}, true},
+		{"goto multiple espacios post-colon", "[goto:   foo]", Marker{Kind: Goto, Goto: "foo"}, true},
+		{"goto solo letras", "[goto: explore]", Marker{Kind: Goto, Goto: "explore"}, true},
+		{"goto empieza con underscore", "[goto: _internal]", Marker{Kind: Goto, Goto: "_internal"}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := Parse(tc.input)
+			if ok != tc.wantOk {
+				t.Fatalf("ok=%v want %v (got=%+v)", ok, tc.wantOk, got)
+			}
+			if got != tc.want {
+				t.Errorf("got %+v want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParse_WhitespaceTolerance(t *testing.T) {
+	// PRD §3.c: trailing newlines/whitespace ignorados; whitespace pegado
+	// al marker dentro de la línea también se tolera.
+	cases := []struct {
+		name  string
+		input string
+		want  Marker
+	}{
+		{"trailing whitespace", "[next]   ", Marker{Kind: Next}},
+		{"leading whitespace", "   [next]", Marker{Kind: Next}},
+		{"leading + trailing", "  [next]  ", Marker{Kind: Next}},
+		{"trailing newlines", "[next]\n\n\n", Marker{Kind: Next}},
+		{"leading + trailing newlines", "\n\n[next]\n", Marker{Kind: Next}},
+		{"goto trailing whitespace", "[goto: explore]   ", Marker{Kind: Goto, Goto: "explore"}},
+		{"goto leading whitespace", "   [goto: explore]", Marker{Kind: Goto, Goto: "explore"}},
+		{"stop con tabs", "\t[stop]\t", Marker{Kind: Stop}},
+		{"trailing whitespace + newlines mixto", "[next]   \n   \n", Marker{Kind: Next}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := Parse(tc.input)
+			if !ok {
+				t.Fatalf("expected ok=true; got=%+v", got)
+			}
+			if got != tc.want {
+				t.Errorf("got %+v want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Parse — case sensitivity (PRD §3.c)
+// -----------------------------------------------------------------------------
+
+func TestParse_CaseSensitive(t *testing.T) {
+	// PRD §3.c: "Case-sensitive: [Next] / [GOTO: x] NO matchean".
+	cases := []string{
+		"[Next]",
+		"[NEXT]",
+		"[nExt]",
+		"[Stop]",
+		"[STOP]",
+		"[Goto: foo]",
+		"[GOTO: foo]",
+		"[goto: FOO]", // step name uppercase está fuera de la regex
+		"[goto: Foo]",
+		"[goto: foo_BAR]",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			got, ok := Parse(in)
+			if ok {
+				t.Errorf("Parse(%q) = %+v, ok=true; expected ok=false (case-sensitive)", in, got)
+			}
+			if got.Kind != None {
+				t.Errorf("got Kind=%v want None", got.Kind)
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Parse — sólo última línea no vacía (PRD §3.c)
+// -----------------------------------------------------------------------------
+
+func TestParse_LastLineOnly(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		want   Marker
+		wantOk bool
+	}{
+		{
+			name:   "marker intermedio, prosa al final → no match",
+			input:  "Análisis:\n[next] esto es prosa explicativa\nEl plan está OK pero quiero revisar.",
+			want:   Marker{Kind: None},
+			wantOk: false,
+		},
+		{
+			name:   "marker en última línea, trailing newlines",
+			input:  "Análisis: el plan está OK.\n[next]\n\n\n",
+			want:   Marker{Kind: Next},
+			wantOk: true,
+		},
+		{
+			name:   "marker en última línea con whitespace pegado",
+			input:  "Decisión:\n  [stop]  \n",
+			want:   Marker{Kind: Stop},
+			wantOk: true,
+		},
+		{
+			name:   "marker SOLO en línea intermedia (default a no-marker)",
+			input:  "[goto: explore]\nAhora explico por qué.",
+			want:   Marker{Kind: None},
+			wantOk: false,
+		},
+		{
+			name:   "prosa antes + marker en última línea",
+			input:  "lorem ipsum\n[next]",
+			want:   Marker{Kind: Next},
+			wantOk: true,
+		},
+		{
+			name:   "marker mezclado con prosa en la misma línea final",
+			input:  "primer parrafo\nlorem [next] ipsum\nfin sin marker",
+			want:   Marker{Kind: None},
+			wantOk: false,
+		},
+		{
+			name:   "trailing whitespace lines no afectan",
+			input:  "lorem ipsum\n[stop]\n   \n   \n",
+			want:   Marker{Kind: Stop},
+			wantOk: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := Parse(tc.input)
+			if ok != tc.wantOk {
+				t.Fatalf("ok=%v want %v (got=%+v)", ok, tc.wantOk, got)
+			}
+			if got != tc.want {
+				t.Errorf("got %+v want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Parse — formas inválidas: step destino, brackets, vacío
+// -----------------------------------------------------------------------------
+
+func TestParse_InvalidShape(t *testing.T) {
+	// Casos donde NO hay marker. Parser determinístico, sin fuzzy.
+	cases := []string{
+		"",
+		" ",
+		"\n\n  \n",
+		"plan ok",
+		"goto: foo", // sin brackets
+		"[next] ok", // texto post bracket en la misma línea
+		"prefix [next]",
+		"[]",
+		"[foo]",                  // marker desconocido
+		"[goto:]",                // goto sin destino
+		"[goto: ]",               // goto con sólo whitespace
+		"[goto:  ]",              // goto con varios espacios
+		"[goto: 123foo]",         // step empieza con dígito (regex exige [a-z_])
+		"[goto: 1step]",          // mismo: dígito al inicio
+		"[goto: step-name]",      // guión no permitido
+		"[goto: step.name]",      // punto no permitido
+		"[goto: step name]",      // espacio interno
+		"[next ",                 // bracket roto
+		"[next\n]",               // marker partido en líneas
+		"[next][stop]",           // dos markers seguidos
+		"[next]extra",            // texto sin separador
+	}
+	for _, in := range cases {
+		t.Run(strings.ReplaceAll(in, "\n", "\\n"), func(t *testing.T) {
+			got, ok := Parse(in)
+			if ok {
+				t.Errorf("Parse(%q) = %+v, ok=true; want ok=false", in, got)
+			}
+			if got.Kind != None {
+				t.Errorf("got Kind=%v want None", got.Kind)
+			}
+		})
+	}
+}
+
+func TestParse_EmptyAndWhitespaceOnly(t *testing.T) {
+	cases := []string{
+		"",
+		" ",
+		"   ",
+		"\n",
+		"\n\n\n",
+		"\t\t",
+		" \n \n\t ",
+	}
+	for _, in := range cases {
+		t.Run(strings.ReplaceAll(in, "\n", "\\n"), func(t *testing.T) {
+			got, ok := Parse(in)
+			if ok {
+				t.Errorf("Parse(%q) = %+v, ok=true; want ok=false", in, got)
+			}
+			if got.Kind != None {
+				t.Errorf("got Kind=%v want None", got.Kind)
+			}
+		})
+	}
+}
+
+func TestParse_ProsaLargaTerminandoEnMarker(t *testing.T) {
+	// Caso típico real: el agente escribe párrafos y termina con el marker.
+	input := `Revisé el plan propuesto.
+
+Los puntos sólidos:
+- Tests cubren casos felices y un par de errores
+- El cap de 20 transiciones es defensa razonable
+
+Faltó:
+- No vi cómo se valida que el step destino exista
+- Pequeño nit en la docstring de Parse
+
+Voy a pedir un ajuste antes de avanzar.
+
+[goto: explore]`
+	got, ok := Parse(input)
+	if !ok {
+		t.Fatalf("expected marker found; got=%+v", got)
+	}
+	if got.Kind != Goto || got.Goto != "explore" {
+		t.Errorf("got %+v, want goto:explore", got)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// ParseLastLine — recibe sólo una línea
+// -----------------------------------------------------------------------------
+
+func TestParseLastLine_ReconoceMarkers(t *testing.T) {
+	cases := []struct {
+		name   string
+		input  string
+		want   Marker
+		wantOk bool
+	}{
+		{"next", "[next]", Marker{Kind: Next}, true},
+		{"stop", "[stop]", Marker{Kind: Stop}, true},
+		{"goto", "[goto: foo]", Marker{Kind: Goto, Goto: "foo"}, true},
+		{"con whitespace", "  [next]  ", Marker{Kind: Next}, true},
+		{"vacio", "", Marker{Kind: None}, false},
+		{"prosa pura", "el plan está OK", Marker{Kind: None}, false},
+		{"case-mismatch", "[Next]", Marker{Kind: None}, false},
+		{"goto invalido", "[goto: 1foo]", Marker{Kind: None}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ParseLastLine(tc.input)
+			if ok != tc.wantOk {
+				t.Fatalf("ok=%v want %v (got=%+v)", ok, tc.wantOk, got)
+			}
+			if got != tc.want {
+				t.Errorf("got %+v want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseLastLine_NoEsperaMultilinea(t *testing.T) {
+	// Si el caller le pasa un string con \n adentro, ParseLastLine NO debe
+	// matchear: la regex está anclada con ^...$ pensando en una sola línea.
+	got, ok := ParseLastLine("blah\n[next]")
+	if ok {
+		t.Errorf("ParseLastLine multilínea no debería matchear; got=%+v", got)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// ParseStreamJSON — stream NDJSON con tool use
+// -----------------------------------------------------------------------------
+
+func TestParseStreamJSON_LastResultEvent(t *testing.T) {
+	// Stream típico: system init, varios assistant/tool_use, y al final un
+	// evento result con el texto del asistente.
+	stream := strings.Join([]string{
+		`{"type":"system","subtype":"init"}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"working..."}]}}`,
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"foo.go"}}]}}`,
+		`{"type":"result","subtype":"success","result":"todo OK\n[next]"}`,
+	}, "\n")
+
+	got, ok := ParseStreamJSON(stream)
+	if !ok {
+		t.Fatalf("expected marker; got=%+v", got)
+	}
+	if got.Kind != Next {
+		t.Errorf("got %+v want next", got)
+	}
+}
+
+func TestParseStreamJSON_LastResultWins(t *testing.T) {
+	// Si hay múltiples events `result` (escenario raro pero documentable),
+	// gana el último — el stream cierra con su outcome final.
+	stream := strings.Join([]string{
+		`{"type":"result","subtype":"interim","result":"[goto: explore]"}`,
+		`{"type":"result","subtype":"success","result":"[stop]"}`,
+	}, "\n")
+
+	got, ok := ParseStreamJSON(stream)
+	if !ok {
+		t.Fatalf("expected marker; got=%+v", got)
+	}
+	if got.Kind != Stop {
+		t.Errorf("got %+v want stop (último result gana)", got)
+	}
+}
+
+func TestParseStreamJSON_NoResultEvent(t *testing.T) {
+	// PRD §3.c: si el último output no es texto (LLM cerró con tool_use
+	// sin response final), default [next] — pero ese default lo aplica el
+	// caller. El parser sólo reporta "no encontró marker".
+	stream := strings.Join([]string{
+		`{"type":"system","subtype":"init"}`,
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"ls"}}]}}`,
+	}, "\n")
+
+	got, ok := ParseStreamJSON(stream)
+	if ok {
+		t.Errorf("expected no marker (sin event result); got=%+v", got)
+	}
+	if got.Kind != None {
+		t.Errorf("got Kind=%v want None", got.Kind)
+	}
+}
+
+func TestParseStreamJSON_ResultConTextoVacio(t *testing.T) {
+	// Evento result con `result` vacío → tratamos como "no hay marker".
+	stream := `{"type":"result","subtype":"success","result":""}`
+	got, ok := ParseStreamJSON(stream)
+	if ok {
+		t.Errorf("expected no marker (result vacío); got=%+v", got)
+	}
+	if got.Kind != None {
+		t.Errorf("got Kind=%v want None", got.Kind)
+	}
+}
+
+func TestParseStreamJSON_IgnoraLineasNoJSON(t *testing.T) {
+	// Algunos fakes de e2e o headers de claude --verbose escriben texto
+	// plano. El parser no debe fallar — sólo ignorar esas líneas.
+	stream := strings.Join([]string{
+		`>>> claude verbose header`,
+		`{"type":"result","subtype":"success","result":"[next]"}`,
+		`>>> trailing log noise`,
+	}, "\n")
+
+	got, ok := ParseStreamJSON(stream)
+	if !ok {
+		t.Fatalf("expected marker; got=%+v", got)
+	}
+	if got.Kind != Next {
+		t.Errorf("got %+v want next", got)
+	}
+}
+
+func TestParseStreamJSON_IgnoraLineasJSONInvalido(t *testing.T) {
+	// JSON mal formado en el stream no debe colgar el parser. La línea con
+	// JSON válido sigue ganando.
+	stream := strings.Join([]string{
+		`{"type":"system","subtype":"init"}`,
+		`{not valid json at all`,
+		`{"type":"result","subtype":"success","result":"[goto: validate]"}`,
+	}, "\n")
+
+	got, ok := ParseStreamJSON(stream)
+	if !ok {
+		t.Fatalf("expected marker; got=%+v", got)
+	}
+	if got.Kind != Goto || got.Goto != "validate" {
+		t.Errorf("got %+v want goto:validate", got)
+	}
+}
+
+func TestParseStreamJSON_EmptyStream(t *testing.T) {
+	got, ok := ParseStreamJSON("")
+	if ok {
+		t.Errorf("expected no marker on empty stream; got=%+v", got)
+	}
+	if got.Kind != None {
+		t.Errorf("got Kind=%v want None", got.Kind)
+	}
+}
+
+func TestParseStreamJSON_OnlyWhitespace(t *testing.T) {
+	got, ok := ParseStreamJSON("   \n\n   \n\t  ")
+	if ok {
+		t.Errorf("expected no marker on whitespace-only stream; got=%+v", got)
+	}
+	if got.Kind != None {
+		t.Errorf("got Kind=%v want None", got.Kind)
+	}
+}
+
+func TestParseStreamJSON_ResultConProsaLargaTerminandoEnMarker(t *testing.T) {
+	// El campo `result` viene como texto multilinea — Parse mira la última
+	// línea no vacía.
+	stream := `{"type":"result","subtype":"success","result":"Revisé el código.\n\nTodo bien.\n\n[goto: validate_pr]"}`
+	got, ok := ParseStreamJSON(stream)
+	if !ok {
+		t.Fatalf("expected marker; got=%+v", got)
+	}
+	if got.Kind != Goto || got.Goto != "validate_pr" {
+		t.Errorf("got %+v, want goto:validate_pr", got)
+	}
+}
+
+func TestParseStreamJSON_ResultSinMarker(t *testing.T) {
+	// El último result tiene texto pero la última línea no es un marker —
+	// el parser reporta no-match (caller aplicará default [next]).
+	stream := `{"type":"result","subtype":"success","result":"todo bien, sin marker explícito"}`
+	got, ok := ParseStreamJSON(stream)
+	if ok {
+		t.Errorf("expected no marker (último result sin marker); got=%+v", got)
+	}
+	if got.Kind != None {
+		t.Errorf("got Kind=%v want None", got.Kind)
+	}
+}
+
+func TestParseStreamJSON_ResultConCaseMismatch(t *testing.T) {
+	// Stream con [Next] (mayúscula) en el result → no matchea.
+	stream := `{"type":"result","subtype":"success","result":"trabajado\n[Next]"}`
+	got, ok := ParseStreamJSON(stream)
+	if ok {
+		t.Errorf("expected no marker (case-mismatch); got=%+v", got)
+	}
+	if got.Kind != None {
+		t.Errorf("got Kind=%v want None", got.Kind)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Kind.String — sanity check para logs y test failures
+// -----------------------------------------------------------------------------
+
+func TestKindString(t *testing.T) {
+	cases := []struct {
+		kind Kind
+		want string
+	}{
+		{None, "none"},
+		{Next, "next"},
+		{Goto, "goto"},
+		{Stop, "stop"},
+		{Kind(99), "unknown"},
+	}
+	for _, tc := range cases {
+		if got := tc.kind.String(); got != tc.want {
+			t.Errorf("Kind(%d).String()=%q want %q", tc.kind, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Implementa #61.

Closes #61

## Implementado

Nuevo paquete puro `internal/markerparser/` (string in, marker out, sin deps del engine ni del agent). Implementa el contrato del PRD §3.c.

API publica:
- `Kind` enum: `None`, `Next`, `Goto`, `Stop` (+ `String()`)
- `Marker{ Kind, Goto }`
- `Parse(text) (Marker, bool)` — recorre el output completo, regex sobre la ultima linea no-vacia
- `ParseLastLine(line) (Marker, bool)` — version single-line
- `ParseStreamJSON(stream) (Marker, bool)` — recorre NDJSON, ultimo evento `result`, aplica `Parse` sobre `.result`

Regex canonica: `^\s*\[(next|stop|goto:\s*([a-z_][a-z0-9_]*))\]\s*$` (case-sensitive estricta).

## Tests

21 tests + 71 subtests (92 asserts):
- Markers validos: `[next]`, `[stop]`, `[goto: explore]`
- Whitespace tolerance: `  [next]  `, `\n\n[next]\n`
- Case-sensitive: `[Next]`/`[STOP]` no matchean
- Solo ultima linea no-vacia: marker en linea intermedia → no match
- Brackets rotos, step destino invalido, empty/whitespace-only
- Stream JSON: sin event `result`, ultimo `result` gana, lineas no-JSON, JSON invalido, result con texto vacio

`go build ./...`, `go vet`, `go test ./...` full suite verde.

## Compatibilidad con PR5b

`internal/engine/marker.go` quedo como thin shim:
- Type aliases (`MarkerKind = markerparser.Kind`, `Marker = markerparser.Marker`, constantes `MarkerNone/Next/Goto/Stop`)
- Funciones delegantes (`ParseMarker`, `ParseStreamMarker`)
- `engine.go` y `engine_test.go` NO se tocaron — siguen verdes

`type Marker = markerparser.Marker` (alias, no nuevo type) preserva igualdad estructural perfecta.

## Decisiones de diseño

- Parser NO aplica default `[next]` cuando no encuentra marker. Devuelve `(None, false)` y deja la decision al motor. Permite distinguir "output sin marker pero invocacion OK → next" de "invocacion fallo → stop".
- Step destino: identificador go-like (`[a-z_][a-z0-9_]*`). Step `123foo` o vacio no matchean.
- Stream JSON parser usa NDJSON line-by-line, sin parsear payload completo en memoria.

## Pendiente (menor)

- Cleanup opcional: borrar `internal/engine/marker_test.go` (los tests duplicados pasan por el shim — redundancia barata, no urgente).
- Migrar callers internos de `engine.MarkerXxx` a `markerparser.Xxx` cuando se toque PR4/PR5d. El shim funciona sin urgencia.
