### PR TITLE
feat(#56): [#50 PR4] Subcomandos del gestor de pipelines

### DIFF
--- a/cmd/pipeline.go
+++ b/cmd/pipeline.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/chichex/che/internal/pipeline"
+	"github.com/spf13/cobra"
+)
+
+// pipelineCmd es el padre de los subcomandos `che pipeline *`. No tiene
+// RunE: si el usuario tipea `che pipeline` sin argumentos, cobra muestra
+// el help con la lista de subcomandos disponibles.
+//
+// Los subcomandos viven en archivos hermanos (`pipeline_list.go`,
+// `pipeline_show.go`, etc.) y se enganchan via `pipelineCmd.AddCommand`
+// en sus respectivos init().
+var pipelineCmd = &cobra.Command{
+	Use:   "pipeline",
+	Short: "gestiona los pipelines del repo (list, show, use, new, clone, validate, simulate)",
+	Long: `pipeline agrupa los subcomandos para inspeccionar y operar sobre los
+pipelines configurables de che (PRD §7).
+
+Layout on-disk:
+  .che/pipelines/<name>.json    archivos de pipeline
+  .che/pipelines.config.json    declara qué pipeline es default
+
+Subcomandos:
+  list       lista los pipelines del repo + el default activo
+  show       imprime un pipeline por nombre (JSON o resumen)
+  use        marca un pipeline como default
+  new        materializa un pipeline desde el built-in (template)
+  clone      copia un pipeline aplicando sustituciones de strings
+  validate   chequea sintaxis + referencias a agentes (registry)
+  simulate   dry-run: muestra cómo se resolvería una corrida sin invocar LLM`,
+}
+
+func init() {
+	rootCmd.AddCommand(pipelineCmd)
+}
+
+// repoRootForPipeline resuelve el repo root activo via `git rev-parse
+// --show-toplevel`. Si falla (no hay git, cwd fuera de repo), devuelve
+// un error con un hint útil.
+//
+// Centralizado acá para que los 7 subcomandos compartan la misma
+// detección — si en un PR siguiente pasamos a `--repo-root` flag global,
+// solo cambia esta función.
+func repoRootForPipeline() (string, error) {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", fmt.Errorf("no se pudo detectar el repo root (asegurate de estar dentro de un repo git): %w", err)
+	}
+	root := strings.TrimSpace(string(out))
+	if root == "" {
+		return "", errors.New("git rev-parse --show-toplevel devolvió vacío")
+	}
+	return root, nil
+}
+
+// formatLoadError devuelve la representación humana de un error de
+// carga del paquete pipeline. Si es *pipeline.LoadError respeta los
+// metadatos (path:line:column field); sino, fallback al .Error() crudo.
+//
+// Mantenerlo en un helper evita repetir el `errors.As` en cada
+// subcomando que muestra errores de loader/validator.
+func formatLoadError(err error) string {
+	if err == nil {
+		return ""
+	}
+	var le *pipeline.LoadError
+	if errors.As(err, &le) {
+		return le.Error()
+	}
+	return err.Error()
+}

--- a/cmd/pipeline_clone.go
+++ b/cmd/pipeline_clone.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/chichex/che/internal/pipeline"
+	"github.com/spf13/cobra"
+)
+
+var (
+	pipelineCloneReplace []string
+	pipelineCloneForce   bool
+)
+
+var pipelineCloneCmd = &cobra.Command{
+	Use:   "clone <src> <dst>",
+	Short: "copia un pipeline aplicando sustituciones de strings",
+	Long: `clone duplica un pipeline existente y opcionalmente sustituye refs
+a agentes (PRD §1.c, ejemplo de quickstart caso B).
+
+Sustituciones:
+  --replace claude-opus=claude-sonnet
+  --replace plan-reviewer-strict=my-reviewer
+
+Las sustituciones aplican exact-match sobre los strings de
+` + "`entry.agents`" + ` y ` + "`steps[*].agents`" + `. No tocan ` + "`name`" + ` de step
+ni ` + "`aggregator`" + ` (esos son metadata, no refs reemplazables).
+
+Ejemplo del PRD:
+  che pipeline clone default fast --replace claude-opus=claude-sonnet
+
+Si <src> es ` + "`default`" + ` y no hay archivo on-disk, clone usa el built-in
+` + "`pipeline.Default()`" + ` como fuente.
+
+Por seguridad ` + "`clone`" + ` falla si <dst> ya existe. Para sobrescribir
+pasá --force.`,
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		root, err := repoRootForPipeline()
+		if err != nil {
+			return err
+		}
+		mgr, err := pipeline.NewManager(root)
+		if err != nil {
+			return fmt.Errorf("init pipeline manager: %s", formatLoadError(err))
+		}
+		return runPipelineClone(cmd.OutOrStdout(), mgr, args[0], args[1], pipelineCloneReplace, pipelineCloneForce)
+	},
+}
+
+func init() {
+	pipelineCloneCmd.Flags().StringArrayVar(&pipelineCloneReplace, "replace", nil,
+		"sustitución exact-match de agentes (formato old=new); puede repetirse")
+	pipelineCloneCmd.Flags().BoolVar(&pipelineCloneForce, "force", false,
+		"sobrescribe el destino si ya existe")
+	pipelineCmd.AddCommand(pipelineCloneCmd)
+}
+
+// runPipelineClone resuelve src (con fallback al built-in para "default"),
+// parsea las reglas --replace, aplica sustituciones, valida el resultado
+// y lo escribe en .che/pipelines/<dst>.json.
+func runPipelineClone(out io.Writer, mgr *pipeline.Manager, src, dst string, rawReplace []string, force bool) error {
+	if src == "" || dst == "" {
+		return fmt.Errorf("src y dst son obligatorios")
+	}
+	if src == dst {
+		return fmt.Errorf("src y dst no pueden ser iguales (%q)", src)
+	}
+
+	rules, err := parseReplaceRules(rawReplace)
+	if err != nil {
+		return err
+	}
+
+	srcPipeline, _, err := lookupPipelineForShow(mgr, src)
+	if err != nil {
+		return fmt.Errorf("leyendo src %q: %s", src, formatLoadError(err))
+	}
+
+	cloned := applyReplacements(srcPipeline, rules)
+	if err := pipeline.Validate(cloned); err != nil {
+		return fmt.Errorf("pipeline resultante inválido: %s", formatLoadError(err))
+	}
+
+	dest := filepath.Join(mgr.PipelinesDir(), dst+".json")
+	if !force {
+		if _, err := os.Stat(dest); err == nil {
+			return fmt.Errorf("%s ya existe — pasá --force para sobrescribir", dest)
+		}
+	}
+	if err := writeClonedPipeline(dest, cloned); err != nil {
+		return fmt.Errorf("escribir %s: %w", dest, err)
+	}
+	fmt.Fprintf(out, "creado %s (clonado de %q)\n", dest, src)
+	return nil
+}
+
+// parseReplaceRules valida el shape "old=new" de cada regla. Reglas
+// con old vacío o sin '=' se rechazan. new vacío SÍ es válido a nivel
+// parse (Validate del pipeline luego rechaza agentes vacíos — así el
+// usuario obtiene un error de loader puntual en vez de uno genérico
+// del flag parser).
+func parseReplaceRules(raw []string) (map[string]string, error) {
+	rules := map[string]string{}
+	for _, r := range raw {
+		idx := strings.Index(r, "=")
+		if idx < 0 {
+			return nil, fmt.Errorf("--replace %q: formato inválido, usá old=new", r)
+		}
+		old := strings.TrimSpace(r[:idx])
+		neu := strings.TrimSpace(r[idx+1:])
+		if old == "" {
+			return nil, fmt.Errorf("--replace %q: old no puede ser vacío", r)
+		}
+		if prev, dup := rules[old]; dup && prev != neu {
+			return nil, fmt.Errorf("--replace duplicado para %q (%q vs %q)", old, prev, neu)
+		}
+		rules[old] = neu
+	}
+	return rules, nil
+}
+
+// applyReplacements devuelve un pipeline nuevo con las reglas
+// aplicadas a entry.agents y steps[*].agents. NO muta el input.
+func applyReplacements(p pipeline.Pipeline, rules map[string]string) pipeline.Pipeline {
+	out := pipeline.Pipeline{
+		Version: p.Version,
+	}
+	if p.Entry != nil {
+		entry := pipeline.Entry{
+			Agents:     replaceAll(p.Entry.Agents, rules),
+			Aggregator: p.Entry.Aggregator,
+		}
+		out.Entry = &entry
+	}
+	out.Steps = make([]pipeline.Step, len(p.Steps))
+	for i, s := range p.Steps {
+		out.Steps[i] = pipeline.Step{
+			Name:       s.Name,
+			Agents:     replaceAll(s.Agents, rules),
+			Aggregator: s.Aggregator,
+			Comment:    s.Comment,
+		}
+	}
+	return out
+}
+
+// replaceAll mapea cada agente vía rules. Strings sin entry en rules
+// se devuelven tal cual.
+func replaceAll(agents []string, rules map[string]string) []string {
+	out := make([]string, len(agents))
+	for i, a := range agents {
+		if neu, ok := rules[a]; ok {
+			out[i] = neu
+			continue
+		}
+		out[i] = a
+	}
+	return out
+}
+
+func writeClonedPipeline(path string, p pipeline.Pipeline) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o644)
+}

