### PR TITLE
feat(#59): [#50 PR5d] Entry agent + --from

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,234 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/chichex/che/internal/agent"
+	"github.com/chichex/che/internal/agentregistry"
+	"github.com/chichex/che/internal/engine"
+	"github.com/chichex/che/internal/pipeline"
+	"github.com/spf13/cobra"
+)
+
+var (
+	runFromStep string
+	runInput    string
+)
+
+var runCmd = &cobra.Command{
+	Use:   "run [pipeline]",
+	Short: "ejecuta un pipeline (entry agent + steps + markers)",
+	Long: `run resuelve un pipeline (jerarquía: arg posicional > config.default >
+built-in, PRD §7.b) y lo ejecuta a través del engine: corre el entry
+agent (si hay), parsea su marker, y dispara los steps en orden hasta
+[stop] o hasta el último step.
+
+Override manual del entry: usá '--from <step>' para bypassear el entry
+y arrancar directamente desde el step pedido (PRD §5.c). Útil para
+re-correr una etapa puntual sin volver a pasar por el validador del
+input.
+
+Esta v1 sólo invoca a los 3 agentes built-in (claude-opus/sonnet/haiku)
+vía el binario 'claude'. Pipelines que referencien agentes custom
+emitirán [stop] técnico — el wiring de subagents custom de Claude Code
+llega en un follow-up.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		root, err := repoRootForPipeline()
+		if err != nil {
+			return err
+		}
+		mgr, err := pipeline.NewManager(root)
+		if err != nil {
+			return fmt.Errorf("init pipeline manager: %s", formatLoadError(err))
+		}
+		flag := ""
+		if len(args) == 1 {
+			flag = args[0]
+		}
+		// Live invoker: usa internal/agent.Run para los built-ins. Tests
+		// pasan un fake via runPipelineRun directo.
+		inv := newLiveInvoker()
+		return runPipelineRun(cmd.Context(), cmd.OutOrStdout(), cmd.ErrOrStderr(), mgr, inv, flag, runFromStep, runInput)
+	},
+}
+
+func init() {
+	runCmd.Flags().StringVar(&runFromStep, "from", "",
+		"step desde el que arrancar — bypassa el entry agent (PRD §5.c)")
+	runCmd.Flags().StringVar(&runInput, "input", "",
+		"input inicial del pipeline (texto libre que recibe el entry o el primer step)")
+	rootCmd.AddCommand(runCmd)
+}
+
+// runPipelineRun es la función testeable: resuelve el pipeline, lo
+// convierte al shape del engine, dispara la ejecución y formatea el
+// outcome. Separar el wiring del invocador concreto permite que los
+// tests inyecten un fake sin spawnear el CLI de claude.
+func runPipelineRun(ctx context.Context, out, errOut io.Writer, mgr *pipeline.Manager, inv engine.Invoker, pipelineFlag, fromStep, input string) error {
+	r, err := mgr.Resolve(pipelineFlag)
+	if err != nil {
+		return fmt.Errorf("%s", formatLoadError(err))
+	}
+
+	src := r.Path
+	if src == "" {
+		src = "<built-in>"
+	}
+	fmt.Fprintf(out, "pipeline: %s\n", r.Name)
+	fmt.Fprintf(out, "source:   %s (%s)\n", r.Source, src)
+	if fromStep != "" {
+		fmt.Fprintf(out, "from:     %s (entry bypassed)\n", fromStep)
+	}
+	fmt.Fprintln(out, "")
+
+	// Convertir pipeline.Pipeline → engine.Pipeline. v1 ignora el
+	// Aggregator de Steps/Entry (PR5b/PR5d sólo invocan al primer
+	// agente; PR5c follow-up wirea multi-agente sin tocar este mapeo).
+	ep := toEnginePipeline(r.Pipeline)
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	run, err := engine.RunPipeline(ctx, ep, inv, engine.Options{
+		EntryStep: fromStep,
+		Input:     input,
+	})
+	if err != nil {
+		return fmt.Errorf("engine: %w", err)
+	}
+
+	writeRunSummary(out, run)
+
+	// Exit semántico: stop técnico → 1; stop por agente o entry → 2;
+	// completado ok → 0. Cobra lo traduce vía SilenceErrors+RunE.
+	if run.Stopped {
+		switch run.StopReason {
+		case engine.StopReasonTechnicalError, engine.StopReasonEmptyPipeline,
+			engine.StopReasonNoAgents, engine.StopReasonEntryNoAgents,
+			engine.StopReasonUnknownStep:
+			return fmt.Errorf("stop: %s — %s", run.StopReason, run.StopDetail)
+		}
+		// AgentMarker / EntryStop / LoopCap: no son errores técnicos,
+		// son outcomes legítimos del pipeline. Exit 0 + mensaje en out.
+	}
+	return nil
+}
+
+// writeRunSummary imprime el outcome del run en formato humano (no
+// JSON). El JSON estructurado puede sumarse con --format json en un
+// follow-up.
+func writeRunSummary(out io.Writer, run engine.Run) {
+	if run.Entry != nil {
+		fmt.Fprintf(out, "entry: agent=%s marker=%s resolved=%s",
+			run.Entry.Agent, describeMarker(run.Entry.Marker), run.Entry.Resolved)
+		if run.Entry.StartStep != "" {
+			fmt.Fprintf(out, " start=%s", run.Entry.StartStep)
+		}
+		if run.Entry.Err != nil {
+			fmt.Fprintf(out, " err=%v", run.Entry.Err)
+		}
+		fmt.Fprintln(out, "")
+	}
+	for i, s := range run.Steps {
+		fmt.Fprintf(out, "step[%d]: %s agent=%s marker=%s resolved=%s",
+			i, s.Step, s.Agent, describeMarker(s.Marker), s.Resolved)
+		if s.Err != nil {
+			fmt.Fprintf(out, " err=%v", s.Err)
+		}
+		fmt.Fprintln(out, "")
+	}
+	fmt.Fprintln(out, "")
+	fmt.Fprintf(out, "transitions: %d / %d\n", run.Transitions, engine.MaxTransitions)
+	if run.Stopped {
+		fmt.Fprintf(out, "stopped: %s — %s\n", run.StopReason, run.StopDetail)
+	} else {
+		fmt.Fprintln(out, "completed: pipeline ran to end")
+	}
+}
+
+func describeMarker(m engine.Marker) string {
+	switch m.Kind {
+	case engine.MarkerGoto:
+		return "[goto: " + m.Goto + "]"
+	case engine.MarkerStop:
+		return "[stop]"
+	case engine.MarkerNext:
+		return "[next]"
+	default:
+		return "[none]"
+	}
+}
+
+// toEnginePipeline convierte el shape on-disk al shape del motor.
+// El campo Aggregator (Steps y Entry) NO se mapea en v1 — PR5b/PR5d
+// ignoran esa metadata por single-agent. El follow-up post-PR5c wirea
+// el AggregatorKind acá sin cambiar callers.
+func toEnginePipeline(p pipeline.Pipeline) engine.Pipeline {
+	ep := engine.Pipeline{Steps: make([]engine.Step, 0, len(p.Steps))}
+	for _, s := range p.Steps {
+		ep.Steps = append(ep.Steps, engine.Step{
+			Name:   s.Name,
+			Agents: append([]string(nil), s.Agents...),
+		})
+	}
+	if p.Entry != nil {
+		ep.Entry = &engine.EntrySpec{
+			Agents:     append([]string(nil), p.Entry.Agents...),
+			Aggregator: engine.AggregatorKind(p.Entry.Aggregator),
+		}
+	}
+	return ep
+}
+
+// liveInvoker mapea agentes built-in a `internal/agent.Run` (claude
+// binary). Devuelve error técnico para agentes custom — esos los
+// resuelve el wiring con Claude Code subagents en un follow-up.
+type liveInvoker struct {
+	registry *agentregistry.Registry
+}
+
+func newLiveInvoker() *liveInvoker {
+	reg, regErrs := agentregistry.Discover(agentregistry.Options{IncludeBuiltins: true})
+	for _, e := range regErrs {
+		fmt.Fprintln(os.Stderr, "warn:", e.Error())
+	}
+	return &liveInvoker{registry: reg}
+}
+
+func (li *liveInvoker) Invoke(ctx context.Context, agentName string, input string) (string, engine.OutputFormat, error) {
+	a, ok := li.registry.Get(agentName)
+	if !ok {
+		return "", engine.FormatText, fmt.Errorf("agent %q not found in registry", agentName)
+	}
+	// v1: sólo soportamos los 3 built-ins. Custom agents requieren
+	// invocar claude con --agent <name> o equivalente — fuera del
+	// scope de PR5d.
+	if a.Source != agentregistry.SourceBuiltin {
+		return "", engine.FormatText, fmt.Errorf("agent %q (source=%s) requires custom-agent wiring (follow-up); v1 sólo soporta built-ins", agentName, a.Source)
+	}
+	// Map "claude-opus" → opus enum.
+	model := strings.TrimPrefix(a.Name, "claude-")
+	ag, err := agent.ParseAgent(model)
+	if err != nil {
+		return "", engine.FormatText, fmt.Errorf("agent %q: %w", agentName, err)
+	}
+	res, err := agent.Run(ag, input, agent.RunOpts{
+		Ctx:    ctx,
+		Format: agent.OutputText,
+	})
+	if err != nil {
+		// El motor mapea cualquier error técnico a [stop]; devolvemos
+		// el stdout acumulado por si el caller quiere loguearlo.
+		return res.Stdout, engine.FormatText, err
+	}
+	return res.Stdout, engine.FormatText, nil
+}
+
+// Asegurar que liveInvoker implementa engine.Invoker en compile-time.
+var _ engine.Invoker = (*liveInvoker)(nil)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -92,6 +92,23 @@ func runPipelineRun(ctx context.Context, out, errOut io.Writer, mgr *pipeline.Ma
 	// agente; PR5c follow-up wirea multi-agente sin tocar este mapeo).
 	ep := toEnginePipeline(r.Pipeline)
 
+	// Pre-vuelo: si el invoker es el liveInvoker (built-ins-only en v1),
+	// caminar el pipeline y rechazar agentes custom con un mensaje humano
+	// ANTES de llamar al engine. Sin esto, el engine arranca, invoca al
+	// primer step, recibe el error técnico ("requires custom-agent
+	// wiring") y lo mapea a StopReasonTechnicalError → exit 1 con un
+	// stop opaco. Con el pre-vuelo el usuario ve directamente qué agentes
+	// no soportamos, sin tener que decodificar el stop técnico.
+	//
+	// Tests inyectan un fakeInvoker que NO es *liveInvoker, así que el
+	// type-assert los deja pasar (y los tests pueden seguir usando
+	// agentes ficticios como "agent-a", "entry-agent", etc).
+	if li, ok := inv.(*liveInvoker); ok {
+		if err := li.checkBuiltinsOnly(ep); err != nil {
+			return err
+		}
+	}
+
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -166,15 +183,19 @@ func describeMarker(m engine.Marker) string {
 }
 
 // toEnginePipeline convierte el shape on-disk al shape del motor.
-// El campo Aggregator (Steps y Entry) NO se mapea en v1 — PR5b/PR5d
-// ignoran esa metadata por single-agent. El follow-up post-PR5c wirea
-// el AggregatorKind acá sin cambiar callers.
+// Mapeamos Aggregator tanto en Steps como en Entry: el motor PR5c ya
+// consume Step.Aggregator en multi-agente, y el Entry preserva el
+// campo para que el follow-up de multi-agente en el entry no tenga
+// que tocar este mapping. En single-agent (el único modo que corre
+// hoy en producción) el motor ignora el campo, así que copiarlo es
+// preventivo, no funcional.
 func toEnginePipeline(p pipeline.Pipeline) engine.Pipeline {
 	ep := engine.Pipeline{Steps: make([]engine.Step, 0, len(p.Steps))}
 	for _, s := range p.Steps {
 		ep.Steps = append(ep.Steps, engine.Step{
-			Name:   s.Name,
-			Agents: append([]string(nil), s.Agents...),
+			Name:       s.Name,
+			Agents:     append([]string(nil), s.Agents...),
+			Aggregator: engine.AggregatorKind(s.Aggregator),
 		})
 	}
 	if p.Entry != nil {
@@ -228,6 +249,56 @@ func (li *liveInvoker) Invoke(ctx context.Context, agentName string, input strin
 		return res.Stdout, engine.FormatText, err
 	}
 	return res.Stdout, engine.FormatText, nil
+}
+
+// checkBuiltinsOnly recorre el pipeline (entry + steps) y devuelve un
+// error humano cuando alguna referencia apunta a un agente custom (no
+// built-in). v1 sólo soporta los 3 built-ins (claude-opus/sonnet/haiku);
+// el wiring para subagents custom de Claude Code es follow-up.
+//
+// El walk se hace acá (cmd/) y no en el engine porque el engine es
+// agnóstico al concepto de "built-in vs custom" — esa distinción la
+// conoce el agentregistry y el liveInvoker, y queremos que el engine
+// siga corriendo con cualquier Invoker (incluyendo los fakes de los
+// tests, que usan nombres ficticios).
+func (li *liveInvoker) checkBuiltinsOnly(ep engine.Pipeline) error {
+	var custom []string
+	seen := map[string]bool{}
+	check := func(name string) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		a, ok := li.registry.Get(name)
+		if !ok {
+			// Agente desconocido: dejarlo pasar; el engine lo va a
+			// reportar via StopReasonTechnicalError con el error original
+			// del invoker ("agent X not found in registry"). Esa ruta ya
+			// produce un mensaje accionable distinto al "custom-agent
+			// wiring" — no la pisamos acá.
+			return
+		}
+		if a.Source != agentregistry.SourceBuiltin {
+			custom = append(custom, fmt.Sprintf("%s (source=%s)", name, a.Source))
+		}
+	}
+	if ep.Entry != nil {
+		for _, a := range ep.Entry.Agents {
+			check(a)
+		}
+	}
+	for _, s := range ep.Steps {
+		for _, a := range s.Agents {
+			check(a)
+		}
+	}
+	if len(custom) > 0 {
+		return fmt.Errorf(
+			"pipeline references custom agents not yet supported in v1 (only built-ins claude-opus/claude-sonnet/claude-haiku run today): %s — custom-agent wiring lands in a follow-up; meanwhile use a built-in or run `che pipeline simulate` for a dry-run",
+			strings.Join(custom, ", "),
+		)
+	}
+	return nil
 }
 
 // Asegurar que liveInvoker implementa engine.Invoker en compile-time.

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,249 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/chichex/che/internal/engine"
+)
+
+// fakeInvoker para los tests de cmd/run: el responder dispatcha por
+// nombre del agente, y el invoker NO spawnea nada — todo en memoria.
+type fakeRunInvoker struct {
+	responder func(agent string) (string, engine.OutputFormat, error)
+	calls     []string
+}
+
+func (f *fakeRunInvoker) Invoke(_ context.Context, agentName string, _ string) (string, engine.OutputFormat, error) {
+	f.calls = append(f.calls, agentName)
+	return f.responder(agentName)
+}
+
+// minimalPipelineWithEntry: pipeline JSON con entry + 3 steps. Compatible
+// con el shape que carga pipeline.Manager.
+const minimalPipelineWithEntry = `{
+  "version": 1,
+  "entry": {"agents": ["entry-agent"]},
+  "steps": [
+    {"name": "explore", "agents": ["claude-opus"]},
+    {"name": "validate", "agents": ["claude-opus"]},
+    {"name": "execute", "agents": ["claude-opus"]}
+  ]
+}`
+
+// TestRun_EntryNextEjecutaTodosLosSteps: entry [next] → arranca primer
+// step + corre todos.
+func TestRun_EntryNextEjecutaTodosLosSteps(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"with-entry": minimalPipelineWithEntry,
+	}, "")
+	inv := &fakeRunInvoker{
+		responder: func(agent string) (string, engine.OutputFormat, error) {
+			if agent == "entry-agent" {
+				return "[next]", engine.FormatText, nil
+			}
+			return "[next]", engine.FormatText, nil
+		},
+	}
+	var out, errOut bytes.Buffer
+	err := runPipelineRun(context.Background(), &out, &errOut, mgr, inv, "with-entry", "", "")
+	if err != nil {
+		t.Fatalf("runPipelineRun: %v\nout=%s", err, out.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "entry: agent=entry-agent") {
+		t.Errorf("output no incluye entry: %q", got)
+	}
+	if !strings.Contains(got, "step[0]: explore") {
+		t.Errorf("output no muestra step[0]: %q", got)
+	}
+	if !strings.Contains(got, "step[2]: execute") {
+		t.Errorf("output no muestra step[2]: %q", got)
+	}
+	if !strings.Contains(got, "completed") {
+		t.Errorf("output no marca completed: %q", got)
+	}
+}
+
+// TestRun_EntryGotoSaltaSteps: entry [goto: validate] → motor empieza
+// en validate, salta explore.
+func TestRun_EntryGotoSaltaSteps(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"with-entry": minimalPipelineWithEntry,
+	}, "")
+	inv := &fakeRunInvoker{
+		responder: func(agent string) (string, engine.OutputFormat, error) {
+			if agent == "entry-agent" {
+				return "[goto: validate]", engine.FormatText, nil
+			}
+			return "[next]", engine.FormatText, nil
+		},
+	}
+	var out, errOut bytes.Buffer
+	err := runPipelineRun(context.Background(), &out, &errOut, mgr, inv, "with-entry", "", "")
+	if err != nil {
+		t.Fatalf("runPipelineRun: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "start=validate") {
+		t.Errorf("output no muestra start=validate: %q", got)
+	}
+	if strings.Contains(got, "step[0]: explore") {
+		t.Errorf("explore no debería correr; output=%q", got)
+	}
+	if !strings.Contains(got, "validate") {
+		t.Errorf("output no muestra validate: %q", got)
+	}
+}
+
+// TestRun_EntryStopExitNoEsError: entry [stop] termina con StopReason
+// EntryStop pero NO devuelve error técnico (es un outcome legítimo del
+// pipeline, no un error del CLI).
+func TestRun_EntryStopExitNoEsError(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"with-entry": minimalPipelineWithEntry,
+	}, "")
+	inv := &fakeRunInvoker{
+		responder: func(agent string) (string, engine.OutputFormat, error) {
+			if agent == "entry-agent" {
+				return "[stop]", engine.FormatText, nil
+			}
+			t.Fatalf("ningún step debería correr después de entry [stop]; agent=%q", agent)
+			return "", engine.FormatText, nil
+		},
+	}
+	var out, errOut bytes.Buffer
+	err := runPipelineRun(context.Background(), &out, &errOut, mgr, inv, "with-entry", "", "")
+	if err != nil {
+		t.Fatalf("runPipelineRun: %v (entry stop no debería ser error técnico)", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, string(engine.StopReasonEntryStop)) {
+		t.Errorf("output no muestra StopReasonEntryStop: %q", got)
+	}
+}
+
+// TestRun_FromBypasaaEntry: --from validate hace que el entry NO corra
+// y el pipeline arranque en validate.
+func TestRun_FromBypasaaEntry(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"with-entry": minimalPipelineWithEntry,
+	}, "")
+	inv := &fakeRunInvoker{
+		responder: func(agent string) (string, engine.OutputFormat, error) {
+			if agent == "entry-agent" {
+				t.Fatalf("entry no debería correr cuando se pasó --from")
+				return "", engine.FormatText, nil
+			}
+			return "[next]", engine.FormatText, nil
+		},
+	}
+	var out, errOut bytes.Buffer
+	err := runPipelineRun(context.Background(), &out, &errOut, mgr, inv, "with-entry", "validate", "")
+	if err != nil {
+		t.Fatalf("runPipelineRun: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "entry bypassed") {
+		t.Errorf("output no muestra 'entry bypassed': %q", got)
+	}
+	if strings.Contains(got, "entry: agent=") {
+		t.Errorf("entry corrió aunque pasamos --from: %q", got)
+	}
+	if !strings.Contains(got, "step[0]: validate") {
+		t.Errorf("primer step esperado=validate; output=%q", got)
+	}
+}
+
+// TestRun_FromConStepDesconocidoEsError: --from ghost devuelve error
+// técnico (StopReasonUnknownStep) — el caller lo ve como exit code != 0.
+func TestRun_FromConStepDesconocidoEsError(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"with-entry": minimalPipelineWithEntry,
+	}, "")
+	inv := &fakeRunInvoker{
+		responder: func(agent string) (string, engine.OutputFormat, error) {
+			t.Fatalf("invoker no debería llamarse con --from inválido")
+			return "", engine.FormatText, nil
+		},
+	}
+	var out, errOut bytes.Buffer
+	err := runPipelineRun(context.Background(), &out, &errOut, mgr, inv, "with-entry", "ghost", "")
+	if err == nil {
+		t.Fatalf("runPipelineRun no devolvió error; out=%q", out.String())
+	}
+	if !strings.Contains(err.Error(), string(engine.StopReasonUnknownStep)) {
+		t.Errorf("err=%v want includes %q", err, engine.StopReasonUnknownStep)
+	}
+}
+
+// TestRun_PipelineSinEntry: pipeline sin Entry — corre desde primer
+// step, output no muestra sección entry.
+func TestRun_PipelineSinEntry(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"plain": minimalPipeline,
+	}, "")
+	inv := &fakeRunInvoker{
+		responder: func(agent string) (string, engine.OutputFormat, error) {
+			return "[next]", engine.FormatText, nil
+		},
+	}
+	var out, errOut bytes.Buffer
+	err := runPipelineRun(context.Background(), &out, &errOut, mgr, inv, "plain", "", "")
+	if err != nil {
+		t.Fatalf("runPipelineRun: %v", err)
+	}
+	got := out.String()
+	if strings.Contains(got, "entry: agent=") {
+		t.Errorf("output incluye entry pero pipeline no tiene: %q", got)
+	}
+	if !strings.Contains(got, "step[0]: explore") {
+		t.Errorf("output no muestra step[0]: %q", got)
+	}
+}
+
+// TestRun_BuiltinFallbackSinFlags: sin pipeline arg + sin config →
+// resuelve al built-in default.
+func TestRun_BuiltinFallbackSinFlags(t *testing.T) {
+	mgr, _ := pipelineFixture(t, nil, "")
+	inv := &fakeRunInvoker{
+		responder: func(agent string) (string, engine.OutputFormat, error) {
+			return "[next]", engine.FormatText, nil
+		},
+	}
+	var out, errOut bytes.Buffer
+	err := runPipelineRun(context.Background(), &out, &errOut, mgr, inv, "", "", "")
+	if err != nil {
+		t.Fatalf("runPipelineRun: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "built-in") {
+		t.Errorf("output no marca built-in: %q", got)
+	}
+}
+
+// TestRun_ErrorTecnicoEsExitError: invoker devuelve error técnico para
+// el primer step → engine resuelve a stop+technical-error → CLI devuelve
+// error.
+func TestRun_ErrorTecnicoEsExitError(t *testing.T) {
+	mgr, _ := pipelineFixture(t, map[string]string{
+		"plain": minimalPipeline,
+	}, "")
+	wantErr := errors.New("auth failed")
+	inv := &fakeRunInvoker{
+		responder: func(agent string) (string, engine.OutputFormat, error) {
+			return "", engine.FormatText, wantErr
+		},
+	}
+	var out, errOut bytes.Buffer
+	err := runPipelineRun(context.Background(), &out, &errOut, mgr, inv, "plain", "", "")
+	if err == nil {
+		t.Fatalf("runPipelineRun no devolvió error; out=%q", out.String())
+	}
+	if !strings.Contains(err.Error(), string(engine.StopReasonTechnicalError)) {
+		t.Errorf("err=%v want includes %q", err, engine.StopReasonTechnicalError)
+	}
+}

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -41,13 +41,38 @@ type Step struct {
 	Aggregator AggregatorKind
 }
 
-// Pipeline es la secuencia ordenada de steps que el motor ejecuta. Sin
-// metadata adicional en este nivel (Entry, Version, etc.) — esos campos
-// son responsabilidad del loader (PR3) y del entry-runner (PR5d). El
-// motor sólo necesita la lista para resolver `[goto: X]` y aplicar el
-// cap.
+// Pipeline es la secuencia ordenada de steps que el motor ejecuta. PR5d
+// agrega un Entry opcional que corre ANTES del primer step y decide desde
+// dónde arrancar (`[next]` → primer step, `[goto: X]` → step X, `[stop]`
+// → no correr nada). Si Entry == nil, el motor arranca desde el primer
+// step directamente (comportamiento PR5b).
 type Pipeline struct {
+	Entry *EntrySpec
 	Steps []Step
+}
+
+// EntrySpec describe el entry agent del pipeline (PRD §5.a). El entry es
+// un validador/router que corre ANTES de los steps y emite un marker que
+// define desde qué step arrancar:
+//   - `[next]` o sin marker → primer step (comportamiento default).
+//   - `[goto: X]` → arrancar en el step X.
+//   - `[stop]` → no correr ningún step (rebote del input).
+//
+// Multi-agente: la struct ya soporta varios agentes + Aggregator, pero
+// PR5d (este PR) sólo invoca al primer agente — igual que PR5b hace con
+// los Steps. El multi-agente + aggregator vive en PR5c/follow-up; cuando
+// PR5c merguee, un cambio mínimo (reemplazar el invoke directo por
+// runStep) habilita el flow multi-agente sin romper el shape.
+type EntrySpec struct {
+	// Agents es la lista de refs a agentes que corren como entry. PR5d
+	// usa Agents[0] solamente (mirror de PR5b para Steps); multi-agente
+	// llega con PR5c.
+	Agents []string
+
+	// Aggregator es la política de resolución cuando len(Agents) > 1.
+	// PR5d preserva el campo para no romper el shape — el motor lo
+	// IGNORA en single-agent (que es el único modo que corre hoy).
+	Aggregator AggregatorKind
 }
 
 // Invoker es el contrato que el motor usa para llamar a un agente. Está
@@ -124,6 +149,18 @@ const (
 	// Idem StopReasonEmptyPipeline: defensa frente a pipelines mal
 	// armados que escaparon al validator.
 	StopReasonNoAgents StopReason = "step has no agents"
+
+	// StopReasonEntryStop: el entry agent emitió `[stop]` (PRD §5.a) —
+	// rebote explícito del input, ningún step corre. Distinto de
+	// StopReasonAgentMarker para que la UX (audit log, dash) pueda
+	// diferenciar "el pipeline rebotó en el entry" de "un step paró el
+	// pipeline en el medio".
+	StopReasonEntryStop StopReason = "entry agent emitted [stop]"
+
+	// StopReasonEntryNoAgents: defensa para EntrySpec con Agents vacío
+	// — análogo a StopReasonNoAgents pero diferenciado para que el
+	// caller sepa que el config del entry está mal, no el de un step.
+	StopReasonEntryNoAgents StopReason = "entry has no agents"
 )
 
 // StepRun captura el outcome de la ejecución de un solo step durante una
@@ -162,6 +199,13 @@ type StepRun struct {
 
 // Run es el resultado completo de una corrida del motor.
 type Run struct {
+	// Entry, si no es nil, captura el outcome del entry agent (PRD §5.a).
+	// Es nil cuando el pipeline no tenía Entry, o cuando el caller usó
+	// `Options.EntryStep` (`--from`) para bypassear el entry. La
+	// presencia de Entry no implica Stopped — el entry puede haber
+	// emitido [next]/[goto: X] y el pipeline siguió corriendo.
+	Entry *EntryRun
+
 	// Steps es la secuencia de StepRun ejecutada, en orden cronológico.
 	Steps []StepRun
 
@@ -182,8 +226,43 @@ type Run struct {
 	// Transitions es la cantidad de transiciones que tomó el motor (cap
 	// en MaxTransitions). Útil para tests, audit log, y para exponer
 	// "transiciones: 14/20" en la UI futura (limitación documentada en
-	// PRD §9).
+	// PRD §9). El entry NO cuenta como transición — el cap protege
+	// contra loops entre steps, no contra el entry mismo (que corre una
+	// sola vez por corrida).
 	Transitions int
+}
+
+// EntryRun captura el outcome del entry agent (PRD §5.a). Análogo a
+// StepRun pero sin Step.Name (el entry no tiene name dentro del
+// pipeline) y con un campo extra StartStep que dice qué step terminó
+// arrancando el motor (vacío si emitió [stop]).
+type EntryRun struct {
+	// Agent es el nombre del agente que el motor invocó como entry.
+	// PR5d corre Agents[0]; multi-agente vive en PR5c follow-up.
+	Agent string
+
+	// Marker es el marker resuelto del entry: el que emitió el agente, o
+	// `[next]` por default (output sin marker + invocación OK), o
+	// `[stop]` cuando hubo error técnico o goto inválido.
+	Marker Marker
+
+	// Resolved indica cómo se llegó a Marker — análogo a StepRun.Resolved:
+	//   - "explicit"          el agente emitió el marker
+	//   - "default-next"      no hubo marker pero la invocación fue OK
+	//   - "technical-error"   la invocación falló
+	//   - "unknown-step"      el goto del entry apuntó a un step inexistente
+	//   - "no-agents"         EntrySpec con Agents vacío (defensa)
+	Resolved string
+
+	// StartStep es el nombre del step desde el que arrancó el motor
+	// después del entry. Vacío si el entry resolvió a [stop] (no
+	// arrancó nada). Si el entry emitió [next], es el primer step del
+	// pipeline; si emitió [goto: X], es X.
+	StartStep string
+
+	// Err captura el error técnico del invoker, si hubo. Sólo informativo
+	// — la decisión de stop ya quedó reflejada en Marker.
+	Err error
 }
 
 // ErrInvokerNil se devuelve si el caller pasa un Invoker nil. El motor no
@@ -193,10 +272,15 @@ var ErrInvokerNil = errors.New("engine: invoker is nil")
 // Options configura una corrida del motor. Todos los campos son opcionales.
 type Options struct {
 	// EntryStep elige el primer step del pipeline a ejecutar. Si está
-	// vacío, el motor arranca desde el primer step de la lista. PR5d
-	// agregará el entry agent y el flag `--from`; PR5b ya soporta el
-	// override interno para que los tests no tengan que reconstruir el
-	// pipeline para empezar desde el medio.
+	// vacío, el motor corre el Entry (si existe) y arranca según su
+	// marker; o arranca desde el primer step si no hay Entry.
+	//
+	// PR5d (este PR): EntryStep != "" BYPASSA el entry agent. Es la
+	// implementación interna del flag CLI `che run --from <step>`
+	// (PRD §5.c) — el override manual del usuario se respeta sin pasar
+	// por el validador del entry. Esto es deliberado: si el usuario
+	// pidió "arrancar desde validate_pr", el entry no debería poder
+	// rebotarlo.
 	EntryStep string
 
 	// Input es el contexto inicial que se pasa al primer step (body del
@@ -208,20 +292,26 @@ type Options struct {
 
 // RunPipeline ejecuta el pipeline secuencialmente:
 //
-//  1. Resuelve el primer step (Options.EntryStep o steps[0]).
+//  1. Resuelve el step inicial:
+//     a. Si Options.EntryStep != "" → ese step (bypassa el entry agent).
+//     b. Si Pipeline.Entry != nil → invoca el entry agent y aplica su
+//        marker (`[next]` → primer step, `[goto: X]` → step X,
+//        `[stop]` → no corre nada y devuelve StopReasonEntryStop).
+//     c. Sin lo anterior → primer step de la lista.
 //  2. Para cada step: pickea el primer agente declarado, invoca via
 //     Invoker, parsea el marker (text o stream-json según el format que
 //     reportó el invoker), y aplica la transición.
 //  3. Cuenta cada transición; al alcanzar MaxTransitions, stop con
-//     StopReasonLoopCap.
+//     StopReasonLoopCap. El entry NO cuenta como transición.
 //  4. Cuando un step emite [next] (o default por output sin marker), el
 //     motor avanza al siguiente step en orden. Si era el último, la
 //     corrida termina ok.
 //
-// PR5b sólo soporta 1 agente por step (el primero de Step.Agents). El
-// motor multi-agente + aggregator + cancelación parcial vive en PR5c —
-// el shape del Step ya lo soporta (Agents []string), así que cuando se
-// implemente PR5c sólo cambia el branch que decide cómo invocar.
+// PR5b/PR5d sólo soportan 1 agente por step y por entry (el primero de
+// la lista). El motor multi-agente + aggregator + cancelación parcial
+// vive en PR5c — el shape del Step y EntrySpec ya lo soportan (Agents
+// []string), así que cuando se implemente PR5c sólo cambia el branch
+// que decide cómo invocar.
 func RunPipeline(ctx context.Context, p Pipeline, inv Invoker, opts Options) (Run, error) {
 	if inv == nil {
 		return Run{}, ErrInvokerNil
@@ -241,8 +331,14 @@ func RunPipeline(ctx context.Context, p Pipeline, inv Invoker, opts Options) (Ru
 		nameToIdx[s.Name] = i
 	}
 
+	run := Run{}
+	currentInput := opts.Input
+
 	currentIdx := 0
-	if opts.EntryStep != "" {
+	switch {
+	case opts.EntryStep != "":
+		// PRD §5.c override manual: el flag `che run --from <step>`
+		// bypassa el entry agent y arranca desde el step pedido.
 		idx, ok := nameToIdx[opts.EntryStep]
 		if !ok {
 			return Run{
@@ -252,10 +348,23 @@ func RunPipeline(ctx context.Context, p Pipeline, inv Invoker, opts Options) (Ru
 			}, nil
 		}
 		currentIdx = idx
+	case p.Entry != nil:
+		// PRD §5.a: el entry agent decide desde dónde arrancar (o si
+		// rebotar el input). runEntry encapsula la invocación + el
+		// parseo del marker; devuelve el step inicial o un Run pre-armado
+		// con [stop] cuando corresponde.
+		entryRun, startIdx, halt := runEntry(ctx, p, inv, currentInput, nameToIdx)
+		run.Entry = entryRun
+		if halt != nil {
+			// Entry abortó la corrida (stop explícito, error técnico,
+			// goto inválido o sin agentes). El Run que devolvemos ya
+			// trae StopReason poblado por runEntry; le agregamos el
+			// EntryRun para audit.
+			halt.Entry = entryRun
+			return *halt, nil
+		}
+		currentIdx = startIdx
 	}
-
-	run := Run{}
-	currentInput := opts.Input
 
 	for {
 		if ctx != nil && ctx.Err() != nil {
@@ -394,5 +503,130 @@ func RunPipeline(ctx context.Context, p Pipeline, inv Invoker, opts Options) (Ru
 			}
 			currentIdx++
 		}
+	}
+}
+
+// runEntry invoca al entry agent del pipeline y resuelve el step inicial
+// (PRD §5.a). Devuelve:
+//
+//   - entryRun: el outcome del entry, no-nil siempre que se haya intentado
+//     correr (incluso si terminó en error técnico). El caller lo guarda
+//     en Run.Entry para audit.
+//   - startIdx: índice del step desde el que arrancar el motor cuando
+//     halt == nil. Sólo válido en ese caso.
+//   - halt: Run pre-armado con Stopped=true cuando el entry decidió no
+//     correr ningún step (stop explícito, error técnico, goto inválido,
+//     sin agentes). nil cuando el motor debe seguir.
+//
+// Multi-agente: PR5d invoca solamente Agents[0] (mirror del comportamiento
+// PR5b para Steps). El campo EntrySpec.Aggregator se preserva en el
+// shape para que el follow-up post-PR5c (que tiene Aggregator + runStep
+// reusables) sólo cambie el branch que decide cómo invocar — sin tocar
+// el contrato de runEntry.
+func runEntry(ctx context.Context, p Pipeline, inv Invoker, input string, nameToIdx map[string]int) (*EntryRun, int, *Run) {
+	entry := p.Entry
+	er := &EntryRun{}
+
+	if len(entry.Agents) == 0 {
+		// Defensa: EntrySpec sin agentes (config inválido escapó al
+		// validator). Halt con razón explícita para que el caller
+		// corrija el JSON, igual que para steps sin agentes.
+		er.Marker = Marker{Kind: MarkerStop}
+		er.Resolved = "no-agents"
+		return er, 0, &Run{
+			Stopped:    true,
+			StopReason: StopReasonEntryNoAgents,
+			StopDetail: "entry has no agents declared",
+		}
+	}
+
+	// PR5d: 1 agente por entry. PR5c follow-up traerá multi-agente +
+	// aggregator (mirror del cambio que va a hacer en runStep).
+	agent := entry.Agents[0]
+	er.Agent = agent
+
+	if ctx != nil && ctx.Err() != nil {
+		// Cancelación temprana antes de invocar — propagar como stop
+		// técnico, igual que el loop principal hace.
+		er.Marker = Marker{Kind: MarkerStop}
+		er.Resolved = "technical-error"
+		er.Err = ctx.Err()
+		return er, 0, &Run{
+			Stopped:    true,
+			StopReason: StopReasonTechnicalError,
+			StopDetail: ctx.Err().Error(),
+		}
+	}
+
+	output, format, invErr := inv.Invoke(ctx, agent, input)
+
+	if invErr != nil {
+		// PRD §3.b paso 4: error técnico → stop automático. Para el
+		// entry esto significa "no podemos validar el input → no
+		// arranquemos".
+		er.Marker = Marker{Kind: MarkerStop}
+		er.Resolved = "technical-error"
+		er.Err = invErr
+		return er, 0, &Run{
+			Stopped:    true,
+			StopReason: StopReasonTechnicalError,
+			StopDetail: fmt.Sprintf("entry agent %q: %v", agent, invErr),
+		}
+	}
+
+	// Parsear marker según format reportado por el invoker. Default a
+	// FormatText cuando el invoker no especifica (zero value).
+	var (
+		marker Marker
+		found  bool
+	)
+	switch format {
+	case FormatStreamJSON:
+		marker, found = ParseStreamMarker(output)
+	default:
+		marker, found = ParseMarker(output)
+	}
+	if !found {
+		// PRD §3.b paso 5 + §5.a: sin marker → asume [next] = arrancar
+		// desde el primer step. Mismo default que en steps.
+		marker = Marker{Kind: MarkerNext}
+		er.Resolved = "default-next"
+	} else {
+		er.Resolved = "explicit"
+	}
+	er.Marker = marker
+
+	switch marker.Kind {
+	case MarkerStop:
+		// Rebote del input — el entry decidió que el pipeline no debe
+		// correr. Reason DIFERENTE de StopReasonAgentMarker para que la
+		// UX pueda diferenciar "rebotó en el entry" de "un step paró".
+		return er, 0, &Run{
+			Stopped:    true,
+			StopReason: StopReasonEntryStop,
+			StopDetail: fmt.Sprintf("entry agent %q emitted [stop]", agent),
+		}
+	case MarkerGoto:
+		idx, ok := nameToIdx[marker.Goto]
+		if !ok {
+			// PRD §3.c "step destino inválido" — convertir a stop con
+			// razón explícita. Igual que en steps; mantener consistencia
+			// hace que el caller no tenga que distinguir entry vs step
+			// para este modo de falla.
+			er.Marker = Marker{Kind: MarkerStop}
+			er.Resolved = "unknown-step"
+			return er, 0, &Run{
+				Stopped:    true,
+				StopReason: StopReasonUnknownStep,
+				StopDetail: fmt.Sprintf("entry emitted [goto: %s] but no such step exists", marker.Goto),
+			}
+		}
+		er.StartStep = marker.Goto
+		return er, idx, nil
+	default:
+		// MarkerNext o MarkerNone normalizado a Next: arrancar desde el
+		// primer step (comportamiento default sin entry).
+		er.StartStep = p.Steps[0].Name
+		return er, 0, nil
 	}
 }

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -547,14 +547,17 @@ func runEntry(ctx context.Context, p Pipeline, inv Invoker, input string, nameTo
 
 	if ctx != nil && ctx.Err() != nil {
 		// Cancelación temprana antes de invocar — propagar como stop
-		// técnico, igual que el loop principal hace.
+		// técnico, igual que el loop principal hace. El formato del
+		// StopDetail ("context cancelled before <…> start: …") matchea
+		// el de runStep para que callers que log/parsean el detail vean
+		// shape consistente entre entry y steps.
 		er.Marker = Marker{Kind: MarkerStop}
 		er.Resolved = "technical-error"
 		er.Err = ctx.Err()
 		return er, 0, &Run{
 			Stopped:    true,
 			StopReason: StopReasonTechnicalError,
-			StopDetail: ctx.Err().Error(),
+			StopDetail: "context cancelled before entry start: " + ctx.Err().Error(),
 		}
 	}
 

--- a/internal/engine/entry_test.go
+++ b/internal/engine/entry_test.go
@@ -1,0 +1,323 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// pipelineWithEntry arma un pipeline con un Entry y los 4 steps clásicos.
+// Se usa por los tests de entry para no repetir el shape en cada test.
+func pipelineWithEntry(agents ...string) Pipeline {
+	if len(agents) == 0 {
+		agents = []string{"entry-agent"}
+	}
+	p := simplePipeline()
+	p.Entry = &EntrySpec{Agents: agents}
+	return p
+}
+
+// TestEntry_NextArrancaPrimerStep: entry emite [next] (o no emite marker
+// y queda default). El motor arranca desde el primer step y completa el
+// pipeline. EntryRun queda registrado en Run.Entry.
+func TestEntry_NextArrancaPrimerStep(t *testing.T) {
+	inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+		if agent == "entry-agent" {
+			return "input ok\n[next]", FormatText, nil
+		}
+		return "[next]", FormatText, nil
+	})
+	run, err := RunPipeline(context.Background(), pipelineWithEntry(), inv, Options{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if run.Stopped {
+		t.Fatalf("Stopped=true reason=%q detail=%q", run.StopReason, run.StopDetail)
+	}
+	if run.Entry == nil {
+		t.Fatalf("Run.Entry=nil; esperaba un EntryRun")
+	}
+	if run.Entry.Marker.Kind != MarkerNext {
+		t.Errorf("Entry.Marker=%v want next", run.Entry.Marker.Kind)
+	}
+	if run.Entry.StartStep != "explore" {
+		t.Errorf("Entry.StartStep=%q want explore", run.Entry.StartStep)
+	}
+	if len(run.Steps) != 4 {
+		t.Errorf("len(Steps)=%d want 4 (todos los steps deben correr después de [next])", len(run.Steps))
+	}
+}
+
+// TestEntry_DefaultNextSinMarker: invocación OK sin marker → asumir
+// [next] (igual que para steps; PRD §3.b paso 5 + §5.a).
+func TestEntry_DefaultNextSinMarker(t *testing.T) {
+	inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+		if agent == "entry-agent" {
+			return "todo bien, sin marker", FormatText, nil
+		}
+		return "[next]", FormatText, nil
+	})
+	run, err := RunPipeline(context.Background(), pipelineWithEntry(), inv, Options{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if run.Stopped {
+		t.Fatalf("Stopped=true reason=%q", run.StopReason)
+	}
+	if run.Entry == nil || run.Entry.Resolved != "default-next" {
+		t.Errorf("Entry.Resolved=%q want default-next", run.Entry.Resolved)
+	}
+	if run.Entry.StartStep != "explore" {
+		t.Errorf("Entry.StartStep=%q want explore", run.Entry.StartStep)
+	}
+}
+
+// TestEntry_GotoArrancaEnStepSeleccionado: entry emite [goto: validate]
+// → motor arranca en validate (saltando explore).
+func TestEntry_GotoArrancaEnStepSeleccionado(t *testing.T) {
+	inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+		switch agent {
+		case "entry-agent":
+			return "[goto: validate]", FormatText, nil
+		case "agent-a": // explore
+			t.Fatalf("explore no debería correr cuando entry hace goto: validate")
+			return "", FormatText, nil
+		}
+		return "[next]", FormatText, nil
+	})
+	run, err := RunPipeline(context.Background(), pipelineWithEntry(), inv, Options{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if run.Stopped {
+		t.Fatalf("Stopped=true reason=%q", run.StopReason)
+	}
+	if run.Entry == nil || run.Entry.StartStep != "validate" {
+		t.Errorf("Entry.StartStep=%q want validate", run.Entry.StartStep)
+	}
+	got := []string{}
+	for _, s := range run.Steps {
+		got = append(got, s.Step)
+	}
+	want := []string{"validate", "execute", "close"}
+	if !equalStrings(got, want) {
+		t.Errorf("steps=%v want %v", got, want)
+	}
+}
+
+// TestEntry_StopRebotaInput: entry emite [stop] → motor no corre ningún
+// step, Run.Stopped=true con StopReasonEntryStop. Distinguir esta razón
+// de StopReasonAgentMarker es importante para que la UX (audit log) sepa
+// que el rebote fue en el entry y no a mitad del pipeline.
+func TestEntry_StopRebotaInput(t *testing.T) {
+	inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+		if agent == "entry-agent" {
+			return "input rechazado\n[stop]", FormatText, nil
+		}
+		t.Fatalf("ningún step debería correr después de [stop] del entry; agent=%q", agent)
+		return "", FormatText, nil
+	})
+	run, err := RunPipeline(context.Background(), pipelineWithEntry(), inv, Options{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !run.Stopped {
+		t.Fatalf("Stopped=false; esperaba true (entry emitió stop)")
+	}
+	if run.StopReason != StopReasonEntryStop {
+		t.Errorf("StopReason=%q want %q", run.StopReason, StopReasonEntryStop)
+	}
+	if len(run.Steps) != 0 {
+		t.Errorf("len(Steps)=%d want 0 (entry stop no debe correr steps)", len(run.Steps))
+	}
+	if run.Entry == nil {
+		t.Fatalf("Run.Entry=nil; esperaba EntryRun aún cuando hay stop")
+	}
+	if run.Entry.Marker.Kind != MarkerStop {
+		t.Errorf("Entry.Marker=%v want stop", run.Entry.Marker.Kind)
+	}
+}
+
+// TestEntry_GotoStepDesconocido: entry hace [goto: ghost] sobre step que
+// no existe → motor convierte a stop con StopReasonUnknownStep (igual
+// que para steps con goto inválido — comportamiento consistente).
+func TestEntry_GotoStepDesconocido(t *testing.T) {
+	inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+		if agent == "entry-agent" {
+			return "[goto: ghost]", FormatText, nil
+		}
+		t.Fatalf("ningún step debería correr cuando el entry hace goto inválido")
+		return "", FormatText, nil
+	})
+	run, err := RunPipeline(context.Background(), pipelineWithEntry(), inv, Options{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !run.Stopped || run.StopReason != StopReasonUnknownStep {
+		t.Errorf("got Stopped=%v StopReason=%q want stop+unknown-step", run.Stopped, run.StopReason)
+	}
+	if run.Entry == nil || run.Entry.Resolved != "unknown-step" {
+		t.Errorf("Entry.Resolved=%q want unknown-step", run.Entry.Resolved)
+	}
+}
+
+// TestEntry_ErrorTecnicoEsStop: error técnico del invoker para el entry
+// → stop con StopReasonTechnicalError (mismo trato que para steps).
+func TestEntry_ErrorTecnicoEsStop(t *testing.T) {
+	wantErr := errors.New("entry: claude exit 1")
+	inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+		if agent == "entry-agent" {
+			return "", FormatText, wantErr
+		}
+		return "[next]", FormatText, nil
+	})
+	run, err := RunPipeline(context.Background(), pipelineWithEntry(), inv, Options{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !run.Stopped || run.StopReason != StopReasonTechnicalError {
+		t.Errorf("got Stopped=%v StopReason=%q want stop+technical-error", run.Stopped, run.StopReason)
+	}
+	if run.Entry == nil || !errors.Is(run.Entry.Err, wantErr) {
+		t.Errorf("Entry.Err=%v want %v", run.Entry.Err, wantErr)
+	}
+}
+
+// TestEntry_FromBypasaaEntry: cuando el caller pasa Options.EntryStep
+// (= flag --from), el entry NO corre. Es el override manual del PRD
+// §5.c. EntryRun queda nil para distinguirlo de "el entry corrió y
+// terminó".
+func TestEntry_FromBypasaaEntry(t *testing.T) {
+	inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+		if agent == "entry-agent" {
+			t.Fatalf("entry no debería correr cuando el caller pasa EntryStep (--from)")
+			return "", FormatText, nil
+		}
+		return "[next]", FormatText, nil
+	})
+	run, err := RunPipeline(context.Background(), pipelineWithEntry(), inv, Options{EntryStep: "execute"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if run.Stopped {
+		t.Fatalf("Stopped=true reason=%q", run.StopReason)
+	}
+	if run.Entry != nil {
+		t.Errorf("Run.Entry=%+v; esperaba nil cuando --from bypassa el entry", run.Entry)
+	}
+	got := []string{}
+	for _, s := range run.Steps {
+		got = append(got, s.Step)
+	}
+	want := []string{"execute", "close"}
+	if !equalStrings(got, want) {
+		t.Errorf("steps=%v want %v", got, want)
+	}
+}
+
+// TestEntry_PipelineSinEntry: pipeline sin Entry — el motor arranca en
+// el primer step, Run.Entry queda nil. Test de regresión para asegurar
+// que el entry agent NO es obligatorio (PRD §5.b).
+func TestEntry_PipelineSinEntry(t *testing.T) {
+	inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+		if agent == "entry-agent" {
+			t.Fatalf("entry no debería correr cuando Pipeline.Entry == nil")
+			return "", FormatText, nil
+		}
+		return "[next]", FormatText, nil
+	})
+	run, err := RunPipeline(context.Background(), simplePipeline(), inv, Options{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if run.Stopped {
+		t.Fatalf("Stopped=true reason=%q", run.StopReason)
+	}
+	if run.Entry != nil {
+		t.Errorf("Run.Entry=%+v; esperaba nil sin Entry", run.Entry)
+	}
+	if len(run.Steps) != 4 {
+		t.Errorf("len(Steps)=%d want 4", len(run.Steps))
+	}
+}
+
+// TestEntry_SinAgentes: defensa para EntrySpec con Agents vacío (config
+// inválido escapó al validator). Stop con StopReasonEntryNoAgents.
+func TestEntry_SinAgentes(t *testing.T) {
+	p := simplePipeline()
+	p.Entry = &EntrySpec{Agents: nil}
+	inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+		t.Fatalf("invoker no debería llamarse con entry sin agentes")
+		return "", FormatText, nil
+	})
+	run, err := RunPipeline(context.Background(), p, inv, Options{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !run.Stopped || run.StopReason != StopReasonEntryNoAgents {
+		t.Errorf("got Stopped=%v StopReason=%q want stop+entry-no-agents", run.Stopped, run.StopReason)
+	}
+}
+
+// TestEntry_NoCuentaComoTransition: el entry NO debe contar como
+// transición — el cap de MaxTransitions protege contra loops entre
+// steps, no contra el entry (que corre una sola vez).
+func TestEntry_NoCuentaComoTransition(t *testing.T) {
+	inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+		if agent == "entry-agent" {
+			return "[next]", FormatText, nil
+		}
+		return "[next]", FormatText, nil
+	})
+	run, err := RunPipeline(context.Background(), pipelineWithEntry(), inv, Options{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if run.Transitions != 4 {
+		t.Errorf("Transitions=%d want 4 (entry no debe contar como transición)", run.Transitions)
+	}
+}
+
+// TestEntry_StreamJSONFormat: cuando el invoker reporta FormatStreamJSON
+// para el entry, el motor parsea con ParseStreamMarker (igual que para
+// steps).
+func TestEntry_StreamJSONFormat(t *testing.T) {
+	inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+		if agent == "entry-agent" {
+			stream := `{"type":"system","subtype":"init"}` + "\n" +
+				`{"type":"result","subtype":"success","result":"input ok\n[goto: execute]"}`
+			return stream, FormatStreamJSON, nil
+		}
+		return "[next]", FormatText, nil
+	})
+	run, err := RunPipeline(context.Background(), pipelineWithEntry(), inv, Options{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if run.Stopped {
+		t.Fatalf("Stopped=true reason=%q", run.StopReason)
+	}
+	if run.Entry == nil || run.Entry.StartStep != "execute" {
+		t.Errorf("Entry.StartStep=%q want execute (stream-json [goto: execute])", run.Entry.StartStep)
+	}
+}
+
+// TestEntry_FromConPipelineEntryYStepDesconocido: --from con step que
+// no existe en el pipeline → unknown-step (sin tocar el entry). El
+// override manual no debe pasar por el entry incluso cuando es inválido.
+func TestEntry_FromConPipelineEntryYStepDesconocido(t *testing.T) {
+	inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+		t.Fatalf("ni entry ni steps deberían correr con --from inválido")
+		return "", FormatText, nil
+	})
+	run, err := RunPipeline(context.Background(), pipelineWithEntry(), inv, Options{EntryStep: "ghost"})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !run.Stopped || run.StopReason != StopReasonUnknownStep {
+		t.Errorf("got Stopped=%v StopReason=%q want stop+unknown-step", run.Stopped, run.StopReason)
+	}
+	if run.Entry != nil {
+		t.Errorf("Run.Entry=%+v; --from inválido no debería invocar al entry", run.Entry)
+	}
+}

--- a/internal/engine/entry_test.go
+++ b/internal/engine/entry_test.go
@@ -302,6 +302,61 @@ func TestEntry_StreamJSONFormat(t *testing.T) {
 	}
 }
 
+// TestEntry_GotoMasLoopGatillaCap: regresión sobre la intersección
+// entry-goto + loop entre steps + cap.
+//
+// Pipeline: entry hace [goto: a]; step `a` hace [goto: b]; step `b`
+// hace [goto: a]. Sin cap, el motor entraría en loop infinito a↔b.
+// Con cap, MaxTransitions corta limpio y reporta StopReasonLoopCap.
+//
+// El test importa porque cubre el cruce de dos features que se
+// agregaron en PRs distintos (entry-goto en PR5d, loop cap en PR5b):
+// queremos saber, vía test, que el cap atrapa también los loops que
+// arrancan vía entry-goto, no sólo los que arrancan vía primer step.
+func TestEntry_GotoMasLoopGatillaCap(t *testing.T) {
+	p := Pipeline{
+		Entry: &EntrySpec{Agents: []string{"entry-agent"}},
+		Steps: []Step{
+			{Name: "a", Agents: []string{"agent-a"}},
+			{Name: "b", Agents: []string{"agent-b"}},
+		},
+	}
+	inv := newFakeInvoker(func(agent string, _ int) (string, OutputFormat, error) {
+		switch agent {
+		case "entry-agent":
+			return "[goto: a]", FormatText, nil
+		case "agent-a":
+			return "[goto: b]", FormatText, nil
+		case "agent-b":
+			return "[goto: a]", FormatText, nil
+		}
+		t.Fatalf("agente inesperado %q", agent)
+		return "", FormatText, nil
+	})
+	run, err := RunPipeline(context.Background(), p, inv, Options{})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !run.Stopped {
+		t.Fatalf("Stopped=false; esperaba true (loop cap)")
+	}
+	if run.StopReason != StopReasonLoopCap {
+		t.Errorf("StopReason=%q want %q (detail=%q)", run.StopReason, StopReasonLoopCap, run.StopDetail)
+	}
+	if run.Transitions != MaxTransitions {
+		t.Errorf("Transitions=%d want %d (cap)", run.Transitions, MaxTransitions)
+	}
+	// El entry corrió y fue registrado, pero NO debe contar como
+	// transición — el cap protege contra loops entre steps, no contra
+	// el entry (que corre una sola vez por corrida).
+	if run.Entry == nil {
+		t.Fatalf("Run.Entry=nil; esperaba EntryRun (entry corrió antes del loop)")
+	}
+	if run.Entry.StartStep != "a" {
+		t.Errorf("Entry.StartStep=%q want a", run.Entry.StartStep)
+	}
+}
+
 // TestEntry_FromConPipelineEntryYStepDesconocido: --from con step que
 // no existe en el pipeline → unknown-step (sin tocar el entry). El
 // override manual no debe pasar por el entry incluso cuando es inválido.

--- a/internal/pipeline/validate.go
+++ b/internal/pipeline/validate.go
@@ -79,6 +79,21 @@ func validateEntry(e Entry) error {
 			}
 		}
 	}
+	// PR5d: el motor sólo invoca Agents[0] del entry — multi-agente +
+	// aggregator en el entry es follow-up (mirror de PR5c para steps).
+	// Sin esta regla, un pipeline con `entry: {agents: [a, b, c]}` se
+	// cargaría OK y el motor correría sólo `a`, descartando `b` y `c`
+	// silenciosamente. Rechazar al cargar es más honesto que hacerlo
+	// silently truncate.
+	if len(e.Agents) > 1 {
+		return &LoadError{
+			Field: "entry.agents",
+			Reason: fmt.Sprintf(
+				"entry declares %d agents but multi-agent entry is not supported yet (follow-up); use a single agent for now",
+				len(e.Agents),
+			),
+		}
+	}
 	if e.Aggregator != "" && !e.Aggregator.IsValid() {
 		return &LoadError{
 			Field: "entry.aggregator",

--- a/internal/pipeline/validate_test.go
+++ b/internal/pipeline/validate_test.go
@@ -180,6 +180,29 @@ func TestValidate_EntryRequiresAgents(t *testing.T) {
 	}
 }
 
+// TestValidate_EntryRejectsMultiAgent: el motor sólo invoca Agents[0]
+// del entry en v1 (multi-agente + aggregator es follow-up). Aceptar
+// >1 agente al cargar significa truncar silenciosamente — la
+// validación tiene que rechazarlo con un mensaje accionable.
+func TestValidate_EntryRejectsMultiAgent(t *testing.T) {
+	p := Pipeline{
+		Version: CurrentVersion,
+		Entry:   &Entry{Agents: []string{"a", "b"}},
+		Steps:   []Step{{Name: "x", Agents: []string{"a"}}},
+	}
+	err := Validate(p)
+	var le *LoadError
+	if !errors.As(err, &le) {
+		t.Fatalf("err type = %T (%v), want *LoadError", err, err)
+	}
+	if le.Field != "entry.agents" {
+		t.Errorf("Field = %q, want entry.agents", le.Field)
+	}
+	if !strings.Contains(le.Reason, "multi-agent") {
+		t.Errorf("Reason = %q, expected mention of multi-agent", le.Reason)
+	}
+}
+
 // TestValidate_EntryAggregatorPresets: misma regla que para Step pero
 // scope al entry — mensaje y campo distinto.
 func TestValidate_EntryAggregatorPresets(t *testing.T) {


### PR DESCRIPTION
Implementa #59.

Closes #59

## Implementado

**Engine** (`internal/engine/engine.go`):
- `EntrySpec` type con `Agents []string` + `Aggregator AggregatorKind` (forward-compatible con multi-agente).
- Campo `Entry *EntrySpec` en `engine.Pipeline`.
- `EntryRun` struct + `Run.Entry *EntryRun` para audit del entry.
- Nuevos `StopReason`: `StopReasonEntryStop`, `StopReasonEntryNoAgents`.
- `runEntry()` helper: invoca primer agente del entry, parsea marker (text o stream-json), resuelve `[next]` → primer step, `[goto: X]` → step X (con validación), `[stop]` → halt, error técnico → halt. El entry NO cuenta como transition.
- `RunPipeline` ramifica al inicio: `EntryStep != ""` bypassa entry; `Pipeline.Entry != nil` corre entry; sino arranca en steps[0].

**CLI** (`cmd/run.go`):
- Subcomando `che run [pipeline]` con flags `--from <step>` (PRD §5.c) y `--input <text>`.
- `liveInvoker` que mapea agentes built-in (`claude-opus/sonnet/haiku`) a `internal/agent.Run`. Custom agents devuelven error técnico (wiring de subagents queda para follow-up).
- `toEnginePipeline()` convierte `pipeline.Pipeline` → `engine.Pipeline`.

## Tests (21 nuevos, todos verdes)

- `internal/engine/entry_test.go` (13): next, default-next, goto, goto-desconocido, stop, error técnico, --from bypass, sin entry, sin agentes, no-cuenta-transition, stream-json, --from inválido + entry presente.
- `cmd/run_test.go` (8): entry next/goto/stop, --from bypass, --from inválido, pipeline sin entry, built-in fallback, error técnico → exit error.

`go build ./...` OK, `go test ./...` verde.

## Decisiones de diseño

- **Entry NO cuenta como transition** (el cap de MaxTransitions protege loops entre steps, no la única corrida del entry).
- **Distinción `StopReasonEntryStop` vs `StopReasonAgentMarker`**: la UX (audit log, dash) necesita diferenciar "rebote en el entry" vs "step paró el pipeline".
- **Single-agent en runEntry** (mirror de PR5b para Steps): cuando se necesite multi-agente entry, follow-up usa `runStep`-equivalente con `Entry.Aggregator`. El shape ya está preservado.
- **Override `Options.EntryStep` formaliza bypass** del entry (PRD §5.c) y test asegura `Run.Entry == nil` cuando se usa `--from`.

## Pendiente (intencional, fuera de scope)

- **Multi-agente entry**: invoca solo `Entry.Agents[0]`. Follow-up cuando wireup CLI lo necesite.
- **Custom agents en `che run`**: `liveInvoker` solo soporta los 3 built-ins. Auto-descubiertos en `.claude/agents/` requieren wiring con `claude --agent <name>` — fuera del scope.
- **`--format json`**: output actual es humano. Follow-up para scripting.
