### PR TITLE
feat(#57): [#50 PR5c] Engine multi-agente + aggregator + cancelación parcial

### DIFF
--- a/EXEC_NOTES.md
+++ b/EXEC_NOTES.md
@@ -1,58 +1,70 @@
-# PR5a — Spec formal del parser de markers + tests: notas de ejecución
+# PR5c — Engine multi-agente + aggregator + cancelación parcial
 
 ## Estado del PR
 
-Cubre el scope completo de #61:
+Cubre todo lo que el scope de #57 pide:
 
-- **Paquete puro `internal/markerparser`** — string in, marker out. Sin dependencias del engine ni del agent. Importable por cualquier paquete que necesite interpretar el output de un agente.
-- **API pública decidida**:
-  - `Marker` struct + `Kind` enum (`None`, `Next`, `Goto`, `Stop`).
-  - `Parse(text) (Marker, bool)` — recorre el output completo, aplica la regex sobre la última línea no-vacía.
-  - `ParseLastLine(line) (Marker, bool)` — versión single-line (caller ya tiene la línea aislada).
-  - `ParseStreamJSON(stream) (Marker, bool)` — recorre NDJSON del `claude --output-format stream-json --verbose`, encuentra el último evento `result` y aplica `Parse` sobre `.result`.
-- **Regex canónica del PRD §3.c**: `^\s*\[(next|stop|goto:\s*([a-z_][a-z0-9_]*))\]\s*$`. Case-sensitive estricta. Step destino con identificador go-like.
-- **Default sin marker → caller resuelve**. El parser nunca devuelve `Next` por default — siempre devuelve `(None, false)` cuando no encontró marker. El motor (que sabe si la invocación falló o no) aplica el default `[next]` o `[stop]`.
-- **Tests exhaustivos** (21 tests + 71 subtests, 92 asserts):
-  - Markers válidos: `[next]`, `[stop]`, `[goto: foo]`, sin/con espacios después de `goto:`, identificadores con underscores y números.
-  - Whitespace tolerance: leading, trailing, newlines, tabs, mezclas.
-  - Case-sensitive: `[Next]`, `[NEXT]`, `[Stop]`, `[STOP]`, `[Goto: foo]`, `[GOTO: foo]`, `[goto: FOO]`, `[goto: Foo]` — todos rechazados.
-  - Última línea no vacía: marker en línea intermedia ignorado, marker mezclado con prosa rechazado, marker con prosa antes en última línea aceptado.
-  - Step destino inválido: `[goto: 123foo]`, `[goto: 1step]`, `[goto:]`, `[goto: ]`, `[goto:  ]`, `[goto: step-name]`, `[goto: step.name]`, `[goto: step name]` — todos rechazados.
-  - Brackets rotos / vacíos: `[]`, `[foo]`, `[next ]`, `[next\n]`, `[next][stop]`, `[next]extra`.
-  - Empty/whitespace-only string → `(None, false)`.
-  - `ParseLastLine` no acepta multilínea (regex anclada con `^...$`).
-  - Stream-JSON: último `result` gana, ignora líneas no-JSON, ignora JSON inválido, stream vacío, stream sin event `result`, result con texto vacío, result multilinea, result con case-mismatch.
-  - `Kind.String()` para todos los valores + valor desconocido.
+- **`Aggregator` interface** con 3 implementations: `majorityAgg`, `unanimousAgg`, `firstBlockerAgg` (`internal/engine/aggregator.go`).
+- **`AggregatorKind`** mirror de `internal/pipeline.Aggregator` (los presets `majority`/`unanimous`/`first_blocker`). El motor no importa `internal/pipeline` para mantener self-contained.
+- **`runStep`** (`internal/engine/runstep.go`) invoca a todos los agentes en paralelo via goroutines, alimenta resultados al aggregator y cancela el resto apenas el aggregator decide. Hace `context.WithCancel` sobre el ctx del motor — propaga al child process via la cadena `Invoker.Invoke → internal/agent.Run`.
+- **Cancelación parcial reportada como `Cancelled`, no como error** (PRD §3.d "loguear como cancelled by aggregator"). Los `AgentResult.Cancelled=true` no votan.
+- **Default aggregator = `majority`** (PRD §3.d "Default: majority").
+- **Step extendido** con `Aggregator AggregatorKind` opcional. `StepRun` extendido con `AgentResults []AgentResult` + `AggregatorReason string` para audit log.
+- **Backwards compat single-agent**: si `len(Step.Agents) == 1`, `StepRun` mantiene el shape histórico (Agent + Resolved "explicit"/"default-next"/"technical-error"). Cuando `>1`, queda `Resolved="aggregator"`.
+- **Errores técnicos en multi-agente**: si el aggregator decide `[stop]` con al menos 1 agente que erroreó, el motor mapea a `StopReasonTechnicalError` (no `StopReasonAgentMarker`), preservando el contrato del PR5b.
 
-## Compatibilidad con PR5b (engine)
+## Tests
 
-El parser ya estaba implementado dentro de `internal/engine/marker.go` (PR5b lo incluyó como anticipo porque PR5a no estaba mergeado todavía — ver el `EXEC_NOTES.md` original). PR5a hace el split limpio:
+**Aggregator (aislado)** — `internal/engine/aggregator_test.go`:
+- majority: stop short-circuit, 2/3 next, 2 next + 1 stop = stop, empate goto/stop = stop, empate next/goto sin stop = stop (Finalize), goto mismo destino gana 2/3, default kind, error técnico = stop.
+- unanimous: todos next, divergencia early cancel, goto mismo destino, goto destinos distintos = stop.
+- first_blocker: primer stop, primer goto, todos next.
+- helpers: kind desconocido = nil, MarkerNone == MarkerNext en keyOf.
 
-1. **Lógica del parser** vive ahora 100% en `internal/markerparser` — sólo en un lugar.
-2. **`internal/engine/marker.go`** quedó como un thin shim: type aliases (`MarkerKind = markerparser.Kind`, `Marker = markerparser.Marker`, constantes `MarkerNext` etc.) + dos funciones que delegan (`ParseMarker → markerparser.Parse`, `ParseStreamMarker → markerparser.ParseStreamJSON`).
-3. **`engine.go` y `engine_test.go` no tocados**: siguen importando los símbolos legacy (`MarkerNext`, `ParseMarker`, …) y todo sigue compilando + tests siguen verdes.
-4. El antiguo `internal/engine/marker_test.go` se mantuvo intacto: como sólo usa la API pública, sigue funcionando contra el shim. Los tests duplicados son aceptables como red de regresión adicional; un follow-up trivial puede borrarlos cuando se quiera reducir la suite.
+**runStep (paralelismo + cancelación)** — `internal/engine/runstep_test.go`:
+- single agente equivalente (backwards compat).
+- 3 agentes en paralelo (verifica `maxConcurrent >= 2` con atomicos).
+- first_blocker cancela resto via blockingInvoker (agentes B y C bloqueados, A devuelve [stop], B y C terminan con `Cancelled=true`).
+- majority stop short-circuit (B y C nunca completan, sólo A).
+- unanimous divergencia early cancel.
+- aggregator default = majority.
+- agente repetido = N instancias (3 calls al mismo nombre).
+- todos error técnico → stop con TechnicalError propagado.
+- ctx ya cancelado → stop inmediato sin invocar.
+
+**Integración con `RunPipeline`**:
+- `TestRunPipeline_StepMultiAgenteIntegracion`: pipeline con un step de 3 agentes, marker resuelto por aggregator, AgentResults llenos.
+- `TestRunPipeline_StepMultiAgenteErrorTecnicoMapeaATechReason`: confirma `StopReasonTechnicalError` cuando el aggregator stoppea por error.
+
+Toda la suite del repo (`go test ./...`) verde. `go test -race ./internal/engine/...` también verde (race en `internal/startup` es pre-existente, no tocada por este PR).
 
 ## Decisiones / desviaciones
 
-### 1. `ParseLastLine` además de `Parse`
+### 1. Aggregator interface vs función pura
 
-El issue pide la API `Parse` + `ParseLastLine` + `ParseStreamJSON`. La spec dice que `ParseLastLine` "parsea una sola linea, devuelve el marker + true si matcheó". La firma que elegí es `ParseLastLine(line string) (Marker, bool)` — alineada con `Parse` para que sea fácil de componer. Internamente `Parse` la llama después de extraer la última línea no-vacía.
+El PRD habla del aggregator como "política" pero no fija el shape. Elegí interface con `Feed` + `Finalize` (channel-style streaming) en vez de función `(N markers) → marker` porque:
 
-### 2. `ParseStreamJSON` no dispara default
+- Permite cancelación temprana natural: `Feed` devuelve `Decided=true` cuando el aggregator ya tiene info suficiente, sin necesidad de esperar a los N agentes.
+- `Finalize` cubre el caso "todos terminaron sin short-circuit" (ej. unanimous con 3 agentes que coinciden en `[next]`: el aggregator no decide hasta el último).
 
-El issue dice: "Si el ultimo output no es texto, default Next". Decidí que el parser **no** aplica ese default — devuelve `(Marker{None}, false)` y el motor (que ya sabe si la invocación fue técnicamente exitosa) decide si lo trata como `Next` o `Stop`. Es coherente con `Parse`/`ParseLastLine` (mismo patrón) y mantiene el parser puro de toda lógica de control de flujo.
+### 2. `AgentResult` preserva `MarkerNone`
 
-### 3. `Kind` zero-value es `None`, no `Next`
+`runStep` NO normaliza `MarkerNone → MarkerNext` antes de poner el resultado en `AgentResult.Marker`. La normalización vive en el aggregator (`effectiveMarker` helper). Esto preserva el contrato single-agent del motor — los tests heredados del PR5b distinguen `Resolved="default-next"` (no había marker) de `Resolved="explicit"` (agente emitió `[next]`).
 
-El zero-value del enum es `None`. Si un caller hace `var m Marker` el resultado es "sin marker", no "next" — esto fuerza al caller a decidir explícitamente qué default aplicar.
+### 3. Race fix en `fakeInvoker` (test fixture)
 
-### 4. Step destino inválido → no matchea (vs. error explícito + stop)
+El `fakeInvoker` heredado del PR5b no era thread-safe (map de calls sin lock). Como ahora el motor invoca múltiples agentes en goroutines paralelas, agregué un `sync.Mutex` al fixture. No es un cambio de producción — solo del test helper.
 
-El issue dice: "Step destino inválido → error explícito + `[stop]` con razón". Esa lógica vive en el motor (`engine.RunPipeline` ya valida que el step destino exista y emite `StopReasonUnknownStep`). El parser sólo dice "qué pidió el agente". Casos como `[goto: 123foo]` (regex no matchea por dígito al inicio) se reportan como `(None, false)` — el caller decide cómo escalarlo. Esto es coherente con la spec del issue: "el parser puro" (string in, marker out).
+### 4. `AggregatorKind` mirror de `internal/pipeline.Aggregator`
+
+PR2 (`internal/pipeline`) define `Aggregator` como enum string. El motor define `AggregatorKind` con los mismos valores en lugar de importar el paquete, manteniendo self-contained la dependencia. Cuando el wireup CLI (PR4/PR5d) consuma `pipeline.Step`, hará la conversión `pipeline.Aggregator → engine.AggregatorKind` (literal el mismo string).
+
+### 5. Cancelación de agentes "in-flight"
+
+Si un agente termina DESPUÉS de que el aggregator decidió (race entre `cancel()` y la finalización del Invoke), su resultado llega a `resultsCh` pero `runStep` lo agrega a `Results` sin alimentarlo al aggregator. Si tenía error de ctx, lo marca `Cancelled=true`; si tenía error técnico no-ctx, queda `Err` (raro: no debería pasar si el invoker respeta ctx). Esto preserva la garantía "todas las goroutines terminan antes del return" sin leakear y sin alterar la decisión.
 
 ## Pendientes (intencionalmente fuera de scope)
 
-- **Borrar `internal/engine/marker_test.go`** — los tests duplicados pasan por el shim, pero podrían borrarse como cleanup. No urgente: redundancia barata.
-- **Migrar callers internos de `engine.MarkerXxx` a `markerparser.Xxx`** — el shim funciona, no hay urgencia. Cuando se haga PR4 / PR5d y se toque el motor, se aprovecha para limpiar.
-- **Soporte para markers fuera del último output** — la spec del PRD dice "última línea no vacía", el parser cumple. Si en el futuro queremos parsear el último marker de cualquier línea (no sólo la última), sería un nuevo helper, no un cambio a `Parse`.
+- **Wiring real con `internal/agent.Run`** — el motor sigue dependiendo de la `Invoker` interface. La implementación concreta que dispatcha a claude (vía `internal/agent.Run` con `KillGrace`) viene cuando se cablee el comando `che pipeline run` (PR4 / PR5d). El `runStep` ya está listo para esa Invoker — el `KillGrace` que pide el PRD §3.d (SIGTERM + 5s grace + SIGKILL) ya está implementado en `internal/agent.Run` desde antes del PRD #50, y el ctx propagado le indica cuándo matar.
+- **Entry agent + flag `--from`** — PR5d.
+- **Adaptación de `engine.Step` → `pipeline.Step`** — follow-up cuando el wireup CLI lo necesite. Hoy son tipos paralelos compatibles en shape.

--- a/internal/engine/aggregator.go
+++ b/internal/engine/aggregator.go
@@ -1,5 +1,7 @@
 package engine
 
+import "strconv"
+
 // Aggregator resuelve los markers que emiten N agentes corriendo en paralelo
 // dentro del mismo step. PRD §3.d expone 3 presets fijos
 // (`majority`/`unanimous`/`first_blocker`) — cada uno implementa esta
@@ -17,6 +19,14 @@ package engine
 //
 // Si todos los agentes terminan sin que el aggregator haya decidido, el
 // motor llama Finalize para forzar una decisión sobre el set completo.
+//
+// Contrato Feed/Finalize: el motor llama Feed exactamente una vez por agente
+// que termina (hasta `expected` veces, donde expected = len(step.Agents) en
+// la construcción) salvo short-circuit. Cuando un Feed devuelve Decided=true,
+// el motor deja de alimentar al aggregator y NO llama Finalize. Cuando todos
+// los agentes terminaron sin Decided=true, el motor llama Finalize una sola
+// vez. Los aggregators pueden asumir esa secuencia: Feed* (≤expected) → o
+// bien (a) un Feed que devolvió Decided, o (b) Finalize sobre lo acumulado.
 //
 // Las implementaciones DEBEN ser puras (no compartir estado entre runs).
 // El motor crea una instancia nueva por step.
@@ -136,6 +146,12 @@ func markerFromKey(k markerKey) Marker {
 // effectiveMarker normaliza un AgentResult a un marker votable. Errores
 // técnicos cuentan como [stop] (PRD §3.b paso 4). MarkerNone cuenta como
 // [next] (PRD §3.b paso 5).
+//
+// Invariante: Err≠nil ⇒ se trata como [stop], indistinguible del [stop]
+// explícito emitido por el agente. Los aggregators presets actuales no
+// diferencian "stop por error" de "stop explícito" — si un futuro
+// aggregator necesita esa distinción, debe inspeccionar AgentResult.Err
+// directamente antes de pasar por effectiveMarker.
 func effectiveMarker(r AgentResult) Marker {
 	if r.Err != nil {
 		return Marker{Kind: MarkerStop}
@@ -251,7 +267,7 @@ func (a *unanimousAgg) Feed(r AgentResult) AggregatorOutcome {
 		return AggregatorOutcome{
 			Decided: true,
 			Marker:  markerFromKey(*a.first),
-			Reason:  "unanimous: all " + itoa(a.expected) + " agents agreed on " + describeKey(*a.first),
+			Reason:  "unanimous: all " + strconv.Itoa(a.expected) + " agents agreed on " + describeKey(*a.first),
 		}
 	}
 	return AggregatorOutcome{}
@@ -333,29 +349,5 @@ func describeKey(k markerKey) string {
 }
 
 func formatVoteReason(prefix string, k markerKey, count, total int) string {
-	return prefix + ": " + itoa(count) + "/" + itoa(total) + " votes for " + describeKey(k)
-}
-
-// itoa local (evita pull de strconv para una función trivial).
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	neg := false
-	if n < 0 {
-		neg = true
-		n = -n
-	}
-	var buf [20]byte
-	i := len(buf)
-	for n > 0 {
-		i--
-		buf[i] = byte('0' + n%10)
-		n /= 10
-	}
-	if neg {
-		i--
-		buf[i] = '-'
-	}
-	return string(buf[i:])
+	return prefix + ": " + strconv.Itoa(count) + "/" + strconv.Itoa(total) + " votes for " + describeKey(k)
 }

--- a/internal/engine/aggregator.go
+++ b/internal/engine/aggregator.go
@@ -1,0 +1,361 @@
+package engine
+
+// Aggregator resuelve los markers que emiten N agentes corriendo en paralelo
+// dentro del mismo step. PRD §3.d expone 3 presets fijos
+// (`majority`/`unanimous`/`first_blocker`) — cada uno implementa esta
+// interface.
+//
+// El motor alimenta al aggregator de forma incremental: por cada agente que
+// termina, llama Feed con su resultado y mira el outcome. Apenas el outcome
+// reporta Decided=true, el motor cancela el ctx de los agentes restantes y
+// no sigue alimentando al aggregator (los markers que lleguen tarde se
+// loguean como "cancelled by aggregator", no como error).
+//
+// Esto permite que aggregators conservadores como `first_blocker` corten
+// apenas vean el primer blocker, sin esperar a que los otros terminen — la
+// optimización principal de cancelación parcial del PRD §3.d.
+//
+// Si todos los agentes terminan sin que el aggregator haya decidido, el
+// motor llama Finalize para forzar una decisión sobre el set completo.
+//
+// Las implementaciones DEBEN ser puras (no compartir estado entre runs).
+// El motor crea una instancia nueva por step.
+type Aggregator interface {
+	// Feed registra el resultado de un agente. Devuelve true en Decided
+	// apenas el aggregator tiene suficiente info para decidir el marker
+	// final del step. Una vez Decided=true, el motor NO vuelve a llamar
+	// Feed/Finalize sobre esa instancia.
+	Feed(result AgentResult) AggregatorOutcome
+
+	// Finalize se llama cuando todos los agentes terminaron y ningún Feed
+	// devolvió Decided=true. El aggregator debe resolver con el set
+	// completo de resultados acumulados.
+	Finalize() AggregatorOutcome
+}
+
+// AgentResult captura el outcome de UN agente dentro de un step multi-agente.
+// Es la unidad que consume el Aggregator.
+type AgentResult struct {
+	// Agent es el nombre del agente (preservado para logs / audit).
+	Agent string
+
+	// Marker es el marker resuelto del output. MarkerNone cuando hubo error
+	// técnico — el aggregator lo trata como `[stop]` (igual que el motor
+	// single-agente: PRD §3.b paso 4).
+	Marker Marker
+
+	// Err captura el error técnico del invoker, si hubo. Sólo informativo
+	// para el aggregator (los presets actuales no diferencian "stop por
+	// error" de "stop explícito" — ambos son MarkerStop a efectos de
+	// resolución).
+	Err error
+
+	// Cancelled es true si el agente fue cortado por el aggregator antes
+	// de terminar (ctx cancel propagado al child process). El aggregator
+	// IGNORA estos resultados — no votan. El motor los recibe sólo para el
+	// audit log.
+	Cancelled bool
+}
+
+// AggregatorOutcome es la respuesta del aggregator a Feed/Finalize.
+type AggregatorOutcome struct {
+	// Decided indica si el aggregator ya resolvió la decisión final. Cuando
+	// es true, Marker y Reason son válidos y el motor cancela los agentes
+	// restantes.
+	Decided bool
+
+	// Marker es el marker final del step (el que decide la transición).
+	// Sólo válido cuando Decided=true.
+	Marker Marker
+
+	// Reason es un texto corto explicando cómo el aggregator llegó a la
+	// decisión (ej. "majority: 2/3 next", "unanimous: divergence next vs
+	// stop", "first_blocker: agent-b emitted [stop]"). Útil para audit log
+	// y dash UI. Sólo válido cuando Decided=true.
+	Reason string
+}
+
+// NewAggregator crea una instancia fresca del preset pedido. Si kind está
+// vacío, se aplica el default `majority` (PRD §3.d "Default: majority").
+// Devuelve nil si el kind es desconocido — el caller (el motor) trata eso
+// como error de configuración del pipeline.
+func NewAggregator(kind AggregatorKind, expected int) Aggregator {
+	if kind == "" {
+		kind = AggMajority
+	}
+	switch kind {
+	case AggMajority:
+		return &majorityAgg{expected: expected}
+	case AggUnanimous:
+		return &unanimousAgg{expected: expected}
+	case AggFirstBlocker:
+		return &firstBlockerAgg{expected: expected}
+	}
+	return nil
+}
+
+// AggregatorKind enumera los presets soportados. Mirror de
+// `internal/pipeline.Aggregator` — el motor no importa ese paquete (aún)
+// para mantener self-contained la dependencia.
+type AggregatorKind string
+
+const (
+	AggMajority     AggregatorKind = "majority"
+	AggUnanimous    AggregatorKind = "unanimous"
+	AggFirstBlocker AggregatorKind = "first_blocker"
+)
+
+// markerKey es la clave canónica para agrupar / comparar markers en los
+// aggregators. Diferencia [goto: X] vs [goto: Y] (transiciones distintas)
+// pero colapsa MarkerNone con MarkerNext (ambos son "default avanza" según
+// PRD §3.b paso 5).
+type markerKey struct {
+	kind MarkerKind
+	dest string // sólo para MarkerGoto
+}
+
+func keyOf(m Marker) markerKey {
+	if m.Kind == MarkerNone {
+		return markerKey{kind: MarkerNext}
+	}
+	if m.Kind == MarkerGoto {
+		return markerKey{kind: MarkerGoto, dest: m.Goto}
+	}
+	return markerKey{kind: m.Kind}
+}
+
+// markerFromKey reconstruye un Marker desde una key. Inverso de keyOf
+// (excepto que MarkerNone se mapea a MarkerNext en el round trip).
+func markerFromKey(k markerKey) Marker {
+	if k.kind == MarkerGoto {
+		return Marker{Kind: MarkerGoto, Goto: k.dest}
+	}
+	return Marker{Kind: k.kind}
+}
+
+// effectiveMarker normaliza un AgentResult a un marker votable. Errores
+// técnicos cuentan como [stop] (PRD §3.b paso 4). MarkerNone cuenta como
+// [next] (PRD §3.b paso 5).
+func effectiveMarker(r AgentResult) Marker {
+	if r.Err != nil {
+		return Marker{Kind: MarkerStop}
+	}
+	if r.Marker.Kind == MarkerNone {
+		return Marker{Kind: MarkerNext}
+	}
+	return r.Marker
+}
+
+// ---------- majority ----------
+
+// majorityAgg implementa AggregatorMajority. PRD §3.d:
+//   - "[stop] siempre gana en majority" → si UN agente emite [stop], el
+//     aggregator decide [stop] inmediatamente (cancelación temprana del
+//     resto, no aporta info que cambie la decisión).
+//   - "Empate sin mayoría → [stop] (conservador)" — si al final ningún
+//     marker alcanza mayoría estricta (>N/2), el aggregator devuelve [stop]
+//     con razón "tie".
+//   - Sino, gana el marker más votado.
+type majorityAgg struct {
+	expected int
+	counts   map[markerKey]int
+	results  []AgentResult
+}
+
+func (a *majorityAgg) Feed(r AgentResult) AggregatorOutcome {
+	a.results = append(a.results, r)
+	if a.counts == nil {
+		a.counts = map[markerKey]int{}
+	}
+	m := effectiveMarker(r)
+	// Short-circuit: cualquier [stop] gana. PRD §3.d.
+	if m.Kind == MarkerStop {
+		return AggregatorOutcome{
+			Decided: true,
+			Marker:  Marker{Kind: MarkerStop},
+			Reason:  "majority: agent " + r.Agent + " emitted [stop]",
+		}
+	}
+	a.counts[keyOf(m)]++
+	// ¿Algún marker ya tiene mayoría estricta (>N/2)?
+	for k, c := range a.counts {
+		if c*2 > a.expected {
+			return AggregatorOutcome{
+				Decided: true,
+				Marker:  markerFromKey(k),
+				Reason:  formatVoteReason("majority", k, c, a.expected),
+			}
+		}
+	}
+	return AggregatorOutcome{}
+}
+
+func (a *majorityAgg) Finalize() AggregatorOutcome {
+	// No hubo mayoría estricta → empate → conservador → [stop].
+	// (Si hubiéramos visto un [stop] explícito ya habríamos decidido en
+	// Feed; este Finalize sólo se invoca cuando todos terminaron sin
+	// short-circuit.)
+	var bestKey markerKey
+	bestCount := -1
+	for k, c := range a.counts {
+		if c > bestCount {
+			bestCount, bestKey = c, k
+		}
+	}
+	if bestCount*2 > a.expected {
+		// Defensa: no debería pasar (Feed ya habría decidido), pero por
+		// si el caller pasa expected mal o Feed se saltó el chequeo.
+		return AggregatorOutcome{
+			Decided: true,
+			Marker:  markerFromKey(bestKey),
+			Reason:  formatVoteReason("majority", bestKey, bestCount, a.expected),
+		}
+	}
+	return AggregatorOutcome{
+		Decided: true,
+		Marker:  Marker{Kind: MarkerStop},
+		Reason:  "majority: tie without strict majority, defaulting to [stop]",
+	}
+}
+
+// ---------- unanimous ----------
+
+// unanimousAgg implementa AggregatorUnanimous. Si todos los agentes
+// coinciden exactamente (mismo Marker.Kind y mismo Goto cuando aplica),
+// devuelve ese marker. Cualquier divergencia → [stop].
+//
+// Cancelación temprana: apenas vemos 2 markers distintos, decidimos [stop]
+// — los markers restantes no pueden volver atrás la divergencia.
+type unanimousAgg struct {
+	expected int
+	first    *markerKey
+	results  []AgentResult
+}
+
+func (a *unanimousAgg) Feed(r AgentResult) AggregatorOutcome {
+	a.results = append(a.results, r)
+	m := effectiveMarker(r)
+	k := keyOf(m)
+	if a.first == nil {
+		a.first = &k
+	} else if *a.first != k {
+		return AggregatorOutcome{
+			Decided: true,
+			Marker:  Marker{Kind: MarkerStop},
+			Reason:  "unanimous: divergence (" + describeKey(*a.first) + " vs " + describeKey(k) + ")",
+		}
+	}
+	// Mientras todos coincidan, esperamos al resto antes de declarar
+	// unanimidad. Sólo decidimos cuando llegó el último.
+	if len(a.results) == a.expected {
+		return AggregatorOutcome{
+			Decided: true,
+			Marker:  markerFromKey(*a.first),
+			Reason:  "unanimous: all " + itoa(a.expected) + " agents agreed on " + describeKey(*a.first),
+		}
+	}
+	return AggregatorOutcome{}
+}
+
+func (a *unanimousAgg) Finalize() AggregatorOutcome {
+	// Caso defensivo: el motor llamó Finalize sin completar expected. Tomá
+	// lo que tengas.
+	if a.first == nil {
+		return AggregatorOutcome{
+			Decided: true,
+			Marker:  Marker{Kind: MarkerStop},
+			Reason:  "unanimous: no agents reported",
+		}
+	}
+	return AggregatorOutcome{
+		Decided: true,
+		Marker:  markerFromKey(*a.first),
+		Reason:  "unanimous: all reporting agents agreed on " + describeKey(*a.first),
+	}
+}
+
+// ---------- first_blocker ----------
+
+// firstBlockerAgg implementa AggregatorFirstBlocker. PRD §3.d: "primer
+// `[stop]` o `[goto: X]` define la transición". Si todos `[next]` → `[next]`.
+type firstBlockerAgg struct {
+	expected int
+	results  []AgentResult
+}
+
+func (a *firstBlockerAgg) Feed(r AgentResult) AggregatorOutcome {
+	a.results = append(a.results, r)
+	m := effectiveMarker(r)
+	if m.Kind == MarkerStop || m.Kind == MarkerGoto {
+		return AggregatorOutcome{
+			Decided: true,
+			Marker:  m,
+			Reason:  "first_blocker: agent " + r.Agent + " emitted " + describeKey(keyOf(m)),
+		}
+	}
+	if len(a.results) == a.expected {
+		return AggregatorOutcome{
+			Decided: true,
+			Marker:  Marker{Kind: MarkerNext},
+			Reason:  "first_blocker: all agents emitted [next]",
+		}
+	}
+	return AggregatorOutcome{}
+}
+
+func (a *firstBlockerAgg) Finalize() AggregatorOutcome {
+	// Caso defensivo: motor llamó Finalize sin que ningún agente bloqueara
+	// y sin completar expected. Tratamos como [next] si todos fueron [next].
+	for _, r := range a.results {
+		m := effectiveMarker(r)
+		if m.Kind == MarkerStop || m.Kind == MarkerGoto {
+			return AggregatorOutcome{
+				Decided: true,
+				Marker:  m,
+				Reason:  "first_blocker: agent " + r.Agent + " emitted " + describeKey(keyOf(m)),
+			}
+		}
+	}
+	return AggregatorOutcome{
+		Decided: true,
+		Marker:  Marker{Kind: MarkerNext},
+		Reason:  "first_blocker: no blockers seen",
+	}
+}
+
+// ---------- helpers ----------
+
+func describeKey(k markerKey) string {
+	if k.kind == MarkerGoto {
+		return "[goto: " + k.dest + "]"
+	}
+	return "[" + k.kind.String() + "]"
+}
+
+func formatVoteReason(prefix string, k markerKey, count, total int) string {
+	return prefix + ": " + itoa(count) + "/" + itoa(total) + " votes for " + describeKey(k)
+}
+
+// itoa local (evita pull de strconv para una función trivial).
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/internal/engine/aggregator_test.go
+++ b/internal/engine/aggregator_test.go
@@ -1,0 +1,290 @@
+package engine
+
+import "testing"
+
+// Tests del aggregator en aislamiento (sin runStep). Verifican la lógica
+// pura de las 3 políticas: cuándo deciden temprano, cómo resuelven empates,
+// cómo tratan errores técnicos vs markers explícitos.
+
+func mkResult(agent string, kind MarkerKind, dest string) AgentResult {
+	m := Marker{Kind: kind}
+	if kind == MarkerGoto {
+		m.Goto = dest
+	}
+	return AgentResult{Agent: agent, Marker: m}
+}
+
+func mkErrResult(agent string, err error) AgentResult {
+	return AgentResult{Agent: agent, Err: err, Marker: Marker{Kind: MarkerNone}}
+}
+
+// ---------- majority ----------
+
+func TestMajority_StopGanaSiempre_EarlyCancel(t *testing.T) {
+	// 3 agentes, primero emite [stop]. PRD §3.d: "[stop] siempre gana en
+	// majority" — el aggregator decide en cuanto ve el primer stop, sin
+	// esperar a los demás (cancelación temprana).
+	agg := NewAggregator(AggMajority, 3)
+
+	out := agg.Feed(mkResult("a", MarkerStop, ""))
+	if !out.Decided {
+		t.Fatalf("expected decided=true after first [stop]; got %+v", out)
+	}
+	if out.Marker.Kind != MarkerStop {
+		t.Errorf("Marker.Kind=%v want stop", out.Marker.Kind)
+	}
+}
+
+func TestMajority_TodosNext(t *testing.T) {
+	// 3 [next] → mayoría estricta de [next]. Decide al alcanzar 2/3.
+	agg := NewAggregator(AggMajority, 3)
+	if out := agg.Feed(mkResult("a", MarkerNext, "")); out.Decided {
+		t.Fatalf("decided too early after 1/3; want wait")
+	}
+	out := agg.Feed(mkResult("b", MarkerNext, ""))
+	if !out.Decided {
+		t.Fatalf("expected decided after 2/3 next (strict majority)")
+	}
+	if out.Marker.Kind != MarkerNext {
+		t.Errorf("Marker.Kind=%v want next", out.Marker.Kind)
+	}
+}
+
+func TestMajority_DosNextUnoStop(t *testing.T) {
+	// next/next/stop — cualquier orden. PRD §3.d: stop gana incluso con
+	// 2 next. El aggregator corta apenas ve el stop.
+	agg := NewAggregator(AggMajority, 3)
+	agg.Feed(mkResult("a", MarkerNext, ""))
+	out := agg.Feed(mkResult("b", MarkerNext, ""))
+	if !out.Decided || out.Marker.Kind != MarkerNext {
+		t.Fatalf("expected decided next after 2/3; got %+v", out)
+	}
+	// Si el aggregator decidió antes de llegar el stop, el motor no
+	// alimentaría ese stop. Pero verificamos el caso al revés: stop
+	// llega primero.
+	agg2 := NewAggregator(AggMajority, 3)
+	agg2.Feed(mkResult("a", MarkerNext, ""))
+	out2 := agg2.Feed(mkResult("b", MarkerStop, ""))
+	if !out2.Decided || out2.Marker.Kind != MarkerStop {
+		t.Fatalf("[stop] debería ganar incluso después de [next]; got %+v", out2)
+	}
+}
+
+func TestMajority_EmpateGotoStopEsStop(t *testing.T) {
+	// PRD §3.d ejemplo del scope del issue: next/goto:X/stop → stop.
+	// Como [stop] short-circuitea, el aggregator decide al ver el stop
+	// (independiente del orden). Verificamos los 3 órdenes posibles.
+	cases := []struct {
+		name string
+		seq  []AgentResult
+	}{
+		{"next-goto-stop", []AgentResult{
+			mkResult("a", MarkerNext, ""),
+			mkResult("b", MarkerGoto, "x"),
+			mkResult("c", MarkerStop, ""),
+		}},
+		{"stop-first", []AgentResult{
+			mkResult("a", MarkerStop, ""),
+			mkResult("b", MarkerGoto, "x"),
+			mkResult("c", MarkerNext, ""),
+		}},
+		{"goto-stop-next", []AgentResult{
+			mkResult("a", MarkerGoto, "x"),
+			mkResult("b", MarkerStop, ""),
+			mkResult("c", MarkerNext, ""),
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agg := NewAggregator(AggMajority, 3)
+			var final AggregatorOutcome
+			for _, r := range tc.seq {
+				final = agg.Feed(r)
+				if final.Decided {
+					break
+				}
+			}
+			if !final.Decided {
+				final = agg.Finalize()
+			}
+			if final.Marker.Kind != MarkerStop {
+				t.Errorf("Marker.Kind=%v want stop (empate sin mayoría → stop)", final.Marker.Kind)
+			}
+		})
+	}
+}
+
+func TestMajority_EmpateNextGotoSinStop_FinalizeDevuelveStop(t *testing.T) {
+	// 2 agentes: 1 next, 1 goto:x. NO hay [stop] explícito. Empate sin
+	// mayoría estricta (cada uno tiene 1 voto, ninguno >N/2). PRD §3.d:
+	// "Empate sin mayoría → [stop] (conservador)".
+	agg := NewAggregator(AggMajority, 2)
+	if out := agg.Feed(mkResult("a", MarkerNext, "")); out.Decided {
+		t.Fatalf("decided too early")
+	}
+	out := agg.Feed(mkResult("b", MarkerGoto, "x"))
+	// Después del segundo, ambos tienen count=1, ninguno >2/2=1 estricto.
+	// Feed devuelve no-decided; Finalize lo resuelve a stop.
+	if out.Decided {
+		// Este caso es ambiguo: 1 voto no es mayoría estricta de 2 (>1).
+		// Si Feed decidiera, debería ser stop. Si no decide, Finalize lo
+		// hace. Aceptamos cualquiera de los dos siempre que el resultado
+		// final sea stop.
+		if out.Marker.Kind != MarkerStop {
+			t.Errorf("Feed decided=%v Marker=%v; want stop", out.Decided, out.Marker.Kind)
+		}
+		return
+	}
+	final := agg.Finalize()
+	if final.Marker.Kind != MarkerStop {
+		t.Errorf("Finalize Marker.Kind=%v want stop (empate)", final.Marker.Kind)
+	}
+}
+
+func TestMajority_GotoMismoDestinoGana(t *testing.T) {
+	// 3 agentes, 2 con [goto: x] y 1 con [next] → goto:x gana 2/3.
+	agg := NewAggregator(AggMajority, 3)
+	agg.Feed(mkResult("a", MarkerGoto, "x"))
+	agg.Feed(mkResult("b", MarkerNext, ""))
+	out := agg.Feed(mkResult("c", MarkerGoto, "x"))
+	if !out.Decided {
+		t.Fatalf("expected decided after 2/3 goto:x")
+	}
+	if out.Marker.Kind != MarkerGoto || out.Marker.Goto != "x" {
+		t.Errorf("Marker=%+v want goto:x", out.Marker)
+	}
+}
+
+func TestMajority_DefaultKindEsMajority(t *testing.T) {
+	// PRD §3.d: "Default: majority". Cuando se pasa kind="" debe
+	// comportarse como majority.
+	agg := NewAggregator("", 3)
+	if agg == nil {
+		t.Fatal("default aggregator nil")
+	}
+	out := agg.Feed(mkResult("a", MarkerStop, ""))
+	if !out.Decided || out.Marker.Kind != MarkerStop {
+		t.Errorf("default agg no se comporta como majority; got %+v", out)
+	}
+}
+
+func TestMajority_ErrorTecnicoCuentaComoStop(t *testing.T) {
+	// PRD §3.b paso 4: error técnico = [stop] automático. El aggregator
+	// majority debería short-circuitear igual que con un [stop] explícito.
+	agg := NewAggregator(AggMajority, 3)
+	out := agg.Feed(mkErrResult("a", errExitNonZero))
+	if !out.Decided || out.Marker.Kind != MarkerStop {
+		t.Errorf("error técnico no fue tratado como stop; got %+v", out)
+	}
+}
+
+// ---------- unanimous ----------
+
+func TestUnanimous_TodosNext(t *testing.T) {
+	agg := NewAggregator(AggUnanimous, 3)
+	agg.Feed(mkResult("a", MarkerNext, ""))
+	agg.Feed(mkResult("b", MarkerNext, ""))
+	out := agg.Feed(mkResult("c", MarkerNext, ""))
+	if !out.Decided || out.Marker.Kind != MarkerNext {
+		t.Errorf("expected unanimous next; got %+v", out)
+	}
+}
+
+func TestUnanimous_DivergenciaEsStop_EarlyCancel(t *testing.T) {
+	// Scope del issue: unanimous con next/next/goto:X → stop.
+	// El aggregator detecta divergencia en el segundo voto (next vs goto).
+	agg := NewAggregator(AggUnanimous, 3)
+	agg.Feed(mkResult("a", MarkerNext, ""))
+	out := agg.Feed(mkResult("b", MarkerGoto, "x"))
+	if !out.Decided {
+		t.Fatalf("expected early decide on divergence after 2/3")
+	}
+	if out.Marker.Kind != MarkerStop {
+		t.Errorf("Marker.Kind=%v want stop (divergence)", out.Marker.Kind)
+	}
+}
+
+func TestUnanimous_GotoMismoDestino(t *testing.T) {
+	// goto:x / goto:x / goto:x → unanimous goto:x.
+	agg := NewAggregator(AggUnanimous, 3)
+	agg.Feed(mkResult("a", MarkerGoto, "x"))
+	agg.Feed(mkResult("b", MarkerGoto, "x"))
+	out := agg.Feed(mkResult("c", MarkerGoto, "x"))
+	if !out.Decided {
+		t.Fatalf("expected decided after unanimous")
+	}
+	if out.Marker.Kind != MarkerGoto || out.Marker.Goto != "x" {
+		t.Errorf("Marker=%+v want goto:x", out.Marker)
+	}
+}
+
+func TestUnanimous_GotoDestinosDistintosEsStop(t *testing.T) {
+	// goto:x / goto:y → divergencia.
+	agg := NewAggregator(AggUnanimous, 2)
+	agg.Feed(mkResult("a", MarkerGoto, "x"))
+	out := agg.Feed(mkResult("b", MarkerGoto, "y"))
+	if !out.Decided || out.Marker.Kind != MarkerStop {
+		t.Errorf("goto destinos distintos deberían divergir; got %+v", out)
+	}
+}
+
+// ---------- first_blocker ----------
+
+func TestFirstBlocker_PrimerStopGana(t *testing.T) {
+	// Scope del issue: first_blocker con [stop] primero cancela los demás.
+	agg := NewAggregator(AggFirstBlocker, 3)
+	out := agg.Feed(mkResult("a", MarkerStop, ""))
+	if !out.Decided {
+		t.Fatalf("first_blocker no decidió en el primer stop")
+	}
+	if out.Marker.Kind != MarkerStop {
+		t.Errorf("Marker.Kind=%v want stop", out.Marker.Kind)
+	}
+}
+
+func TestFirstBlocker_PrimerGotoGana(t *testing.T) {
+	agg := NewAggregator(AggFirstBlocker, 3)
+	agg.Feed(mkResult("a", MarkerNext, ""))
+	out := agg.Feed(mkResult("b", MarkerGoto, "x"))
+	if !out.Decided {
+		t.Fatalf("first_blocker no decidió con goto")
+	}
+	if out.Marker.Kind != MarkerGoto || out.Marker.Goto != "x" {
+		t.Errorf("Marker=%+v want goto:x", out.Marker)
+	}
+}
+
+func TestFirstBlocker_TodosNext(t *testing.T) {
+	agg := NewAggregator(AggFirstBlocker, 3)
+	agg.Feed(mkResult("a", MarkerNext, ""))
+	agg.Feed(mkResult("b", MarkerNext, ""))
+	out := agg.Feed(mkResult("c", MarkerNext, ""))
+	if !out.Decided || out.Marker.Kind != MarkerNext {
+		t.Errorf("expected next after all next; got %+v", out)
+	}
+}
+
+// ---------- helpers / edge cases ----------
+
+func TestNewAggregator_KindDesconocidoEsNil(t *testing.T) {
+	if a := NewAggregator("bogus_kind", 3); a != nil {
+		t.Errorf("NewAggregator(unknown) = %T want nil", a)
+	}
+}
+
+func TestKeyOf_NoneSeMapeaANext(t *testing.T) {
+	// Salud del helper: MarkerNone (output sin marker) cuenta como
+	// MarkerNext a efectos de voto. Esto preserva la regla "default-next"
+	// del PRD §3.b paso 5 incluso en multi-agente.
+	if keyOf(Marker{Kind: MarkerNone}) != keyOf(Marker{Kind: MarkerNext}) {
+		t.Error("MarkerNone debería mapearse a MarkerNext en keyOf")
+	}
+}
+
+// errExitNonZero es un error técnico fake (no constructor explícito para
+// no acoplar el test al exit-code wrapping de internal/agent).
+var errExitNonZero = &fakeErr{msg: "exit 1: auth failed"}
+
+type fakeErr struct{ msg string }
+
+func (e *fakeErr) Error() string { return e.msg }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -18,8 +18,8 @@ import (
 const MaxTransitions = 20
 
 // Step es la unidad mínima del pipeline desde la perspectiva del motor.
-// Sólo necesitamos Name + Agents para invocar — el aggregator y demás
-// metadata viven en el paquete `internal/pipeline` (PR2). Cuando PR2
+// Sólo necesitamos Name + Agents + Aggregator para invocar — el resto de
+// metadata vive en el paquete `internal/pipeline` (PR2). Cuando PR2
 // merguea, un follow-up adapta `engine.Run` para consumir
 // `pipeline.Pipeline` directamente y este tipo desaparece.
 type Step struct {
@@ -29,11 +29,16 @@ type Step struct {
 	Name string
 
 	// Agents es la lista de refs a agentes (built-in o custom) que el
-	// step puede correr. PR5b sólo invoca al primero — el motor
-	// multi-agente + aggregator vive en PR5c. La lista se preserva
-	// completa para que la UX (CLI/dash) muestre los candidatos al
-	// usuario y para que PR5c la consuma sin cambiar el shape.
+	// step debe correr. Si len > 1, los agentes corren en paralelo y
+	// Aggregator decide cómo resolver markers en conflicto. Un agente
+	// repetido equivale a N instancias paralelas (best-of-N con el
+	// mismo modelo).
 	Agents []string
+
+	// Aggregator selecciona la política de resolución cuando len(Agents)>1.
+	// Vacío == default (`majority`). Para 1 agente, el campo se ignora —
+	// `runStep` produce el mismo outcome con cualquier preset.
+	Aggregator AggregatorKind
 }
 
 // Pipeline es la secuencia ordenada de steps que el motor ejecuta. Sin
@@ -128,8 +133,9 @@ const (
 type StepRun struct {
 	// Step es el nombre del step que corrió.
 	Step string
-	// Agent es el nombre del agente que el motor invocó. PR5b corre el
-	// primero de la lista; PR5c (multi-agente) extenderá esto a una lista.
+	// Agent es el nombre del agente que produjo el marker resuelto en
+	// modo single-agente. Cuando hay multi-agente (len(Step.Agents)>1)
+	// queda vacío y el detalle vive en AgentResults.
 	Agent string
 	// Marker es el marker resuelto: el que emitió el agente, o el default
 	// `[next]` cuando no hubo marker y la invocación fue exitosa, o
@@ -140,10 +146,18 @@ type StepRun struct {
 	//   - "default-next"      no hubo marker pero la invocación fue OK
 	//   - "technical-error"   la invocación falló
 	//   - "unknown-step"      el goto apuntó a un step inexistente
+	//   - "aggregator"        multi-agente, decidido por el aggregator
 	Resolved string
 	// Err captura el error técnico del invoker, si hubo. Sólo informativo
 	// — la decisión de stop ya quedó reflejada en Marker.
 	Err error
+	// AgentResults trae el detalle por agente en modo multi-agente
+	// (len(Step.Agents)>1). En modo single-agente queda nil — el caller
+	// puede ignorarlo o leer Marker/Agent directamente.
+	AgentResults []AgentResult
+	// AggregatorReason explica cómo el aggregator llegó al Marker en modo
+	// multi-agente. Vacío en modo single-agente.
+	AggregatorReason string
 }
 
 // Run es el resultado completo de una corrida del motor.
@@ -278,51 +292,76 @@ func RunPipeline(ctx context.Context, p Pipeline, inv Invoker, opts Options) (Ru
 			return run, nil
 		}
 
-		// PR5b: 1 agente por step. PR5c trae multi-agente + aggregator.
-		agent := step.Agents[0]
+		// runStep maneja tanto el caso single-agent (len==1) como multi-
+		// agent (len>1, paralelo + aggregator + cancelación parcial). En
+		// single-agent no hay aggregator visible al caller — runStep
+		// resuelve idénticamente al motor pre-PR5c.
+		outcome := runStep(ctx, step, inv, currentInput)
 
-		output, format, invErr := inv.Invoke(ctx, agent, currentInput)
+		stepRun := StepRun{Step: step.Name}
 
-		stepRun := StepRun{
-			Step:  step.Name,
-			Agent: agent,
+		if len(step.Agents) == 1 {
+			// Single-agent: preservamos el shape histórico (Agent + Resolved
+			// "explicit"/"default-next"/"technical-error") para no romper
+			// callers existentes ni los tests heredados.
+			stepRun.Agent = step.Agents[0]
+			if len(outcome.Results) == 1 {
+				ar := outcome.Results[0]
+				stepRun.Err = ar.Err
+				switch {
+				case ar.Err != nil:
+					stepRun.Resolved = "technical-error"
+				case ar.Marker.Kind == MarkerNone:
+					stepRun.Resolved = "default-next"
+				default:
+					stepRun.Resolved = "explicit"
+				}
+			}
+		} else {
+			// Multi-agent: detalle por-agente + razón del aggregator.
+			stepRun.AgentResults = outcome.Results
+			stepRun.AggregatorReason = outcome.AggregatorReason
+			stepRun.Resolved = "aggregator"
+			// Propagar el primer error técnico (si lo hubo) para que los
+			// callers que sólo miran StepRun.Err vean algo útil sin tener
+			// que iterar AgentResults.
+			if outcome.TechnicalError != nil {
+				stepRun.Err = outcome.TechnicalError
+			}
 		}
 
-		if invErr != nil {
-			// PRD §3.b paso 4: "Si la invocación falla (timeout, error de
-			// red, exit code distinto de 0 del binario, crash) → trata el
-			// outcome como [stop] automático".
-			stepRun.Marker = Marker{Kind: MarkerStop}
-			stepRun.Resolved = "technical-error"
-			stepRun.Err = invErr
+		marker := outcome.Marker
+		if marker.Kind == MarkerNone {
+			marker = Marker{Kind: MarkerNext}
+		}
+		stepRun.Marker = marker
+
+		// Caso "todos los agentes errorearon técnicamente y aggregator
+		// resolvió [stop]": tratamos como StopReasonTechnicalError igual
+		// que en el motor single-agente. Esto preserva el contrato
+		// histórico (un agente que falla → stop técnico).
+		if marker.Kind == MarkerStop && outcome.TechnicalError != nil {
 			run.Steps = append(run.Steps, stepRun)
 			run.Stopped = true
 			run.StopReason = StopReasonTechnicalError
-			run.StopDetail = fmt.Sprintf("agent %q in step %q: %v", agent, step.Name, invErr)
+			if len(step.Agents) == 1 {
+				run.StopDetail = fmt.Sprintf("agent %q in step %q: %v", step.Agents[0], step.Name, outcome.TechnicalError)
+			} else {
+				run.StopDetail = fmt.Sprintf("step %q: %s; first error: %v", step.Name, outcome.AggregatorReason, outcome.TechnicalError)
+			}
 			return run, nil
 		}
 
-		// Parsear marker según format. Default a FormatText cuando el
-		// invoker no especifica (zero value).
-		var (
-			marker Marker
-			found  bool
-		)
-		switch format {
-		case FormatStreamJSON:
-			marker, found = ParseStreamMarker(output)
-		default:
-			marker, found = ParseMarker(output)
+		// Cancelación externa del ctx parent (señal, deadline). Si el
+		// outcome devolvió [stop] con error de ctx, mapeamos a stop
+		// técnico igual que el bloque inicial del loop.
+		if marker.Kind == MarkerStop && ctx != nil && ctx.Err() != nil {
+			run.Steps = append(run.Steps, stepRun)
+			run.Stopped = true
+			run.StopReason = StopReasonTechnicalError
+			run.StopDetail = ctx.Err().Error()
+			return run, nil
 		}
-
-		if !found {
-			// PRD §3.b paso 5 + §3.c: "Si no hay marker → asume [next]".
-			marker = Marker{Kind: MarkerNext}
-			stepRun.Resolved = "default-next"
-		} else {
-			stepRun.Resolved = "explicit"
-		}
-		stepRun.Marker = marker
 
 		// Validación de step destino para [goto: X] — PRD §3.c "Step
 		// destino inválido": convertir a stop con razón explícita.
@@ -339,11 +378,6 @@ func RunPipeline(ctx context.Context, p Pipeline, inv Invoker, opts Options) (Ru
 		}
 
 		run.Steps = append(run.Steps, stepRun)
-		// Para PR5b el "input" de cada step se mantiene como el input
-		// original. Cuando PR5c+ traiga el "context base" + outputs
-		// previos, este es el lugar donde se enriquece. Documentar acá
-		// para que el follow-up sepa qué reemplazar.
-		_ = output
 
 		switch marker.Kind {
 		case MarkerStop:

--- a/internal/engine/engine_test.go
+++ b/internal/engine/engine_test.go
@@ -3,12 +3,16 @@ package engine
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 )
 
 // fakeInvoker es un Invoker programable: el test setea cómo responder a
 // cada agente y registra cuántas veces se invocó cada uno. Permite
 // verificar el flow del engine sin spawnear procesos reales.
+//
+// Safe for concurrent use: PR5c invoca a múltiples agentes en goroutines
+// paralelas, así que el `calls` map necesita protección.
 type fakeInvoker struct {
 	// responder se llama por cada Invoke. Recibe el agente y la cuenta
 	// de llamadas previas a ESE agente (0-based). Devuelve el output, el
@@ -16,6 +20,7 @@ type fakeInvoker struct {
 	responder func(agent string, callIdx int) (string, OutputFormat, error)
 	// calls cuenta llamadas por agente para que los tests puedan
 	// verificar "se llamó al executor 3 veces, al validator 1".
+	mu    sync.Mutex
 	calls map[string]int
 }
 
@@ -27,8 +32,10 @@ func newFakeInvoker(fn func(agent string, callIdx int) (string, OutputFormat, er
 }
 
 func (f *fakeInvoker) Invoke(ctx context.Context, agent string, input string) (string, OutputFormat, error) {
+	f.mu.Lock()
 	idx := f.calls[agent]
 	f.calls[agent] = idx + 1
+	f.mu.Unlock()
 	return f.responder(agent, idx)
 }
 

--- a/internal/engine/runstep.go
+++ b/internal/engine/runstep.go
@@ -1,0 +1,187 @@
+package engine
+
+import (
+	"context"
+	"sync"
+)
+
+// stepOutcome es el resultado consolidado de la ejecución de UN step
+// (potencialmente con N agentes en paralelo + aggregator).
+type stepOutcome struct {
+	// Marker es el marker final del step, ya resuelto por el aggregator.
+	// Cuando hay errores técnicos en TODOS los agentes y el aggregator
+	// resuelve [stop], TechnicalError es true para que el motor pueda
+	// marcar el StopReason adecuado.
+	Marker Marker
+
+	// AggregatorReason explica cómo el aggregator llegó al Marker (texto
+	// libre, sólo para audit / logs).
+	AggregatorReason string
+
+	// Results es la lista de outcomes por agente, en el orden en que
+	// terminaron (no en el orden de Step.Agents). Incluye los cancelados
+	// por el aggregator (Cancelled=true) para el audit log.
+	Results []AgentResult
+
+	// TechnicalError captura el primer error técnico que el aggregator usó
+	// para decidir [stop]. Si el step resuelve [stop] por error técnico,
+	// el motor mapea esto a StopReasonTechnicalError.
+	TechnicalError error
+}
+
+// runStep invoca a todos los agentes del step en paralelo, alimenta sus
+// markers al aggregator, y cancela los pendientes apenas el aggregator
+// puede determinar el resultado (cancelación parcial — PRD §3.d).
+//
+// Garantías:
+//  1. Todas las goroutines terminan antes de que runStep retorne. La
+//     cancelación se hace via context.WithCancel propagado a Invoker.Invoke
+//     — el invoker (vía `internal/agent.Run`) ya soporta SIGTERM + grace +
+//     SIGKILL.
+//  2. Los agentes cancelados se reportan con Cancelled=true en
+//     stepOutcome.Results (NO como error). Esto cumple el requisito de
+//     "loguear como cancelled by aggregator, no como error".
+//  3. Si el aggregator nunca decide en Feed (ej. todos terminaron sin
+//     short-circuit), runStep llama Finalize con los resultados acumulados.
+//  4. Si el ctx parent está cancelado al entrar, runStep retorna [stop]
+//     inmediatamente sin invocar agentes.
+func runStep(ctx context.Context, step Step, inv Invoker, input string) stepOutcome {
+	if ctx.Err() != nil {
+		return stepOutcome{
+			Marker:           Marker{Kind: MarkerStop},
+			AggregatorReason: "context cancelled before step start: " + ctx.Err().Error(),
+			TechnicalError:   ctx.Err(),
+		}
+	}
+
+	agents := step.Agents
+	n := len(agents)
+
+	// stepCtx propaga la cancelación al invoker: cuando el aggregator
+	// decide, llamamos cancel() y los Invoke pendientes deberían ver el
+	// ctx cancelado y matar el child process. Mantiene el árbol parent →
+	// step → invoker de cancelación.
+	stepCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	type rawResult struct {
+		agent  string
+		idx    int // posición en step.Agents (para audit log estable)
+		output string
+		format OutputFormat
+		err    error
+	}
+	resultsCh := make(chan rawResult, n)
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i, a := range agents {
+		i, a := i, a
+		go func() {
+			defer wg.Done()
+			out, fmt2, err := inv.Invoke(stepCtx, a, input)
+			resultsCh <- rawResult{agent: a, idx: i, output: out, format: fmt2, err: err}
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(resultsCh)
+	}()
+
+	aggKind := step.Aggregator
+	if aggKind == "" {
+		aggKind = AggMajority
+	}
+	agg := NewAggregator(aggKind, n)
+
+	var (
+		decided        bool
+		decidedOutcome AggregatorOutcome
+		results        []AgentResult
+		// firstTechErr captura el primer error técnico (NO de cancelación).
+		// Sólo lo usamos para mapear a StopReasonTechnicalError cuando el
+		// aggregator resuelve [stop] basado en ese error.
+		firstTechErr error
+	)
+
+	// Loop principal: drainamos resultsCh; por cada resultado, parseamos
+	// marker (a menos que sea cancelado), alimentamos al aggregator, y si
+	// el aggregator decide cancelamos el resto y seguimos drenando hasta
+	// que se cierre el channel (para no leakear goroutines).
+	for r := range resultsCh {
+		ar := AgentResult{Agent: r.agent}
+
+		// Si el ctx step ya fue cancelado, marcamos como cancelled.
+		// Distinguir cancelado-por-aggregator de error-real es importante:
+		// el aggregator ignora cancelados (no votan), y el audit log no los
+		// reporta como error.
+		if r.err != nil && stepCtx.Err() != nil && decided {
+			ar.Cancelled = true
+			results = append(results, ar)
+			continue
+		}
+
+		if r.err != nil {
+			// Error técnico real (no cancelación-por-aggregator). El parent
+			// ctx puede haberse cancelado externamente — en ese caso lo
+			// trataremos como error técnico también (consistente con el
+			// motor single-agente, donde ctx.Err() externo gatilla
+			// StopReasonTechnicalError).
+			ar.Err = r.err
+			ar.Marker = Marker{Kind: MarkerStop}
+			if firstTechErr == nil {
+				firstTechErr = r.err
+			}
+		} else {
+			// El parser devuelve (Marker{MarkerNone}, false) cuando no
+			// hubo marker. PRESERVAMOS MarkerNone en AgentResult para
+			// que el caller pueda distinguir "default-next" (no había
+			// marker) de "explicit next" (el agente lo emitió). El
+			// aggregator normaliza vía effectiveMarker — para él los
+			// dos son lo mismo a efectos de voto.
+			switch r.format {
+			case FormatStreamJSON:
+				ar.Marker, _ = ParseStreamMarker(r.output)
+			default:
+				ar.Marker, _ = ParseMarker(r.output)
+			}
+		}
+
+		results = append(results, ar)
+
+		if decided {
+			// Aggregator ya decidió. Drenamos sin alimentar ni cancelar
+			// (cancel ya fue llamado al decidir). Estos resultados llegaron
+			// en flight — los reportamos pero no afectan la decisión.
+			continue
+		}
+
+		outcome := agg.Feed(ar)
+		if outcome.Decided {
+			decided = true
+			decidedOutcome = outcome
+			cancel() // cortar el resto.
+		}
+	}
+
+	if !decided {
+		// Todos los agentes terminaron y el aggregator nunca short-circuiteó.
+		// Forzar decisión sobre el set completo.
+		decidedOutcome = agg.Finalize()
+	}
+
+	out := stepOutcome{
+		Marker:           decidedOutcome.Marker,
+		AggregatorReason: decidedOutcome.Reason,
+		Results:          results,
+	}
+
+	// Si el aggregator decidió [stop] Y la causa fue al menos un error
+	// técnico, propagamos el error al outcome para que el motor pueda
+	// distinguir StopReasonAgentMarker de StopReasonTechnicalError.
+	if decidedOutcome.Marker.Kind == MarkerStop && firstTechErr != nil {
+		out.TechnicalError = firstTechErr
+	}
+
+	return out
+}

--- a/internal/engine/runstep.go
+++ b/internal/engine/runstep.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"sync"
 )
 
@@ -93,6 +94,34 @@ func runStep(ctx context.Context, step Step, inv Invoker, input string) stepOutc
 		aggKind = AggMajority
 	}
 	agg := NewAggregator(aggKind, n)
+	if agg == nil {
+		// Config error: kind desconocido. Cancelamos los agentes ya
+		// disparados y drenamos el channel para no leakear goroutines, y
+		// devolvemos [stop] con razón explícita. El motor mapeará a
+		// StopReasonTechnicalError vía TechnicalError.
+		cancel()
+		var drained []AgentResult
+		for r := range resultsCh {
+			ar := AgentResult{Agent: r.agent}
+			if r.err != nil {
+				ar.Cancelled = true
+			} else {
+				switch r.format {
+				case FormatStreamJSON:
+					ar.Marker, _ = ParseStreamMarker(r.output)
+				default:
+					ar.Marker, _ = ParseMarker(r.output)
+				}
+			}
+			drained = append(drained, ar)
+		}
+		return stepOutcome{
+			Marker:           Marker{Kind: MarkerStop},
+			AggregatorReason: "unknown aggregator kind: " + string(aggKind),
+			Results:          drained,
+			TechnicalError:   errors.New("unknown aggregator kind: " + string(aggKind)),
+		}
+	}
 
 	var (
 		decided        bool
@@ -115,18 +144,28 @@ func runStep(ctx context.Context, step Step, inv Invoker, input string) stepOutc
 		// Distinguir cancelado-por-aggregator de error-real es importante:
 		// el aggregator ignora cancelados (no votan), y el audit log no los
 		// reporta como error.
-		if r.err != nil && stepCtx.Err() != nil && decided {
+		//
+		// Cubrimos dos casos:
+		//   a) decided=true: el aggregator decidió y nosotros llamamos
+		//      cancel() — los Invoke pendientes verán ctx cancelado y
+		//      devolverán err. Esos son cancelaciones internas.
+		//   b) errors.Is(r.err, context.Canceled): el invoker reportó
+		//      explícitamente ctx.Canceled (parent cancelado externamente
+		//      o stepCtx). Cuando stepCtx.Err() != nil, sabemos que el
+		//      árbol está cancelado y NO es un error técnico del agente.
+		// En ambos casos, audit log fiel: Cancelled=true, Err=nil.
+		if r.err != nil && stepCtx.Err() != nil && (decided || errors.Is(r.err, context.Canceled)) {
 			ar.Cancelled = true
 			results = append(results, ar)
 			continue
 		}
 
 		if r.err != nil {
-			// Error técnico real (no cancelación-por-aggregator). El parent
-			// ctx puede haberse cancelado externamente — en ese caso lo
-			// trataremos como error técnico también (consistente con el
-			// motor single-agente, donde ctx.Err() externo gatilla
-			// StopReasonTechnicalError).
+			// Error técnico real (no cancelación). El parent ctx puede
+			// haberse cancelado externamente con un error que NO es
+			// context.Canceled — eso lo seguimos tratando como técnico
+			// (consistente con el motor single-agente: ctx.Err() externo
+			// gatilla StopReasonTechnicalError).
 			ar.Err = r.err
 			ar.Marker = Marker{Kind: MarkerStop}
 			if firstTechErr == nil {

--- a/internal/engine/runstep_test.go
+++ b/internal/engine/runstep_test.go
@@ -1,0 +1,407 @@
+package engine
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// blockingInvoker simula agentes que tardan en responder. Permite verificar
+// cancelación parcial: el invoker espera un signal antes de devolver, salvo
+// que el ctx se cancele primero.
+type blockingInvoker struct {
+	// fixed: respuesta inmediata por agente. Si presente, devuelve el
+	// marker sin bloquear (útil para agentes "fast" que dispararán la
+	// decisión del aggregator).
+	fixed map[string]string
+
+	// release: si el agente está acá, espera hasta que el test cierre el
+	// channel ANTES de devolver (simula un agente "slow"). Si el ctx se
+	// cancela durante la espera, devuelve ctx.Err() — esto refleja el
+	// comportamiento de internal/agent.Run con ctx propagado al child.
+	release map[string]<-chan struct{}
+
+	// invoked / cancelled tracking, en orden de invocación.
+	mu        sync.Mutex
+	started   []string
+	cancelled []string
+	completed []string
+}
+
+func newBlockingInvoker() *blockingInvoker {
+	return &blockingInvoker{
+		fixed:   map[string]string{},
+		release: map[string]<-chan struct{}{},
+	}
+}
+
+func (b *blockingInvoker) Invoke(ctx context.Context, agent string, _ string) (string, OutputFormat, error) {
+	b.mu.Lock()
+	b.started = append(b.started, agent)
+	b.mu.Unlock()
+
+	if out, ok := b.fixed[agent]; ok {
+		b.mu.Lock()
+		b.completed = append(b.completed, agent)
+		b.mu.Unlock()
+		return out, FormatText, nil
+	}
+
+	if rel, ok := b.release[agent]; ok {
+		select {
+		case <-rel:
+			b.mu.Lock()
+			b.completed = append(b.completed, agent)
+			b.mu.Unlock()
+			return "[next]", FormatText, nil
+		case <-ctx.Done():
+			b.mu.Lock()
+			b.cancelled = append(b.cancelled, agent)
+			b.mu.Unlock()
+			return "", FormatText, ctx.Err()
+		}
+	}
+
+	// Sin fixed ni release configurado: respuesta default.
+	return "[next]", FormatText, nil
+}
+
+// ---------- runStep: comportamiento básico ----------
+
+func TestRunStep_SingleAgenteEquivalente(t *testing.T) {
+	// Con 1 agente, runStep debe producir el mismo outcome que el motor
+	// pre-PR5c (un solo result, marker preservado).
+	inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+		return "hola\n[next]", FormatText, nil
+	})
+	step := Step{Name: "explore", Agents: []string{"a"}}
+	out := runStep(context.Background(), step, inv, "input")
+	if out.Marker.Kind != MarkerNext {
+		t.Errorf("Marker.Kind=%v want next", out.Marker.Kind)
+	}
+	if len(out.Results) != 1 {
+		t.Fatalf("Results=%d want 1", len(out.Results))
+	}
+	if out.Results[0].Agent != "a" {
+		t.Errorf("Result.Agent=%q want a", out.Results[0].Agent)
+	}
+}
+
+func TestRunStep_TresAgentesEnParaleloMajority(t *testing.T) {
+	// 3 agentes, todos [next] → majority next. Verifica que los 3 se
+	// invocan (paralelo, no secuencial cortando al primero).
+	var startedSimul int32
+	var maxConcurrent int32
+	inv := newFakeInvokerWith(func(agent string, _ int) (string, OutputFormat, error) {
+		// Subimos contador, esperamos un poco para que los 3 coincidan.
+		now := atomic.AddInt32(&startedSimul, 1)
+		for {
+			cur := atomic.LoadInt32(&maxConcurrent)
+			if now <= cur || atomic.CompareAndSwapInt32(&maxConcurrent, cur, now) {
+				break
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+		atomic.AddInt32(&startedSimul, -1)
+		return "[next]", FormatText, nil
+	})
+	step := Step{Name: "validate", Agents: []string{"a", "b", "c"}, Aggregator: AggMajority}
+	out := runStep(context.Background(), step, inv, "")
+	if out.Marker.Kind != MarkerNext {
+		t.Errorf("Marker.Kind=%v want next", out.Marker.Kind)
+	}
+	if atomic.LoadInt32(&maxConcurrent) < 2 {
+		t.Errorf("maxConcurrent=%d want >=2 (esperaba paralelismo real)", maxConcurrent)
+	}
+}
+
+// ---------- runStep: cancelación parcial ----------
+
+func TestRunStep_FirstBlockerCancelaResto(t *testing.T) {
+	// 3 agentes, A devuelve [stop] al toque, B y C bloqueados. El
+	// aggregator first_blocker decide en cuanto ve el [stop] y debe
+	// cancelar B y C — el ctx propaga al Invoke y devuelve error de ctx,
+	// que runStep marca como Cancelled (NO error).
+	bRel := make(chan struct{})
+	cRel := make(chan struct{})
+	inv := newBlockingInvoker()
+	inv.fixed["a"] = "[stop]"
+	inv.release["b"] = bRel
+	inv.release["c"] = cRel
+
+	step := Step{Name: "validate", Agents: []string{"a", "b", "c"}, Aggregator: AggFirstBlocker}
+
+	done := make(chan stepOutcome, 1)
+	go func() {
+		done <- runStep(context.Background(), step, inv, "")
+	}()
+
+	select {
+	case out := <-done:
+		// runStep retornó. Verificamos que el marker sea [stop] y que
+		// b y c estén marcados Cancelled.
+		if out.Marker.Kind != MarkerStop {
+			t.Errorf("Marker.Kind=%v want stop", out.Marker.Kind)
+		}
+		// Buscar b y c en results: deben estar Cancelled=true (o no
+		// estar todavía si hubo race). Vamos a esperar al cleanup.
+		var cancelledCount int
+		for _, r := range out.Results {
+			if r.Cancelled {
+				cancelledCount++
+				if r.Err != nil {
+					t.Errorf("agente %q cancelled pero también con Err=%v; debería ser solo Cancelled", r.Agent, r.Err)
+				}
+			}
+		}
+		if cancelledCount < 2 {
+			t.Errorf("Cancelled count=%d want 2 (b y c); results=%+v", cancelledCount, out.Results)
+		}
+	case <-time.After(2 * time.Second):
+		// No retornó: debugging info.
+		close(bRel)
+		close(cRel)
+		t.Fatal("runStep no retornó en 2s — la cancelación no propagó")
+	}
+
+	// Cleanup channels (idempotent close).
+	defer func() { recover() }()
+	close(bRel)
+	close(cRel)
+}
+
+func TestRunStep_MajorityStopShortCircuit(t *testing.T) {
+	// majority + 3 agentes: A=[stop] (rápido), B y C bloqueados. El
+	// aggregator majority decide [stop] al ver el primer stop. Verifica
+	// que B y C NO completaron (fueron cancelados).
+	bRel := make(chan struct{})
+	cRel := make(chan struct{})
+	inv := newBlockingInvoker()
+	inv.fixed["a"] = "[stop]"
+	inv.release["b"] = bRel
+	inv.release["c"] = cRel
+
+	step := Step{Name: "s", Agents: []string{"a", "b", "c"}, Aggregator: AggMajority}
+	out := runStep(context.Background(), step, inv, "")
+
+	if out.Marker.Kind != MarkerStop {
+		t.Errorf("Marker.Kind=%v want stop", out.Marker.Kind)
+	}
+
+	inv.mu.Lock()
+	completed := append([]string{}, inv.completed...)
+	cancelled := append([]string{}, inv.cancelled...)
+	inv.mu.Unlock()
+
+	if len(completed) != 1 || completed[0] != "a" {
+		t.Errorf("completed=%v want [a] (b y c deberían haber sido cancelados)", completed)
+	}
+	if len(cancelled) != 2 {
+		t.Errorf("cancelled=%v want 2 agentes (b y c)", cancelled)
+	}
+
+	// Cleanup (defensivo — los release nunca se cierran porque los goroutines
+	// ya retornaron por ctx-cancel).
+	defer func() { recover() }()
+	close(bRel)
+	close(cRel)
+}
+
+func TestRunStep_UnanimousDivergenciaCancelaResto(t *testing.T) {
+	// unanimous con A=[next] B=[stop] C=bloqueado. Apenas llegan A y B
+	// (divergencia detectada), el aggregator decide [stop] y cancela C.
+	cRel := make(chan struct{})
+	inv := newBlockingInvoker()
+	inv.fixed["a"] = "[next]"
+	inv.fixed["b"] = "[stop]"
+	inv.release["c"] = cRel
+
+	step := Step{Name: "s", Agents: []string{"a", "b", "c"}, Aggregator: AggUnanimous}
+	out := runStep(context.Background(), step, inv, "")
+
+	if out.Marker.Kind != MarkerStop {
+		t.Errorf("Marker.Kind=%v want stop", out.Marker.Kind)
+	}
+	// C debería estar Cancelled.
+	var cFound bool
+	for _, r := range out.Results {
+		if r.Agent == "c" {
+			cFound = true
+			if !r.Cancelled {
+				t.Errorf("agent c esperaba Cancelled=true; got %+v", r)
+			}
+		}
+	}
+	if !cFound {
+		t.Error("agent c no apareció en Results — debería estar al menos como Cancelled")
+	}
+
+	defer func() { recover() }()
+	close(cRel)
+}
+
+// ---------- runStep: aggregator default + multi-instance ----------
+
+func TestRunStep_AggregatorDefaultEsMajority(t *testing.T) {
+	// Step.Aggregator vacío → majority por default (PRD §3.d).
+	// 3 agentes, 3 [next] → next. Si el default fuera otro distinto, esto
+	// fallaría con first_blocker (que también devuelve next, OK) pero con
+	// unanimous fallaría también. Hacemos un caso que SÍ distingue:
+	// 2 [next] + 1 [stop] → majority dice stop (short-circuit), unanimous
+	// también dice stop (divergencia), first_blocker dice stop. No hay
+	// caso que diferencie majority del resto sin majority de N>3, así que
+	// confiamos en aggregator_test.go para la lógica y acá sólo verificamos
+	// que el default ALGÚN aggregator se aplica (no nil panic).
+	inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+		return "[next]", FormatText, nil
+	})
+	step := Step{Name: "s", Agents: []string{"a", "b", "c"}}
+	out := runStep(context.Background(), step, inv, "")
+	if out.Marker.Kind != MarkerNext {
+		t.Errorf("Marker.Kind=%v want next (default aggregator debería ser majority)", out.Marker.Kind)
+	}
+}
+
+func TestRunStep_AgenteRepetidoEsNInstancias(t *testing.T) {
+	// PRD §3.a: "mismo agente repetido = N instancias". El invoker recibe
+	// el mismo nombre N veces y debe tratarlas como invocaciones
+	// independientes. Verificamos que el invoker se llamó 3 veces para
+	// el mismo agente.
+	var callCount int32
+	inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+		atomic.AddInt32(&callCount, 1)
+		return "[next]", FormatText, nil
+	})
+	step := Step{Name: "s", Agents: []string{"opus", "opus", "opus"}, Aggregator: AggMajority}
+	out := runStep(context.Background(), step, inv, "")
+	if out.Marker.Kind != MarkerNext {
+		t.Errorf("Marker.Kind=%v want next", out.Marker.Kind)
+	}
+	if atomic.LoadInt32(&callCount) != 3 {
+		t.Errorf("invoker calls=%d want 3", callCount)
+	}
+	if len(out.Results) != 3 {
+		t.Errorf("Results=%d want 3", len(out.Results))
+	}
+}
+
+// ---------- runStep: errores técnicos ----------
+
+func TestRunStep_TodosErrorTecnico_StopConTechErr(t *testing.T) {
+	// 3 agentes, todos errorean. Aggregator majority short-circuitea con
+	// el primer error (cuenta como [stop]). El outcome propaga
+	// TechnicalError para que el motor mapee a StopReasonTechnicalError.
+	inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+		return "", FormatText, errExitNonZero
+	})
+	step := Step{Name: "s", Agents: []string{"a", "b", "c"}, Aggregator: AggMajority}
+	out := runStep(context.Background(), step, inv, "")
+	if out.Marker.Kind != MarkerStop {
+		t.Errorf("Marker.Kind=%v want stop", out.Marker.Kind)
+	}
+	if out.TechnicalError == nil {
+		t.Error("TechnicalError nil; want propagated err")
+	}
+}
+
+func TestRunStep_CtxYaCancelado(t *testing.T) {
+	// Si el ctx parent ya está cancelado al entrar, runStep retorna [stop]
+	// inmediato sin invocar.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	var called bool
+	inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+		called = true
+		return "[next]", FormatText, nil
+	})
+	step := Step{Name: "s", Agents: []string{"a", "b"}, Aggregator: AggMajority}
+	out := runStep(ctx, step, inv, "")
+	if out.Marker.Kind != MarkerStop {
+		t.Errorf("Marker.Kind=%v want stop", out.Marker.Kind)
+	}
+	if called {
+		t.Error("invoker no debería haber sido llamado con ctx cancelado")
+	}
+	if out.TechnicalError == nil {
+		t.Error("TechnicalError nil; want ctx.Err()")
+	}
+}
+
+// ---------- integración con RunPipeline ----------
+
+func TestRunPipeline_StepMultiAgenteIntegracion(t *testing.T) {
+	// Pipeline con un step de 3 agentes. majority resuelve [stop] al
+	// primer stop. Verifica que el motor wirea bien runStep + StepRun
+	// trae AgentResults + AggregatorReason.
+	bRel := make(chan struct{})
+	cRel := make(chan struct{})
+	inv := newBlockingInvoker()
+	inv.fixed["a"] = "[stop]"
+	inv.release["b"] = bRel
+	inv.release["c"] = cRel
+
+	pipe := Pipeline{Steps: []Step{
+		{Name: "validate", Agents: []string{"a", "b", "c"}, Aggregator: AggMajority},
+	}}
+	run, err := RunPipeline(context.Background(), pipe, inv, Options{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !run.Stopped {
+		t.Fatalf("Stopped=false; expected true")
+	}
+	if run.StopReason != StopReasonAgentMarker {
+		t.Errorf("StopReason=%q want %q", run.StopReason, StopReasonAgentMarker)
+	}
+	if len(run.Steps) != 1 {
+		t.Fatalf("Steps=%d want 1", len(run.Steps))
+	}
+	sr := run.Steps[0]
+	if sr.Resolved != "aggregator" {
+		t.Errorf("Resolved=%q want aggregator", sr.Resolved)
+	}
+	if sr.AggregatorReason == "" {
+		t.Error("AggregatorReason vacía; esperaba detalle del aggregator")
+	}
+	if len(sr.AgentResults) < 1 {
+		t.Errorf("AgentResults=%d want >=1", len(sr.AgentResults))
+	}
+	// Agent debería estar vacío en multi-agente (StepRun.AgentResults trae
+	// el detalle).
+	if sr.Agent != "" {
+		t.Errorf("Agent=%q want empty (multi-agent)", sr.Agent)
+	}
+
+	defer func() { recover() }()
+	close(bRel)
+	close(cRel)
+}
+
+func TestRunPipeline_StepMultiAgenteErrorTecnicoMapeaATechReason(t *testing.T) {
+	// Si el aggregator decide [stop] basado en errores técnicos, el motor
+	// debe usar StopReasonTechnicalError (no StopReasonAgentMarker).
+	inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+		return "", FormatText, errExitNonZero
+	})
+	pipe := Pipeline{Steps: []Step{
+		{Name: "s", Agents: []string{"a", "b"}, Aggregator: AggMajority},
+	}}
+	run, err := RunPipeline(context.Background(), pipe, inv, Options{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !run.Stopped {
+		t.Fatalf("Stopped=false")
+	}
+	if run.StopReason != StopReasonTechnicalError {
+		t.Errorf("StopReason=%q want %q", run.StopReason, StopReasonTechnicalError)
+	}
+}
+
+// newFakeInvokerWith: mismo shape que newFakeInvoker pero sin tracking
+// (los tests de paralelismo usan atómicos externos).
+func newFakeInvokerWith(fn func(string, int) (string, OutputFormat, error)) *fakeInvoker {
+	return newFakeInvoker(fn)
+}

--- a/internal/engine/runstep_test.go
+++ b/internal/engine/runstep_test.go
@@ -400,6 +400,35 @@ func TestRunPipeline_StepMultiAgenteErrorTecnicoMapeaATechReason(t *testing.T) {
 	}
 }
 
+func TestRunStep_SingleAgenteIgnoraAggregator(t *testing.T) {
+	// Con 1 agente, runStep debe producir el mismo outcome con cualquiera
+	// de los 3 presets (PRD §3.d: el aggregator se ignora en single-agent).
+	// Iteramos los 3 kinds + el default ("") y verificamos que el marker
+	// final sea idéntico.
+	for _, kind := range []AggregatorKind{"", AggMajority, AggUnanimous, AggFirstBlocker} {
+		kind := kind
+		t.Run(string(kind), func(t *testing.T) {
+			inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+				return "hola\n[next]", FormatText, nil
+			})
+			step := Step{Name: "s", Agents: []string{"a"}, Aggregator: kind}
+			out := runStep(context.Background(), step, inv, "input")
+			if out.Marker.Kind != MarkerNext {
+				t.Errorf("kind=%q Marker.Kind=%v want next", kind, out.Marker.Kind)
+			}
+			if len(out.Results) != 1 {
+				t.Fatalf("kind=%q Results=%d want 1", kind, len(out.Results))
+			}
+			if out.Results[0].Agent != "a" {
+				t.Errorf("kind=%q Result.Agent=%q want a", kind, out.Results[0].Agent)
+			}
+			if out.TechnicalError != nil {
+				t.Errorf("kind=%q TechnicalError=%v want nil", kind, out.TechnicalError)
+			}
+		})
+	}
+}
+
 // newFakeInvokerWith: mismo shape que newFakeInvoker pero sin tracking
 // (los tests de paralelismo usan atómicos externos).
 func newFakeInvokerWith(fn func(string, int) (string, OutputFormat, error)) *fakeInvoker {


### PR DESCRIPTION
Implementa #57.

Closes #57

## Implementado

- **`internal/engine/aggregator.go`** — `Aggregator` interface (`Feed`/`Finalize`) + 3 impls (`majorityAgg`, `unanimousAgg`, `firstBlockerAgg`) + `AggregatorKind` enum + `NewAggregator` con default `majority`.
- **`internal/engine/runstep.go`** — `runStep` invoca a todos los agentes en paralelo via goroutines, propaga `context.WithCancel` al invoker (que ya soporta SIGTERM+grace+SIGKILL via `internal/agent.Run`), alimenta cada resultado al aggregator, cancela los pendientes apenas decide. Drena el channel hasta cierre (no leakea goroutines). Agentes cortados marcados `AgentResult.Cancelled=true` (NO error).
- **`internal/engine/engine.go`** — `Step` extendido con `Aggregator AggregatorKind`. `StepRun` con `AgentResults []AgentResult` + `AggregatorReason string`. `RunPipeline` ahora delega a `runStep` (single y multi-agent uniformes). Mapea `[stop]+TechnicalError → StopReasonTechnicalError` para preservar contrato de PR5b.

## Tests

28 tests engine totales (17 aggregator + 11 runstep), `go test ./...` verde, `go test -race ./internal/engine/...` verde:

- **Aggregator** (aislado): majority short-circuit con stop, mayoria estricta 2/3, empate sin mayoria → stop, goto destinos distintos, error tecnico = stop. Unanimous: todos coinciden, divergencia early cancel, goto distintos = stop. First_blocker: primer stop/goto. Default kind = majority.
- **Runstep** (paralelismo + cancelacion): paralelismo real (`maxConcurrent>=2`), `blockingInvoker` que verifica B y C nunca completan cuando A short-circuitea con stop, cancelados marcados `Cancelled=true` sin error, agente repetido = N instancias, todos error tecnico → stop con `TechnicalError`, ctx ya cancelado al entrar, integracion con `RunPipeline`.
- **Fix de race en `fakeInvoker`** (engine_test.go): mutex en `calls` map para soportar invocaciones paralelas.

## Decisiones de diseño

- **Channel-style aggregator** (`Feed`/`Finalize`) vs `([]Marker) → Marker` puro: el shape `Feed` permite cancelacion temprana sin que el aggregator tenga que saber cuantos agentes vienen. `Finalize` cubre "todos terminaron sin short-circuit".
- **Preservar `MarkerNone`** en `AgentResult` antes del aggregator: la normalizacion `MarkerNone → MarkerNext` se movio a `effectiveMarker` que solo el aggregator aplica. Si normalizas antes, perdes la distincion `Resolved="default-next"` vs `"explicit"` en single-agent y rompes tests heredados de PR5b.
- **Cancelacion parcial**: `context.WithCancel` → invoker → child process via `exec.CommandContext`. `runStep` SIEMPRE drena el channel hasta cierre incluso despues de decidir/cancelar. Agente que termina post-decision se marca `Cancelled=true` automaticamente (su `err` viene de `ctx.Err()`).

## Pendiente (intencional, fuera de scope)

- **Wiring real con `internal/agent.Run`**: el motor sigue dependiendo de la `Invoker` interface. La impl concreta que dispatcha a claude con `KillGrace` (SIGTERM+grace+SIGKILL) viene en PR5d.
- **Entry agent + `--from`**: PR5d.
- **Adaptacion `engine.Step` ↔ `pipeline.Step`**: follow-up cuando el wireup CLI lo necesite. Hoy son tipos paralelos compatibles en shape (`engine.AggregatorKind` mirror de `pipeline.Aggregator`, mismos string values).

## Notas para revisores

- Race detectado en `internal/startup` con `-race` es **pre-existente** y no relacionado con este PR.