--- a/cmd/pipeline_clone_test.go
+++ b/cmd/pipeline_clone_test.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"bytes"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/chichex/che/internal/pipeline"
+)
+
+// TestParseReplaceRules_OK: shape válido old=new.
+func TestParseReplaceRules_OK(t *testing.T) {
+	got, err := parseReplaceRules([]string{"a=b", "c=d"})
+	if err != nil {
+		t.Fatalf("parseReplaceRules: %v", err)
+	}
+	want := map[string]string{"a": "b", "c": "d"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestParseReplaceRules_NoEquals: falta el "=".
+func TestParseReplaceRules_NoEquals(t *testing.T) {
+	_, err := parseReplaceRules([]string{"abc"})
+	if err == nil {
+		t.Fatalf("esperaba error, got nil")
+	}
+	if !strings.Contains(err.Error(), "old=new") {
+		t.Errorf("error no menciona el formato esperado: %v", err)
+	}
+}
+
+// TestParseReplaceRules_EmptyOld: old vacío rechazado.
+func TestParseReplaceRules_EmptyOld(t *testing.T) {
+	_, err := parseReplaceRules([]string{"=value"})
+	if err == nil {
+		t.Fatalf("esperaba error, got nil")
+	}
+}
+
+// TestParseReplaceRules_DuplicateConflict: dos entries con mismo old y
+// distinto new → error.
+func TestParseReplaceRules_DuplicateConflict(t *testing.T) {
+	_, err := parseReplaceRules([]string{"a=b", "a=c"})
+	if err == nil {
+		t.Fatalf("esperaba error, got nil")
+	}
+}
+
+// TestApplyReplacements_StepAndEntry: sustituye en steps + entry.agents,
+// preserva nombres de step + aggregator.
+func TestApplyReplacements_StepAndEntry(t *testing.T) {
+	src := pipeline.Pipeline{
+		Version: 1,
+		Entry: &pipeline.Entry{
+			Agents:     []string{"claude-opus", "guard"},
+			Aggregator: pipeline.AggregatorUnanimous,
+		},
+		Steps: []pipeline.Step{
+			{Name: "explore", Agents: []string{"claude-opus"}},
+			{Name: "validate", Agents: []string{"claude-opus", "reviewer"}, Aggregator: pipeline.AggregatorMajority},
+		},
+	}
+	got := applyReplacements(src, map[string]string{"claude-opus": "claude-sonnet"})
+	if got.Entry.Agents[0] != "claude-sonnet" || got.Entry.Agents[1] != "guard" {
+		t.Errorf("entry.agents drift: %v", got.Entry.Agents)
+	}
+	if got.Entry.Aggregator != pipeline.AggregatorUnanimous {
+		t.Errorf("entry.aggregator drift")
+	}
+	if got.Steps[0].Agents[0] != "claude-sonnet" {
+		t.Errorf("step[0].agents[0] drift: %v", got.Steps[0].Agents)
+	}
+	if got.Steps[1].Agents[0] != "claude-sonnet" || got.Steps[1].Agents[1] != "reviewer" {
+		t.Errorf("step[1].agents drift: %v", got.Steps[1].Agents)
+	}
+	if got.Steps[1].Aggregator != pipeline.AggregatorMajority {
+		t.Errorf("step[1].aggregator drift")
+	}
+	// El src no se mutó (deep equal contra clone manual).
+	if src.Entry.Agents[0] != "claude-opus" {
+		t.Errorf("src.Entry.Agents mutado")
+	}
+}
+
+// TestPipelineClone_DefaultToFast: ejemplo del PRD §1.c.
+//
+//	che pipeline clone default fast --replace claude-opus=claude-sonnet
+func TestPipelineClone_DefaultToFast(t *testing.T) {
+	mgr, root := pipelineFixture(t, nil, "")
+	var out bytes.Buffer
+	err := runPipelineClone(&out, mgr, "default", "fast", []string{"claude-opus=claude-sonnet"}, false)
+	if err != nil {
+		t.Fatalf("runPipelineClone: %v", err)
+	}
+	dest := filepath.Join(root, ".che", "pipelines", "fast.json")
+	got, err := pipeline.Load(dest)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// Cada step que tenía claude-opus debe ahora tener claude-sonnet.
+	// Al menos el primer step (idea) debe haber cambiado.
+	if got.Steps[0].Agents[0] != "claude-sonnet" {
+		t.Errorf("step[0].agents[0] = %q, want claude-sonnet", got.Steps[0].Agents[0])
+	}
+	// Los nombres de step se preservan.
+	if got.Steps[0].Name != "idea" {
+		t.Errorf("step[0].name = %q, want idea", got.Steps[0].Name)
+	}
+}
+
+// TestPipelineClone_ConflictWithoutForce: dst ya existe, sin --force →
+// error.
+func TestPipelineClone_ConflictWithoutForce(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"src": minimalPipeline,
+		"dst": minimalPipeline,
+	}, "")
+	var out bytes.Buffer
+	err := runPipelineClone(&out, mgr, "src", "dst", nil, false)
+	if err == nil {
+		t.Fatalf("esperaba error, got nil")
+	}
+	if !strings.Contains(err.Error(), "ya existe") {
+		t.Errorf("error no menciona conflicto: %v", err)
+	}
+}
+
+// TestPipelineClone_SrcEqDst: clone a sí mismo rechazado.
+func TestPipelineClone_SrcEqDst(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"x": minimalPipeline,
+	}, "")
+	var out bytes.Buffer
+	err := runPipelineClone(&out, mgr, "x", "x", nil, false)
+	if err == nil {
+		t.Fatalf("esperaba error, got nil")
+	}
+}
+
+// TestPipelineClone_BadReplace_RejectsEmptyAgent: --replace
+// claude-opus="" produce un pipeline inválido (agent vacío) — el
+// Validate post-replace debe rechazarlo y clone NO debe escribir el
+// archivo.
+func TestPipelineClone_BadReplace_RejectsEmptyAgent(t *testing.T) {
+	mgr, root := pipelineFixture(t, nil, "")
+	var out bytes.Buffer
+	err := runPipelineClone(&out, mgr, "default", "broken", []string{"claude-opus="}, false)
+	if err == nil {
+		t.Fatalf("esperaba error, got nil")
+	}
+	dest := filepath.Join(root, ".che", "pipelines", "broken.json")
+	if _, statErr := pipeline.Load(dest); statErr == nil {
+		t.Errorf("clone escribió archivo aunque el resultado era inválido")
+	}
+}

--- a/cmd/pipeline_list.go
+++ b/cmd/pipeline_list.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/chichex/che/internal/pipeline"
+	"github.com/spf13/cobra"
+)
+
+var pipelineListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "lista los pipelines del repo + el default activo",
+	Long: `list escanea ` + "`.che/pipelines/`" + ` y muestra los pipelines on-disk en
+formato tabular (NAME, DEFAULT, PATH). La columna DEFAULT marca con
+"*" el pipeline declarado en ` + "`.che/pipelines.config.json`" + `.
+
+El built-in ` + "`default`" + ` (PRD §7.b fallback) NO se lista: es un fallback
+implícito, no un archivo. Para materializarlo a disco usá
+` + "`che pipeline new default`" + `.
+
+Si el repo no tiene ningún pipeline on-disk y tampoco un default
+declarado, ` + "`list`" + ` imprime un mensaje informativo en stderr y devuelve
+exit 0 (no es un error — es un repo limpio).`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		root, err := repoRootForPipeline()
+		if err != nil {
+			return err
+		}
+		mgr, err := pipeline.NewManager(root)
+		if err != nil {
+			return fmt.Errorf("init pipeline manager: %s", formatLoadError(err))
+		}
+		return runPipelineList(cmd.OutOrStdout(), cmd.ErrOrStderr(), mgr)
+	},
+}
+
+func init() {
+	pipelineCmd.AddCommand(pipelineListCmd)
+}
+
+// runPipelineList renderiza la tabla. Separado del RunE para poder
+// testear sin spawnear `git rev-parse` ni tocar disco real (los tests
+// arman un Manager con un tmpdir y le pasan ese a la función).
+func runPipelineList(out, errOut io.Writer, mgr *pipeline.Manager) error {
+	names := mgr.List()
+	if len(names) == 0 {
+		fmt.Fprintf(errOut, "no hay pipelines en %s\n", mgr.PipelinesDir())
+		fmt.Fprintln(errOut, "tip: `che pipeline new default` materializa el built-in como template editable.")
+		return nil
+	}
+
+	def := mgr.Config.Default
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tDEFAULT\tPATH")
+	for _, n := range names {
+		marker := ""
+		if n == def {
+			marker = "*"
+		}
+		path, _ := mgr.Path(n)
+		fmt.Fprintf(tw, "%s\t%s\t%s\n", n, marker, path)
+	}
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+
+	// Si el config declara un default que no existe on-disk, avisar:
+	// es un estado inconsistente que el usuario probablemente quiere
+	// arreglar (typo, archivo borrado).
+	if def != "" {
+		if _, ok := mgr.Path(def); !ok {
+			fmt.Fprintf(errOut, "warn: default %q declarado en %s no existe en %s\n",
+				def, mgr.ConfigPath(), mgr.PipelinesDir())
+		}
+	}
+	return nil
+}

--- a/cmd/pipeline_list_test.go
+++ b/cmd/pipeline_list_test.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chichex/che/internal/pipeline"
+)
+
+// pipelineFixture es un helper para los tests de subcomandos: arma un
+// repo root temporal con un layout ya populado (`.che/pipelines/*.json`
+// + opcionalmente un config) y devuelve el Manager + el dir.
+//
+// No depende de `git`: el Manager toma cualquier path como repo root
+// — eso libera a los tests de spawnar procesos.
+func pipelineFixture(t *testing.T, files map[string]string, configDefault string) (*pipeline.Manager, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	dir := filepath.Join(tmp, ".che", "pipelines")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name+".json"), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	if configDefault != "" {
+		cfg := `{"version": 1, "default": "` + configDefault + `"}`
+		if err := os.WriteFile(filepath.Join(tmp, ".che", "pipelines.config.json"), []byte(cfg), 0o644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+	}
+	mgr, err := pipeline.NewManager(tmp)
+	if err != nil {
+		t.Fatalf("NewManager: %v", err)
+	}
+	return mgr, tmp
+}
+
+const minimalPipeline = `{
+  "version": 1,
+  "steps": [
+    {"name": "explore", "agents": ["claude-opus"]}
+  ]
+}`
+
+// TestPipelineList_Empty: repo sin pipelines. stdout vacío + mensaje
+// informativo en stderr; exit OK.
+func TestPipelineList_Empty(t *testing.T) {
+	mgr, _ := pipelineFixture(t, nil, "")
+	var out, errOut bytes.Buffer
+	if err := runPipelineList(&out, &errOut, mgr); err != nil {
+		t.Fatalf("runPipelineList: %v", err)
+	}
+	if out.Len() != 0 {
+		t.Errorf("stdout = %q, want empty", out.String())
+	}
+	if !strings.Contains(errOut.String(), "no hay pipelines") {
+		t.Errorf("stderr no menciona ausencia de pipelines: %q", errOut.String())
+	}
+}
+
+// TestPipelineList_WithDefault: dos pipelines, uno marcado default. La
+// columna DEFAULT debe tener "*" sólo en la fila correspondiente.
+func TestPipelineList_WithDefault(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"fast":     minimalPipeline,
+		"thorough": minimalPipeline,
+	}, "fast")
+	var out, errOut bytes.Buffer
+	if err := runPipelineList(&out, &errOut, mgr); err != nil {
+		t.Fatalf("runPipelineList: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "NAME") || !strings.Contains(got, "DEFAULT") {
+		t.Errorf("header missing: %q", got)
+	}
+	// orden alfabético: fast antes que thorough
+	idxFast := strings.Index(got, "fast")
+	idxThor := strings.Index(got, "thorough")
+	if idxFast == -1 || idxThor == -1 || idxFast > idxThor {
+		t.Errorf("orden no alfabético: %q", got)
+	}
+	// La línea de fast debe tener "*", la de thorough no.
+	lines := strings.Split(got, "\n")
+	for _, ln := range lines {
+		if strings.HasPrefix(strings.TrimSpace(ln), "fast") {
+			if !strings.Contains(ln, "*") {
+				t.Errorf("línea fast sin marker default: %q", ln)
+			}
+		}
+		if strings.HasPrefix(strings.TrimSpace(ln), "thorough") {
+			if strings.Contains(ln, "*") {
+				t.Errorf("línea thorough con marker default inesperado: %q", ln)
+			}
+		}
+	}
+}
+
+// TestPipelineList_DefaultMissingOnDisk: config declara un default que
+// no existe → warning en stderr.
+func TestPipelineList_DefaultMissingOnDisk(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"fast": minimalPipeline,
+	}, "missing")
+	var out, errOut bytes.Buffer
+	if err := runPipelineList(&out, &errOut, mgr); err != nil {
+		t.Fatalf("runPipelineList: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "warn") || !strings.Contains(errOut.String(), "missing") {
+		t.Errorf("stderr no warnea sobre default inexistente: %q", errOut.String())
+	}
+}

--- a/cmd/pipeline_new.go
+++ b/cmd/pipeline_new.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/chichex/che/internal/pipeline"
+	"github.com/spf13/cobra"
+)
+
+var pipelineNewForce bool
+
+var pipelineNewCmd = &cobra.Command{
+	Use:   "new <name>",
+	Short: "materializa un pipeline a disco a partir del built-in",
+	Long: `new escribe ` + "`.che/pipelines/<name>.json`" + ` con el contenido del
+built-in ` + "`pipeline.Default()`" + ` (PRD §7.b). Es la forma rápida de
+arrancar un pipeline custom: tomás el shape canónico, lo guardás bajo un
+nombre nuevo y lo editás.
+
+Por seguridad ` + "`new`" + ` falla si el archivo ya existe. Para sobrescribir
+pasá --force.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		root, err := repoRootForPipeline()
+		if err != nil {
+			return err
+		}
+		mgr, err := pipeline.NewManager(root)
+		if err != nil {
+			return fmt.Errorf("init pipeline manager: %s", formatLoadError(err))
+		}
+		return runPipelineNew(cmd.OutOrStdout(), mgr, args[0], pipelineNewForce)
+	},
+}
+
+func init() {
+	pipelineNewCmd.Flags().BoolVar(&pipelineNewForce, "force", false,
+		"sobrescribe el archivo si ya existe")
+	pipelineCmd.AddCommand(pipelineNewCmd)
+}
+
+// runPipelineNew valida el nombre, materializa el built-in y reporta.
+func runPipelineNew(out io.Writer, mgr *pipeline.Manager, name string, force bool) error {
+	if name == "" {
+		return fmt.Errorf("pipeline name no puede ser vacío")
+	}
+	dest := filepath.Join(mgr.PipelinesDir(), name+".json")
+	if !force {
+		if _, err := os.Stat(dest); err == nil {
+			return fmt.Errorf("%s ya existe — pasá --force para sobrescribir", dest)
+		}
+	}
+	if err := writePipelineFile(dest, pipeline.Default()); err != nil {
+		return fmt.Errorf("escribir %s: %w", dest, err)
+	}
+	fmt.Fprintf(out, "creado %s\n", dest)
+	return nil
+}
+
+// writePipelineFile serializa un pipeline a JSON indentado y lo escribe
+// en path, creando el dir padre si falta.
+func writePipelineFile(path string, p pipeline.Pipeline) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(p, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o644)
+}

--- a/cmd/pipeline_new_test.go
+++ b/cmd/pipeline_new_test.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/chichex/che/internal/pipeline"
+)
+
+// TestPipelineNew_CreatesDefault: en repo limpio, escribe el built-in
+// como `.che/pipelines/<name>.json` y el archivo parsea + matchea
+// pipeline.Default().
+func TestPipelineNew_CreatesDefault(t *testing.T) {
+	mgr, root := pipelineFixture(t, nil, "")
+	var out bytes.Buffer
+	if err := runPipelineNew(&out, mgr, "mine", false); err != nil {
+		t.Fatalf("runPipelineNew: %v", err)
+	}
+	dest := filepath.Join(root, ".che", "pipelines", "mine.json")
+	got, err := pipeline.Load(dest)
+	if err != nil {
+		t.Fatalf("Load %s: %v", dest, err)
+	}
+	if !reflect.DeepEqual(got, pipeline.Default()) {
+		t.Errorf("contenido drifteó vs Default()")
+	}
+	if !strings.Contains(out.String(), "mine.json") {
+		t.Errorf("stdout no menciona el path: %q", out.String())
+	}
+}
+
+// TestPipelineNew_ConflictWithoutForce: archivo ya existe, sin --force →
+// error.
+func TestPipelineNew_ConflictWithoutForce(t *testing.T) {
+	mgr, root := pipelineFixture(t, map[string]string{
+		"taken": minimalPipeline,
+	}, "")
+	dest := filepath.Join(root, ".che", "pipelines", "taken.json")
+	infoBefore, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	var out bytes.Buffer
+	err = runPipelineNew(&out, mgr, "taken", false)
+	if err == nil {
+		t.Fatalf("esperaba error, got nil")
+	}
+	if !strings.Contains(err.Error(), "ya existe") {
+		t.Errorf("error no menciona conflicto: %v", err)
+	}
+	// El archivo no debe haberse tocado.
+	infoAfter, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if infoBefore.Size() != infoAfter.Size() {
+		t.Errorf("tamaño cambió en path de conflicto")
+	}
+}
+
+// TestPipelineNew_ForceOverwrites: con --force sobrescribe.
+func TestPipelineNew_ForceOverwrites(t *testing.T) {
+	mgr, root := pipelineFixture(t, map[string]string{
+		"taken": minimalPipeline,
+	}, "")
+	var out bytes.Buffer
+	if err := runPipelineNew(&out, mgr, "taken", true); err != nil {
+		t.Fatalf("runPipelineNew --force: %v", err)
+	}
+	dest := filepath.Join(root, ".che", "pipelines", "taken.json")
+	got, err := pipeline.Load(dest)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !reflect.DeepEqual(got, pipeline.Default()) {
+		t.Errorf("contenido tras --force no es Default()")
+	}
+}

--- a/cmd/pipeline_show.go
+++ b/cmd/pipeline_show.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/chichex/che/internal/pipeline"
+	"github.com/spf13/cobra"
+)
+
+var pipelineShowJSON bool
+
+var pipelineShowCmd = &cobra.Command{
+	Use:   "show <name>",
+	Short: "imprime un pipeline por nombre (resumen humano o JSON)",
+	Long: `show carga + valida un pipeline y lo imprime. Por default muestra
+un resumen humano (entry + steps + agentes). Con --json escupe el JSON
+canónico tal como se cargaría on-disk (útil para diff vs el archivo).
+
+Si <name> coincide con el built-in implícito (` + "`default`" + ` cuando no hay
+archivo on-disk), show imprime el built-in `+ "`pipeline.Default()`" + `.
+Esto deja a los usuarios inspeccionar el shape canónico antes de hacer
+` + "`che pipeline clone default mine`" + `.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		root, err := repoRootForPipeline()
+		if err != nil {
+			return err
+		}
+		mgr, err := pipeline.NewManager(root)
+		if err != nil {
+			return fmt.Errorf("init pipeline manager: %s", formatLoadError(err))
+		}
+		return runPipelineShow(cmd.OutOrStdout(), mgr, args[0], pipelineShowJSON)
+	},
+}
+
+func init() {
+	pipelineShowCmd.Flags().BoolVar(&pipelineShowJSON, "json", false,
+		"emite el JSON canónico en vez del resumen humano")
+	pipelineCmd.AddCommand(pipelineShowCmd)
+}
+
+// runPipelineShow resuelve el pipeline (on-disk + fallback al built-in
+// para "default") y delega en el formateador elegido.
+func runPipelineShow(out io.Writer, mgr *pipeline.Manager, name string, asJSON bool) error {
+	p, path, err := lookupPipelineForShow(mgr, name)
+	if err != nil {
+		return fmt.Errorf("%s", formatLoadError(err))
+	}
+	if asJSON {
+		return writePipelineJSON(out, p)
+	}
+	return writePipelineSummary(out, name, path, p)
+}
+
+// lookupPipelineForShow centraliza la regla "name=default cae al
+// built-in si no hay archivo". El resto de los nombres se resuelven
+// estrictamente vía Manager.Get (error si falta).
+//
+// `path` queda vacío para el built-in implícito — el formateador lo
+// usa para imprimir "<built-in>" en el header del resumen.
+func lookupPipelineForShow(mgr *pipeline.Manager, name string) (pipeline.Pipeline, string, error) {
+	if name == "" {
+		return pipeline.Pipeline{}, "", fmt.Errorf("pipeline name no puede ser vacío")
+	}
+	if _, ok := mgr.Path(name); !ok {
+		if name == "default" {
+			return pipeline.Default(), "", nil
+		}
+	}
+	p, err := mgr.Get(name)
+	if err != nil {
+		return pipeline.Pipeline{}, "", err
+	}
+	path, _ := mgr.Path(name)
+	return p, path, nil
+}
+
+// writePipelineJSON emite el JSON canónico (indentado 2 espacios) — el
+// mismo shape que `che pipeline new` deja en disco.
+func writePipelineJSON(out io.Writer, p pipeline.Pipeline) error {
+	enc := json.NewEncoder(out)
+	enc.SetIndent("", "  ")
+	return enc.Encode(p)
+}
+
+// writePipelineSummary imprime un resumen humano: header con name +
+// path, entry (si hay), tabla de steps (NAME, AGENTS, AGGREGATOR).
+func writePipelineSummary(out io.Writer, name, path string, p pipeline.Pipeline) error {
+	if path == "" {
+		fmt.Fprintf(out, "pipeline: %s (built-in)\n", name)
+	} else {
+		fmt.Fprintf(out, "pipeline: %s (%s)\n", name, path)
+	}
+	fmt.Fprintf(out, "version: %d\n", p.Version)
+	if p.Entry != nil {
+		agg := string(p.Entry.Aggregator)
+		if agg == "" {
+			agg = "-"
+		}
+		fmt.Fprintf(out, "entry: agents=%v aggregator=%s\n", p.Entry.Agents, agg)
+	} else {
+		fmt.Fprintln(out, "entry: -")
+	}
+	fmt.Fprintln(out, "")
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "STEP\tAGENTS\tAGGREGATOR")
+	for _, s := range p.Steps {
+		agg := string(s.Aggregator)
+		if agg == "" {
+			agg = "-"
+		}
+		fmt.Fprintf(tw, "%s\t%v\t%s\n", s.Name, s.Agents, agg)
+	}
+	return tw.Flush()
+}

--- a/cmd/pipeline_show_test.go
+++ b/cmd/pipeline_show_test.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/chichex/che/internal/pipeline"
+)
+
+// TestPipelineShow_HumanSummary: pipeline on-disk, sin --json. Debe
+// imprimir header con name+path, mostrar version, listar steps y agentes.
+func TestPipelineShow_HumanSummary(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"fast": minimalPipeline,
+	}, "")
+	var out bytes.Buffer
+	if err := runPipelineShow(&out, mgr, "fast", false); err != nil {
+		t.Fatalf("runPipelineShow: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"pipeline: fast",
+		"fast.json",
+		"version: 1",
+		"explore",
+		"claude-opus",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("falta %q en output: %q", want, got)
+		}
+	}
+}
+
+// TestPipelineShow_JSON: con --json escupe JSON canónico parseable +
+// igual al pipeline cargado.
+func TestPipelineShow_JSON(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"fast": minimalPipeline,
+	}, "")
+	var out bytes.Buffer
+	if err := runPipelineShow(&out, mgr, "fast", true); err != nil {
+		t.Fatalf("runPipelineShow: %v", err)
+	}
+	var got pipeline.Pipeline
+	if err := json.Unmarshal(out.Bytes(), &got); err != nil {
+		t.Fatalf("json invalid: %v\noutput: %s", err, out.String())
+	}
+	if got.Version != 1 {
+		t.Errorf("Version = %d, want 1", got.Version)
+	}
+	if len(got.Steps) != 1 || got.Steps[0].Name != "explore" {
+		t.Errorf("Steps drift: %+v", got.Steps)
+	}
+}
+
+// TestPipelineShow_BuiltinDefault: sin archivo, name=default → cae al
+// built-in.
+func TestPipelineShow_BuiltinDefault(t *testing.T) {
+	mgr, _ := pipelineFixture(t, nil, "")
+	var out bytes.Buffer
+	if err := runPipelineShow(&out, mgr, "default", false); err != nil {
+		t.Fatalf("runPipelineShow: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "built-in") {
+		t.Errorf("no marca built-in: %q", got)
+	}
+	// El built-in declara "validate_issue" entre los steps; sirve como
+	// canario de drift vs `pipeline.Default()`.
+	if !strings.Contains(got, "validate_issue") {
+		t.Errorf("no muestra steps del built-in: %q", got)
+	}
+}
+
+// TestPipelineShow_Missing: nombre no existente, no es "default" → error.
+func TestPipelineShow_Missing(t *testing.T) {
+	mgr, _ := pipelineFixture(t, nil, "")
+	var out bytes.Buffer
+	err := runPipelineShow(&out, mgr, "nope", false)
+	if err == nil {
+		t.Fatalf("esperaba error, got nil")
+	}
+	if !strings.Contains(err.Error(), "nope") {
+		t.Errorf("error no menciona el nombre: %v", err)
+	}
+}

--- a/cmd/pipeline_simulate.go
+++ b/cmd/pipeline_simulate.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"text/tabwriter"
+
+	"github.com/chichex/che/internal/agentregistry"
+	"github.com/chichex/che/internal/pipeline"
+	"github.com/spf13/cobra"
+)
+
+var pipelineSimulatePipeline string
+
+var pipelineSimulateCmd = &cobra.Command{
+	Use:   "simulate",
+	Short: "dry-run: muestra qué pipeline se resolvería y qué agentes correrían",
+	Long: `simulate es un dry-run completo: aplica la jerarquía de resolución
+(--pipeline > config.default > built-in, PRD §7.b), reporta el origen
+y para cada step lista los agentes que correrían + la metadata
+relevante (aggregator, model, source).
+
+NO invoca al LLM ni corre el motor real — sólo imprime el plan. Ideal
+para validar que un cambio en config.default o en un .json se está
+resolviendo como esperás antes de ejecutar.
+
+Si --pipeline está vacío, simulate replica exactamente lo que haría una
+corrida real sin flags.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		root, err := repoRootForPipeline()
+		if err != nil {
+			return err
+		}
+		mgr, err := pipeline.NewManager(root)
+		if err != nil {
+			return fmt.Errorf("init pipeline manager: %s", formatLoadError(err))
+		}
+		reg, regErrs := agentregistry.Discover(agentregistry.Options{IncludeBuiltins: true})
+		for _, e := range regErrs {
+			fmt.Fprintln(cmd.ErrOrStderr(), "warn:", e.Error())
+		}
+		lookup := func(name string) (agentInfo, bool) {
+			a, ok := reg.Get(name)
+			if !ok {
+				return agentInfo{}, false
+			}
+			return agentInfo{
+				Name:   a.Name,
+				Model:  a.Model,
+				Source: string(a.Source),
+				Path:   a.Path,
+			}, true
+		}
+		return runPipelineSimulate(cmd.OutOrStdout(), mgr, lookup, pipelineSimulatePipeline)
+	},
+}
+
+// agentInfo es el subset de metadata del registry que simulate
+// renderiza. Aislar en un struct propio del paquete cmd permite que los
+// tests inyecten un fake lookup sin depender de los internals del
+// package agentregistry (campos no exportados).
+type agentInfo struct {
+	Name   string
+	Model  string
+	Source string
+	Path   string
+}
+
+func init() {
+	pipelineSimulateCmd.Flags().StringVar(&pipelineSimulatePipeline, "pipeline", "",
+		"nombre del pipeline a simular (vacío = aplicar jerarquía default)")
+	pipelineCmd.AddCommand(pipelineSimulateCmd)
+}
+
+// runPipelineSimulate ejecuta Resolve(flag) y renderiza el resultado.
+// `lookup` resuelve nombre → metadata (ok=false si el agente no está en
+// el registry). El simulate marca esos como MISSING en la tabla — útil
+// para detectar agentes referenciados pero no instalados antes de
+// correr el pipeline.
+func runPipelineSimulate(out io.Writer, mgr *pipeline.Manager, lookup func(string) (agentInfo, bool), flag string) error {
+	r, err := mgr.Resolve(flag)
+	if err != nil {
+		return fmt.Errorf("%s", formatLoadError(err))
+	}
+
+	src := r.Path
+	if src == "" {
+		src = "<built-in>"
+	}
+	fmt.Fprintf(out, "pipeline: %s\n", r.Name)
+	fmt.Fprintf(out, "source:   %s (%s)\n", r.Source, src)
+	fmt.Fprintln(out, "")
+
+	if r.Pipeline.Entry != nil {
+		fmt.Fprintln(out, "entry:")
+		if err := writeAgentsTable(out, r.Pipeline.Entry.Agents, lookup); err != nil {
+			return err
+		}
+		agg := string(r.Pipeline.Entry.Aggregator)
+		if agg == "" {
+			agg = "majority (default)"
+		}
+		fmt.Fprintf(out, "  aggregator: %s\n", agg)
+		fmt.Fprintln(out, "")
+	}
+
+	for i, step := range r.Pipeline.Steps {
+		fmt.Fprintf(out, "step[%d]: %s\n", i, step.Name)
+		if err := writeAgentsTable(out, step.Agents, lookup); err != nil {
+			return err
+		}
+		agg := string(step.Aggregator)
+		if agg == "" {
+			if len(step.Agents) > 1 {
+				agg = "majority (default)"
+			} else {
+				agg = "- (1 agente)"
+			}
+		}
+		fmt.Fprintf(out, "  aggregator: %s\n", agg)
+		fmt.Fprintln(out, "")
+	}
+
+	fmt.Fprintln(out, "(dry-run: no se invocó ningún agente)")
+	return nil
+}
+
+// writeAgentsTable imprime una tabla indentada con los agentes del step
+// y el resultado del lookup en el registry (model + source + path o
+// "MISSING" si no existe).
+func writeAgentsTable(out io.Writer, agents []string, lookup func(string) (agentInfo, bool)) error {
+	tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "  AGENT\tMODEL\tSOURCE\tPATH")
+	for _, name := range agents {
+		a, ok := lookup(name)
+		if !ok {
+			fmt.Fprintf(tw, "  %s\t-\tMISSING\t-\n", name)
+			continue
+		}
+		path := a.Path
+		if path == "" {
+			path = "-"
+		}
+		model := a.Model
+		if model == "" {
+			model = "-"
+		}
+		fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\n", a.Name, model, a.Source, path)
+	}
+	return tw.Flush()
+}

--- a/cmd/pipeline_simulate_test.go
+++ b/cmd/pipeline_simulate_test.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// fakeLookup devuelve un agentInfo fijo para los nombres en el map; el
+// resto sale como missing.
+func fakeLookup(known map[string]agentInfo) func(string) (agentInfo, bool) {
+	return func(name string) (agentInfo, bool) {
+		a, ok := known[name]
+		return a, ok
+	}
+}
+
+// TestPipelineSimulate_BuiltinFallback: repo limpio, sin --pipeline →
+// resuelve al built-in, source = "built-in".
+func TestPipelineSimulate_BuiltinFallback(t *testing.T) {
+	mgr, _ := pipelineFixture(t, nil, "")
+	var out bytes.Buffer
+	err := runPipelineSimulate(&out, mgr, fakeLookup(nil), "")
+	if err != nil {
+		t.Fatalf("runPipelineSimulate: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "built-in") {
+		t.Errorf("no marca built-in: %q", got)
+	}
+	if !strings.Contains(got, "dry-run") {
+		t.Errorf("no avisa dry-run: %q", got)
+	}
+}
+
+// TestPipelineSimulate_FlagWins: flag --pipeline gana sobre el config
+// default.
+func TestPipelineSimulate_FlagWins(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"fast":     minimalPipeline,
+		"thorough": minimalPipeline,
+	}, "thorough")
+	var out bytes.Buffer
+	err := runPipelineSimulate(&out, mgr, fakeLookup(map[string]agentInfo{
+		"claude-opus": {Name: "claude-opus", Model: "opus", Source: "built-in"},
+	}), "fast")
+	if err != nil {
+		t.Fatalf("runPipelineSimulate: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "pipeline: fast") {
+		t.Errorf("no resuelve flag: %q", got)
+	}
+	if strings.Contains(got, "thorough") {
+		t.Errorf("config default leaked: %q", got)
+	}
+}
+
+// TestPipelineSimulate_MissingAgent: agente no existe en el lookup → la
+// tabla muestra MISSING. NO aborta.
+func TestPipelineSimulate_MissingAgent(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"fast": minimalPipeline,
+	}, "")
+	var out bytes.Buffer
+	err := runPipelineSimulate(&out, mgr, fakeLookup(nil), "fast")
+	if err != nil {
+		t.Fatalf("runPipelineSimulate: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "MISSING") {
+		t.Errorf("no muestra MISSING: %q", got)
+	}
+	if !strings.Contains(got, "claude-opus") {
+		t.Errorf("no muestra el nombre referenciado: %q", got)
+	}
+}
+
+// TestPipelineSimulate_RendersAgentMetadata: agentes presentes muestran
+// model + source + path en la tabla.
+func TestPipelineSimulate_RendersAgentMetadata(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"fast": minimalPipeline,
+	}, "")
+	var out bytes.Buffer
+	err := runPipelineSimulate(&out, mgr, fakeLookup(map[string]agentInfo{
+		"claude-opus": {Name: "claude-opus", Model: "opus", Source: "built-in", Path: ""},
+	}), "fast")
+	if err != nil {
+		t.Fatalf("runPipelineSimulate: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"claude-opus", "opus", "built-in"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("falta %q en output: %q", want, got)
+		}
+	}
+}
+
+// TestPipelineSimulate_StepsAreEnumerated: el output incluye el header
+// "step[0]" (es un canario para asegurar que iteramos los steps).
+func TestPipelineSimulate_StepsAreEnumerated(t *testing.T) {
+	mgr, _ := pipelineFixture(t, nil, "")
+	var out bytes.Buffer
+	if err := runPipelineSimulate(&out, mgr, fakeLookup(nil), ""); err != nil {
+		t.Fatalf("runPipelineSimulate: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "step[0]") {
+		t.Errorf("no enumera steps: %q", got)
+	}
+}

--- a/cmd/pipeline_use.go
+++ b/cmd/pipeline_use.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/chichex/che/internal/pipeline"
+	"github.com/spf13/cobra"
+)
+
+var pipelineUseCmd = &cobra.Command{
+	Use:   "use <name>",
+	Short: "marca un pipeline como default para el repo",
+	Long: `use escribe ` + "`.che/pipelines.config.json`" + ` con el campo
+` + "`default: <name>`" + ` (PRD §7.b). Después de correr ` + "`use`" + `, los flows
+que no pasen --pipeline van a resolverse a este nombre.
+
+Validaciones:
+  - <name> debe existir en ` + "`.che/pipelines/`" + ` (excepto "default" que
+    matchea el built-in implícito; ver ` + "`che pipeline new default`" + ` si
+    querés materializarlo).
+  - El pipeline tiene que parsear y validar — no permite settear un
+    default roto.
+
+` + "`use`" + ` es idempotente: si el config ya marca <name> como default,
+no hace IO y devuelve OK.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		root, err := repoRootForPipeline()
+		if err != nil {
+			return err
+		}
+		mgr, err := pipeline.NewManager(root)
+		if err != nil {
+			return fmt.Errorf("init pipeline manager: %s", formatLoadError(err))
+		}
+		return runPipelineUse(cmd.OutOrStdout(), mgr, args[0])
+	},
+}
+
+func init() {
+	pipelineCmd.AddCommand(pipelineUseCmd)
+}
+
+// runPipelineUse aplica la jerarquía:
+//  1. valida que el pipeline existe + parsea (excepto "default" implícito)
+//  2. si el config ya marca <name> default → no-op + log
+//  3. sino → escribe `.che/pipelines.config.json` con version + default
+func runPipelineUse(out io.Writer, mgr *pipeline.Manager, name string) error {
+	if name == "" {
+		return fmt.Errorf("pipeline name no puede ser vacío")
+	}
+
+	// Caso especial: "default" sin archivo on-disk == built-in implícito.
+	// Mantener el config con ese nombre es válido — Resolve() cae al
+	// built-in cuando el archivo no existe.
+	if _, ok := mgr.Path(name); !ok && name != "default" {
+		return fmt.Errorf("pipeline %q no existe en %s — corré `che pipeline list` o `che pipeline new %s`",
+			name, mgr.PipelinesDir(), name)
+	}
+
+	// Validar que el pipeline (si está on-disk) parsea + valida. No
+	// queremos permitir `use` apuntando a un .json roto.
+	if _, ok := mgr.Path(name); ok {
+		if _, err := mgr.Get(name); err != nil {
+			return fmt.Errorf("pipeline %q no es válido: %s", name, formatLoadError(err))
+		}
+	}
+
+	if mgr.Config.Default == name {
+		fmt.Fprintf(out, "default ya es %q (no-op)\n", name)
+		return nil
+	}
+
+	cfg := pipeline.Config{
+		Version: pipeline.ConfigVersion,
+		Default: name,
+	}
+	if err := writeConfigFile(mgr.ConfigPath(), cfg); err != nil {
+		return fmt.Errorf("escribir %s: %w", mgr.ConfigPath(), err)
+	}
+	fmt.Fprintf(out, "default = %q (escrito en %s)\n", name, mgr.ConfigPath())
+	return nil
+}
+
+// writeConfigFile serializa cfg a JSON indentado y lo escribe en path.
+// Crea el dir padre si falta — `.che/` puede no existir todavía cuando
+// el repo nunca ejecutó che.
+func writeConfigFile(path string, cfg pipeline.Config) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o644)
+}

--- a/cmd/pipeline_use_test.go
+++ b/cmd/pipeline_use_test.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chichex/che/internal/pipeline"
+)
+
+// readConfig recarga `.che/pipelines.config.json` del repo de prueba.
+// Útil para verificar el efecto de runPipelineUse.
+func readConfig(t *testing.T, root string) pipeline.Config {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(root, ".che", "pipelines.config.json"))
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	var cfg pipeline.Config
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+	return cfg
+}
+
+// TestPipelineUse_WritesConfig: pipeline existe on-disk → escribe
+// config.json con default = name.
+func TestPipelineUse_WritesConfig(t *testing.T) {
+	mgr, root := pipelineFixture(t, map[string]string{
+		"fast": minimalPipeline,
+	}, "")
+	var out bytes.Buffer
+	if err := runPipelineUse(&out, mgr, "fast"); err != nil {
+		t.Fatalf("runPipelineUse: %v", err)
+	}
+	cfg := readConfig(t, root)
+	if cfg.Default != "fast" {
+		t.Errorf("Default = %q, want fast", cfg.Default)
+	}
+	if cfg.Version != pipeline.ConfigVersion {
+		t.Errorf("Version = %d, want %d", cfg.Version, pipeline.ConfigVersion)
+	}
+	if !strings.Contains(out.String(), "fast") {
+		t.Errorf("stdout no menciona el cambio: %q", out.String())
+	}
+}
+
+// TestPipelineUse_Idempotent: si el config ya marca <name>, no reescribe
+// (mtime invariante) y reporta no-op.
+func TestPipelineUse_Idempotent(t *testing.T) {
+	mgr, root := pipelineFixture(t, map[string]string{
+		"fast": minimalPipeline,
+	}, "fast")
+	cfgPath := filepath.Join(root, ".che", "pipelines.config.json")
+	infoBefore, err := os.Stat(cfgPath)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	var out bytes.Buffer
+	if err := runPipelineUse(&out, mgr, "fast"); err != nil {
+		t.Fatalf("runPipelineUse: %v", err)
+	}
+	if !strings.Contains(out.String(), "no-op") {
+		t.Errorf("no reporta no-op: %q", out.String())
+	}
+	infoAfter, err := os.Stat(cfgPath)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if !infoBefore.ModTime().Equal(infoAfter.ModTime()) {
+		t.Errorf("mtime cambió en idempotent path")
+	}
+}
+
+// TestPipelineUse_MissingPipeline: nombre que no existe (y no es
+// default) → error explícito.
+func TestPipelineUse_MissingPipeline(t *testing.T) {
+	mgr, _ := pipelineFixture(t, nil, "")
+	var out bytes.Buffer
+	err := runPipelineUse(&out, mgr, "nope")
+	if err == nil {
+		t.Fatalf("esperaba error, got nil")
+	}
+	if !strings.Contains(err.Error(), "nope") {
+		t.Errorf("error no menciona el nombre: %v", err)
+	}
+}
+
+// TestPipelineUse_BuiltinDefaultAllowed: name=default sin archivo
+// on-disk debe ser válido (built-in implícito).
+func TestPipelineUse_BuiltinDefaultAllowed(t *testing.T) {
+	mgr, root := pipelineFixture(t, nil, "")
+	var out bytes.Buffer
+	if err := runPipelineUse(&out, mgr, "default"); err != nil {
+		t.Fatalf("runPipelineUse: %v", err)
+	}
+	cfg := readConfig(t, root)
+	if cfg.Default != "default" {
+		t.Errorf("Default = %q, want default", cfg.Default)
+	}
+}
+
+// TestPipelineUse_BrokenPipelineRejected: pipeline on-disk roto → use
+// se rehúsa.
+func TestPipelineUse_BrokenPipelineRejected(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"broken": `{"version": 1, "steps": []}`, // 0 steps → invalid
+	}, "")
+	var out bytes.Buffer
+	err := runPipelineUse(&out, mgr, "broken")
+	if err == nil {
+		t.Fatalf("esperaba error, got nil")
+	}
+}

--- a/cmd/pipeline_validate.go
+++ b/cmd/pipeline_validate.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/chichex/che/internal/agentregistry"
+	"github.com/chichex/che/internal/pipeline"
+	"github.com/spf13/cobra"
+)
+
+var pipelineValidateSkipAgents bool
+
+var pipelineValidateCmd = &cobra.Command{
+	Use:   "validate <name>",
+	Short: "valida sintaxis + referencias a agentes de un pipeline",
+	Long: `validate corre 2 chequeos sobre un pipeline:
+
+  1. Schema/loader (` + "`pipeline.Validate`" + `): versión soportada, mínimo
+     1 step, nombres válidos, aggregator preset, etc.
+  2. Referencias a agentes: chequea que cada agente referenciado en
+     entry y steps exista en el agentregistry (built-in + auto-discovered
+     en .claude/agents/, plugins, etc.).
+
+Errores se reportan con path/field cuando el loader puede ubicarlos
+(ej. ` + "`steps[2].agents[1]: agent \"foo\" not found...`" + `).
+
+Para skipear el chequeo de agentes (útil en CI antes de tener los
+agentes custom instalados) pasá --skip-agents.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		root, err := repoRootForPipeline()
+		if err != nil {
+			return err
+		}
+		mgr, err := pipeline.NewManager(root)
+		if err != nil {
+			return fmt.Errorf("init pipeline manager: %s", formatLoadError(err))
+		}
+
+		// Discover puede emitir warnings (collisions, parse errors de
+		// archivos individuales) que no rompen el registry. validate los
+		// imprime en stderr pero no los trata como fatales — el chequeo
+		// "agente referenciado existe" no depende de ellos.
+		reg, regErrs := agentregistry.Discover(agentregistry.Options{IncludeBuiltins: true})
+		for _, e := range regErrs {
+			fmt.Fprintln(cmd.ErrOrStderr(), "warn:", e.Error())
+		}
+
+		has := func(name string) bool {
+			_, ok := reg.Get(name)
+			return ok
+		}
+		return runPipelineValidate(cmd.OutOrStdout(), mgr, has, args[0], pipelineValidateSkipAgents)
+	},
+}
+
+func init() {
+	pipelineValidateCmd.Flags().BoolVar(&pipelineValidateSkipAgents, "skip-agents", false,
+		"skipea la verificación de existencia de agentes (sólo schema)")
+	pipelineCmd.AddCommand(pipelineValidateCmd)
+}
+
+// runPipelineValidate carga + valida el pipeline y, si --skip-agents no
+// está, chequea referencias contra el predicado `has` (típicamente
+// envoltorio sobre `*agentregistry.Registry.Get`). Recibir el predicado
+// en vez del registry concreto deja a los tests inyectar fakes sin
+// depender de los internals del package agentregistry.
+func runPipelineValidate(out io.Writer, mgr *pipeline.Manager, has func(string) bool, name string, skipAgents bool) error {
+	p, path, err := lookupPipelineForShow(mgr, name)
+	if err != nil {
+		return fmt.Errorf("%s", formatLoadError(err))
+	}
+	// Validación del schema. Get + Default ya validan; este Validate
+	// extra es defensivo (si lookupPipelineForShow cambia o si alguien
+	// llama esta función con un Pipeline no validado).
+	if err := pipeline.Validate(p); err != nil {
+		return fmt.Errorf("%s", formatLoadError(err))
+	}
+
+	if !skipAgents {
+		if err := pipeline.ValidateAgents(p, has); err != nil {
+			return fmt.Errorf("%s", formatLoadError(err))
+		}
+	}
+
+	src := path
+	if src == "" {
+		src = "<built-in>"
+	}
+	fmt.Fprintf(out, "ok: %s (%s) válido\n", name, src)
+	return nil
+}

--- a/cmd/pipeline_validate_test.go
+++ b/cmd/pipeline_validate_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// fakeHas devuelve true para los nombres en el set, false para el resto.
+// Inyectable como predicado de runPipelineValidate.
+func fakeHas(known ...string) func(string) bool {
+	set := map[string]bool{}
+	for _, k := range known {
+		set[k] = true
+	}
+	return func(name string) bool { return set[name] }
+}
+
+// TestPipelineValidate_OK: pipeline OK + agentes presentes → ok.
+func TestPipelineValidate_OK(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"fast": minimalPipeline,
+	}, "")
+	var out bytes.Buffer
+	err := runPipelineValidate(&out, mgr, fakeHas("claude-opus"), "fast", false)
+	if err != nil {
+		t.Fatalf("runPipelineValidate: %v", err)
+	}
+	if !strings.Contains(out.String(), "ok") || !strings.Contains(out.String(), "fast") {
+		t.Errorf("stdout no reporta ok: %q", out.String())
+	}
+}
+
+// TestPipelineValidate_MissingAgent: agente referenciado no existe →
+// error con field path.
+func TestPipelineValidate_MissingAgent(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"fast": minimalPipeline,
+	}, "")
+	var out bytes.Buffer
+	err := runPipelineValidate(&out, mgr, fakeHas(), "fast", false)
+	if err == nil {
+		t.Fatalf("esperaba error, got nil")
+	}
+	if !strings.Contains(err.Error(), "claude-opus") {
+		t.Errorf("error no menciona el agente faltante: %v", err)
+	}
+	if !strings.Contains(err.Error(), "steps[0].agents[0]") {
+		t.Errorf("error sin field path: %v", err)
+	}
+}
+
+// TestPipelineValidate_SkipAgents: con --skip-agents, agentes faltantes
+// no rompen.
+func TestPipelineValidate_SkipAgents(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"fast": minimalPipeline,
+	}, "")
+	var out bytes.Buffer
+	err := runPipelineValidate(&out, mgr, fakeHas(), "fast", true)
+	if err != nil {
+		t.Fatalf("runPipelineValidate --skip-agents: %v", err)
+	}
+}
+
+// TestPipelineValidate_BrokenSchema: pipeline mal formado (0 steps) →
+// error de schema, sin ni mirar agentes.
+func TestPipelineValidate_BrokenSchema(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"broken": `{"version": 1, "steps": []}`,
+	}, "")
+	var out bytes.Buffer
+	err := runPipelineValidate(&out, mgr, fakeHas("claude-opus"), "broken", false)
+	if err == nil {
+		t.Fatalf("esperaba error, got nil")
+	}
+	if !strings.Contains(err.Error(), "step") {
+		t.Errorf("error no menciona steps: %v", err)
+	}
+}
+
+// TestPipelineValidate_BuiltinDefault: validar el built-in implícito.
+// En tests, los agentes referenciados (plan-reviewer-strict, etc.) no
+// existen en el fake, pero si pasamos los nombres del built-in, ok.
+func TestPipelineValidate_BuiltinDefault(t *testing.T) {
+	mgr, _ := pipelineFixture(t, nil, "")
+	var out bytes.Buffer
+	// Skip agentes para no listar todos los reviewers del built-in.
+	err := runPipelineValidate(&out, mgr, fakeHas(), "default", true)
+	if err != nil {
+		t.Fatalf("runPipelineValidate default: %v", err)
+	}
+	if !strings.Contains(out.String(), "default") || !strings.Contains(out.String(), "built-in") {
+		t.Errorf("stdout no marca built-in: %q", out.String())
+	}
+}


### PR DESCRIPTION
Implementa #56.

Closes #56

## Implementado

7 subcomandos de `che pipeline`, siguiendo el patron cobra del repo:

- **`che pipeline`** (root) — grupo padre con help; helpers compartidos.
- **`che pipeline list`** — tabla de pipelines on-disk con marker `*` para el default. Warning si el config declara default inexistente.
- **`che pipeline show <name>`** — resumen humano por defecto; `--json` escupe JSON canonico. Soporta `default` con fallback al built-in implicito.
- **`che pipeline use <name>`** — escribe `.che/pipelines.config.json` con el default. Idempotente. Valida antes de marcar.
- **`che pipeline new <name>`** — materializa `pipeline.Default()` en `.che/pipelines/<name>.json`. `--force` para sobrescribir.
- **`che pipeline clone <src> <dst> --replace old=new` (repetible)** — copia con sustituciones exact-match en `entry.agents` + `steps[*].agents`. Re-valida el resultado.
- **`che pipeline validate <name>`** — schema validation + `pipeline.ValidateAgents` contra `agentregistry.Discover`. `--skip-agents` para skipear.
- **`che pipeline simulate [--pipeline X]`** — dry-run que aplica jerarquia de resolucion (`Manager.Resolve`), imprime origen + path, y para cada step lista los agentes con metadata del registry (`MISSING` si no existe). NO invoca LLM.

## Tests (28 nuevos)

- Helpers de fixture (`pipelineFixture`) que arman `.che/pipelines/*.json` + config sin necesitar `git`.
- `parseReplaceRules` cubre OK / sin `=` / old vacio / duplicados.
- `applyReplacements` verifica sustitucion en entry+steps + no mutacion del input.
- Escenarios end-to-end por subcomando con tmpdir.

`go build ./...`, `go vet`, `go test -count=1 ./...` full suite verde.

Smoke test del binario contra `/tmp/simtest`: list/new/use/clone/show/validate/simulate funcionan end-to-end.

## Decisiones de diseño

- `runPipelineValidate` y `runPipelineSimulate` reciben **predicado/lookup como closure** (`func(name string) bool` / `func(name string) (agentInfo, bool)`) en vez del `*agentregistry.Registry` concreto. Razon: `Registry` tiene campos no exportados y no es construible desde tests externos. El RunE de cobra wrappea el registry real en el closure; los tests inyectan fakes.
- `name=default sin archivo on-disk → built-in implicito` es regla cross-cutting (aplica a `show`, `use`, `clone` como src, `validate`). Centralizado en `lookupPipelineForShow`.
- `Manager.Get("default")` NO cae al built-in (solo `Resolve("")` lo hace). El built-in fallback es decision de jerarquia, no de lookup directo.

## Pendiente

Vacio.
