### PR TITLE
feat(#67): [#50 PR6b] Migración flow por flow a labels v2 (idea/explore/execute)

### DIFF
--- a/EXEC_NOTES.md
+++ b/EXEC_NOTES.md
@@ -1,70 +1,198 @@
-# PR5c — Engine multi-agente + aggregator + cancelación parcial
+# PR6b — Migración flow por flow a labels v2: notas de ejecución
 
-## Estado del PR
+## Scope cubierto
 
-Cubre todo lo que el scope de #57 pide:
+PR mediano siguiendo la guidance del issue: "Si el alcance se vuelve XL …
+priorizar 2-3 flows mas representativos y dejar los demás como TODO".
+Migrados los 3 flows que cubren toda la combinatoria interesante:
 
-- **`Aggregator` interface** con 3 implementations: `majorityAgg`, `unanimousAgg`, `firstBlockerAgg` (`internal/engine/aggregator.go`).
-- **`AggregatorKind`** mirror de `internal/pipeline.Aggregator` (los presets `majority`/`unanimous`/`first_blocker`). El motor no importa `internal/pipeline` para mantener self-contained.
-- **`runStep`** (`internal/engine/runstep.go`) invoca a todos los agentes en paralelo via goroutines, alimenta resultados al aggregator y cancela el resto apenas el aggregator decide. Hace `context.WithCancel` sobre el ctx del motor — propaga al child process via la cadena `Invoker.Invoke → internal/agent.Run`.
-- **Cancelación parcial reportada como `Cancelled`, no como error** (PRD §3.d "loguear como cancelled by aggregator"). Los `AgentResult.Cancelled=true` no votan.
-- **Default aggregator = `majority`** (PRD §3.d "Default: majority").
-- **Step extendido** con `Aggregator AggregatorKind` opcional. `StepRun` extendido con `AgentResults []AgentResult` + `AggregatorReason string` para audit log.
-- **Backwards compat single-agent**: si `len(Step.Agents) == 1`, `StepRun` mantiene el shape histórico (Agent + Resolved "explicit"/"default-next"/"technical-error"). Cuando `>1`, queda `Resolved="aggregator"`.
-- **Errores técnicos en multi-agente**: si el aggregator decide `[stop]` con al menos 1 agente que erroreó, el motor mapea a `StopReasonTechnicalError` (no `StopReasonAgentMarker`), preservando el contrato del PR5b.
+1. **`internal/flow/idea`** — el más simple: solo `Ensure`/`AddLabels` +
+   `--label`. Demuestra que el reemplazo `labels.CheIdea` →
+   `pipelinelabels.StateIdea` es trivial cuando no hay máquina de
+   estados involucrada.
+2. **`internal/flow/explore`** — el primer flow con `labels.Apply(from,
+   to)` real (idea → applying:explore → explore + rollback). Prueba que
+   las transiciones v2 registradas en `internal/labels` funcionan
+   end-to-end (Lock + Apply + rollback + tests + e2e).
+3. **`internal/flow/execute`** — el flow más complejo que migra: 3
+   estados de origen aceptados (idea / explore / validate_pr), rollback
+   condicional según se haya creado PR o no, gate con 5 chequeos de
+   estado, fromState() para resolver ambigüedad. Cubre todos los
+   patrones de uso del modelo viejo.
 
-## Tests
+## Coexistencia (clave del PR)
 
-**Aggregator (aislado)** — `internal/engine/aggregator_test.go`:
-- majority: stop short-circuit, 2/3 next, 2 next + 1 stop = stop, empate goto/stop = stop, empate next/goto sin stop = stop (Finalize), goto mismo destino gana 2/3, default kind, error técnico = stop.
-- unanimous: todos next, divergencia early cancel, goto mismo destino, goto destinos distintos = stop.
-- first_blocker: primer stop, primer goto, todos next.
-- helpers: kind desconocido = nil, MarkerNone == MarkerNext en keyOf.
+El paquete viejo `internal/labels` se preserva intacto (no se borra ni
+se modifica el set de constantes / transiciones existentes). Lo único
+que se agregó es:
 
-**runStep (paralelismo + cancelación)** — `internal/engine/runstep_test.go`:
-- single agente equivalente (backwards compat).
-- 3 agentes en paralelo (verifica `maxConcurrent >= 2` con atomicos).
-- first_blocker cancela resto via blockingInvoker (agentes B y C bloqueados, A devuelve [stop], B y C terminan con `Cancelled=true`).
-- majority stop short-circuit (B y C nunca completan, sólo A).
-- unanimous divergencia early cancel.
-- aggregator default = majority.
-- agente repetido = N instancias (3 calls al mismo nombre).
-- todos error técnico → stop con TechnicalError propagado.
-- ctx ya cancelado → stop inmediato sin invocar.
+- `internal/pipelinelabels/v2states.go` — 9 constantes públicas
+  (`StateIdea`, `StateApplyingExplore`, `StateExplore`,
+  `StateApplyingExecute`, `StateExecute`, `StateApplyingValidatePR`,
+  `StateValidatePR`, `StateApplyingClose`, `StateClose`) que mapean los
+  9 estados viejos al modelo v2 según PRD §6.c. Más constantes de step
+  (`StepIdea`, `StepExplore`, `StepExecute`, `StepValidatePR`,
+  `StepClose`) que actúan de fuente de verdad para los nombres.
+- `internal/labels/v2_transitions.go` — `init()` que registra las 21
+  transiciones del modelo viejo en `validTransitions` con keys formadas
+  por strings v2. Esto permite que `labels.Apply(ref,
+  pipelinelabels.StateIdea, pipelinelabels.StateApplyingExplore)` funcione
+  sin tocar el código del paquete viejo. Ambos sets de keys (viejas +
+  v2) coexisten en el mismo mapa — ningún colisión porque los strings
+  son distintos (`"che:idea→che:planning"` vs.
+  `"che:state:idea→che:state:applying:explore"`).
+- Tests para ambos: `pipelinelabels/v2states_test.go` (literales fijos
+  + round-trip por `Parse`), `labels/v2_transitions_test.go` (las 21
+  transiciones v2 + coexistencia con las viejas).
 
-**Integración con `RunPipeline`**:
-- `TestRunPipeline_StepMultiAgenteIntegracion`: pipeline con un step de 3 agentes, marker resuelto por aggregator, AgentResults llenos.
-- `TestRunPipeline_StepMultiAgenteErrorTecnicoMapeaATechReason`: confirma `StopReasonTechnicalError` cuando el aggregator stoppea por error.
+Los flows ya migrados (`idea`, `explore`, `execute`) usan
+**exclusivamente** los strings v2 en producción. Si un flow ya migrado
+corre sobre un issue/PR con labels viejos (`che:plan` etc.), `Apply`
+fallaría porque GitHub no encuentra el label viejo para borrar — la
+conversión runtime de labels existentes vive fuera del scope de PR6b
+(necesita un subcomando `migrate-labels-v2` similar al
+`migrate-labels` actual; queda para PR siguiente).
 
-Toda la suite del repo (`go test ./...`) verde. `go test -race ./internal/engine/...` también verde (race en `internal/startup` es pre-existente, no tocada por este PR).
+## Tests verdes en cada paquete migrado
+
+```
+internal/labels                  ok (incluye nuevos v2_transitions_test.go)
+internal/pipelinelabels          ok (incluye nuevos v2states_test.go)
+internal/flow/idea               ok (no test files; build verificada)
+internal/flow/explore            ok (fixtures en explore_test.go updated)
+internal/flow/execute            ok (fixtures en execute_test.go updated)
+e2e                              ok (idea/explore/execute fixtures + asserts updated)
+```
+
+`go test ./...` 100% verde tras la migración. `go vet ./...` clean.
+
+## Pendiente (TODO para PR6c+)
+
+Por orden de complejidad ascendente:
+
+1. **`internal/flow/stateref`** — exporta el set `stateLabelSet` de los
+   9 estados viejos (usado por `che close` para detectar issues con
+   estado che:* aplicado). La migración es trivial (mapeo directo) pero
+   afecta el detector de drift entre `internal/labels` y el set de
+   estados que el dash/closing usan. Recomendado abordar **junto** con
+   el flow de close.
+2. **`internal/flow/close`** — gate ramifica por `che:executed` /
+   `che:validated`, transiciones a `che:closing` → `che:closed`,
+   resolución por `closingIssuesReferences` con fallback al PR. La
+   migración es mecánica pero atraviesa varias funciones (`prFrom`,
+   `groupCloseable`, `closeIssue`, `closeFromPR`). Tests: actualizar
+   `closing_test.go` (tiene fixtures con todos los estados viejos).
+3. **`internal/flow/iterate`** — dos modos (PR + plan), cada uno con su
+   propio gate + Apply. PR-mode usa `che:validated` /
+   `che:executing` / `che:executed`; plan-mode usa `che:validated` /
+   `che:planning` / `che:plan`. También toca verdicts
+   (`plan-validated:changes-requested`) que NO migran (esos labels
+   sobreviven al modelo v2). Tests: `iterate_test.go` espeja la
+   matriz; cuidado con la asimetría PR/plan.
+4. **`internal/flow/validate`** — el más complejo. PR-mode con
+   `executed → validating → validated` + rollback, plan-mode con
+   `plan → validating → validated` + rollback, además aplica labels
+   verdict (`validated:approve`, `plan-validated:approve`, etc.) que
+   NO se migran a v2 (los verdicts conviven con la máquina de estados
+   pero no son estados). El test file tiene ~1700 líneas con muchas
+   matrices.
+5. **Callers fuera de los flows** — todavía importan `internal/labels`
+   y usan las constantes viejas:
+   - `cmd/migrate_labels.go` (input del migrador viejo `status:*` →
+     `che:*`; queda como referencia histórica).
+   - `cmd/unlock.go` (usa `labels.Unlock` — orthogonal, NO migra).
+   - `internal/dash/gh_source.go` (usa `labels.CheClosed`,
+     `labels.CtPlan`, `labels.CheLocked` — algunos migrarían en PR6c
+     cuando dash hable v2; otros son orthogonal).
+   - `internal/tui/model.go` (usa `labels.LockedRef`, `labels.Unlock`,
+     `labels.ListLocked` — todos orthogonal, NO migran).
+   - `internal/startup/checks.go` (no usa estados, OK).
+   - `internal/flow/stateref/stateref.go` (mapeo del set de estados;
+     ver pendiente #1).
+
+6. **Nuevo subcomando `migrate-labels-v2`** — para repos vivos con
+   issues en estados viejos. Renombrar in-place `che:idea` →
+   `che:state:idea` etc. en todos los issues. Análogo a `cmd/migrate_labels.go`.
+   FUERA del scope del PR6b por la guidance "migración flow por flow".
+
+7. **Borrado de las constantes viejas** (`labels.CheIdea` etc.) y de
+   las keys viejas en `validTransitions` — eso es PR6c (post-migración
+   de TODOS los flows). El test `TestNoHardcodedLabelsOutsideThisPackage`
+   se actualizará para forbiddear los strings v2 también, garantizando
+   que ningún caller invente literales.
 
 ## Decisiones / desviaciones
 
-### 1. Aggregator interface vs función pura
+### 1. `pipelinelabels.State*` como `var`, no `const`
 
-El PRD habla del aggregator como "política" pero no fija el shape. Elegí interface con `Feed` + `Finalize` (channel-style streaming) en vez de función `(N markers) → marker` porque:
+Los 9 estados v2 son `var` porque se inicializan llamando
+`StateLabel("idea")` / `ApplyingLabel("explore")` — las funciones del
+paquete son la fuente de verdad de los prefijos (`PrefixState`,
+`PrefixApplying`). Si en el futuro alguien renombrara los prefijos sin
+actualizar las constantes, los tests de round-trip
+(`TestV2States_LiteralValues` + `TestV2States_RoundTripParse`) lo
+detectarían inmediatamente.
 
-- Permite cancelación temprana natural: `Feed` devuelve `Decided=true` cuando el aggregator ya tiene info suficiente, sin necesidad de esperar a los N agentes.
-- `Finalize` cubre el caso "todos terminaron sin short-circuit" (ej. unanimous con 3 agentes que coinciden en `[next]`: el aggregator no decide hasta el último).
+### 2. `labels/v2_transitions.go` usa `init()`
 
-### 2. `AgentResult` preserva `MarkerNone`
+En vez de incrustar el mapa v2 dentro del literal de `validTransitions`
+en `labels.go` (que requeriría tocar el archivo viejo y hacerlo
+depender de `pipelinelabels`), uso un archivo separado con `init()` que
+muta el mapa. Esto cumple "no borrar" + "coexistencia" con un solo
+file diff, y un futuro PR6c puede borrar este archivo entero (más las
+keys viejas) en un solo cambio.
 
-`runStep` NO normaliza `MarkerNone → MarkerNext` antes de poner el resultado en `AgentResult.Marker`. La normalización vive en el aggregator (`effectiveMarker` helper). Esto preserva el contrato single-agent del motor — los tests heredados del PR5b distinguen `Resolved="default-next"` (no había marker) de `Resolved="explicit"` (agente emitió `[next]`).
+### 3. Mapeo de estados viejos → v2 (PRD §6.c)
 
-### 3. Race fix en `fakeInvoker` (test fixture)
+| viejo            | v2                              |
+|------------------|---------------------------------|
+| `che:idea`       | `che:state:idea`                |
+| `che:planning`   | `che:state:applying:explore`    |
+| `che:plan`       | `che:state:explore`             |
+| `che:executing`  | `che:state:applying:execute`    |
+| `che:executed`   | `che:state:execute`             |
+| `che:validating` | `che:state:applying:validate_pr`|
+| `che:validated`  | `che:state:validate_pr`         |
+| `che:closing`    | `che:state:applying:close`      |
+| `che:closed`     | `che:state:close`               |
 
-El `fakeInvoker` heredado del PR5b no era thread-safe (map de calls sin lock). Como ahora el motor invoca múltiples agentes en goroutines paralelas, agregué un `sync.Mutex` al fixture. No es un cambio de producción — solo del test helper.
+Notar que el modelo v2 colapsa "validate sobre plan" y "validate sobre
+PR" en un solo step (`validate_pr`). El modelo viejo tampoco
+distinguía a nivel de label (ambos usaban `che:validating` /
+`che:validated` — la distinción venía del tipo de entidad target). En
+PR6b mantenemos el mapeo 1:1; refinar a steps separados (`validate_plan`
+vs. `validate_pr`) requiere extender el pipeline declarativo
+(`internal/pipeline`) con dos steps de validate, fuera del scope de la
+migración.
 
-### 4. `AggregatorKind` mirror de `internal/pipeline.Aggregator`
+### 4. Fixtures de e2e usan literales v2 directamente
 
-PR2 (`internal/pipeline`) define `Aggregator` como enum string. El motor define `AggregatorKind` con los mismos valores en lugar de importar el paquete, manteniendo self-contained la dependencia. Cuando el wireup CLI (PR4/PR5d) consuma `pipeline.Step`, hará la conversión `pipeline.Aggregator → engine.AggregatorKind` (literal el mismo string).
+Los archivos `e2e/testdata/{explore,execute,idea}/*.json` y los asserts
+en `e2e/{explore,execute,idea}_test.go` ahora contienen literales v2
+(`"che:state:idea"`, `"che:state:explore"`, etc.). Como los archivos
+`_test.go` y `testdata/` están excluidos de
+`TestNoHardcodedLabelsOutsideThisPackage`, esto es legal y evita
+arrastrar `pipelinelabels` como dependencia del harness e2e.
 
-### 5. Cancelación de agentes "in-flight"
+### 5. Marker labels NO migran
 
-Si un agente termina DESPUÉS de que el aggregator decidió (race entre `cancel()` y la finalización del Invoke), su resultado llega a `resultsCh` pero `runStep` lo agrega a `Results` sin alimentarlo al aggregator. Si tenía error de ctx, lo marca `Cancelled=true`; si tenía error técnico no-ctx, queda `Err` (raro: no debería pasar si el invoker respeta ctx). Esto preserva la garantía "todas las goroutines terminan antes del return" sin leakear y sin alterar la decisión.
+`labels.CtPlan` (y `labels.CheLocked`) son labels ortogonales — NO son
+parte de la máquina de estados, y el modelo v2 no los redefine. Siguen
+viviendo en `internal/labels` y siguen referenciándose como `labels.CtPlan`
+/ `labels.CheLocked` desde los flows migrados. Los verdicts
+(`labels.ValidatedApprove`, `labels.PlanValidatedChangesRequested`,
+etc.) son la misma situación: no son estados, no migran.
 
-## Pendientes (intencionalmente fuera de scope)
+## Cómo continuar (PR6c+)
 
-- **Wiring real con `internal/agent.Run`** — el motor sigue dependiendo de la `Invoker` interface. La implementación concreta que dispatcha a claude (vía `internal/agent.Run` con `KillGrace`) viene cuando se cablee el comando `che pipeline run` (PR4 / PR5d). El `runStep` ya está listo para esa Invoker — el `KillGrace` que pide el PRD §3.d (SIGTERM + 5s grace + SIGKILL) ya está implementado en `internal/agent.Run` desde antes del PRD #50, y el ctx propagado le indica cuándo matar.
-- **Entry agent + flag `--from`** — PR5d.
-- **Adaptación de `engine.Step` → `pipeline.Step`** — follow-up cuando el wireup CLI lo necesite. Hoy son tipos paralelos compatibles en shape.
+Recomendación de orden:
+1. Migrar `stateref` + `close` juntos (forman una unidad lógica).
+2. Migrar `iterate` (más complejo pero auto-contenido).
+3. Migrar `validate` (el más complejo, pero con todos los demás
+   migrados antes ya tenés el patrón resuelto).
+4. Migrar callers no-flow (`dash/gh_source.go` para los estados,
+   dejar TUI/unlock/migrate_labels en paz).
+5. Borrar el shim `v2_transitions.go` y las 9 constantes viejas en
+   `labels.go` (más sus 21 transiciones); actualizar
+   `TestNoHardcodedLabelsOutsideThisPackage` para que prohíba ambos
+   sets de literales.

--- a/e2e/execute_signal_test.go
+++ b/e2e/execute_signal_test.go
@@ -135,9 +135,9 @@ func assertCleanupApplied(t *testing.T, env *harness.Env, stderr string) {
 
 	// 3) Rollback de label ejecutado: debe haber un POST REST agregando
 	//    che:plan (transición executing→plan).
-	posts := env.Invocations().FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:plan")
+	posts := env.Invocations().FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:state:explore")
 	if len(posts) == 0 {
-		t.Fatalf("expected rollback POST adding che:plan; calls=%v",
+		t.Fatalf("expected rollback POST adding che:state:explore; calls=%v",
 			env.Invocations().For("gh"))
 	}
 

--- a/e2e/execute_test.go
+++ b/e2e/execute_test.go
@@ -102,10 +102,10 @@ func TestExecute_GoldenPath(t *testing.T) {
 	// che:executing). 2) executing→executed (DELETE che:executing + POST
 	// che:executed). awaiting-human ya no se aplica (el gate vive en
 	// plan-validated:* / validated:*).
-	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:executing"); len(got) != 1 {
+	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:state:applying:execute"); len(got) != 1 {
 		t.Fatalf("expected 1 POST adding che:executing, got %d", len(got))
 	}
-	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:executed"); len(got) != 1 {
+	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:state:execute"); len(got) != 1 {
 		t.Fatalf("expected 1 POST adding che:executed, got %d", len(got))
 	}
 
@@ -125,7 +125,7 @@ func TestExecute_IssueNotStatusPlan_Exit3(t *testing.T) {
 	if r.ExitCode != 3 {
 		t.Fatalf("expected exit 3, got %d\nstderr: %s", r.ExitCode, r.Stderr)
 	}
-	harness.AssertContains(t, r.Stderr, "che:idea, che:plan ni che:validated")
+	harness.AssertContains(t, r.Stderr, "che:state:idea, che:state:explore ni che:state:validate_pr")
 	env.Invocations().AssertNotCalled(t, "claude")
 }
 
@@ -173,7 +173,8 @@ func TestExecute_IssueAlreadyExecuting_Exit3(t *testing.T) {
 	if r.ExitCode != 3 {
 		t.Fatalf("expected exit 3, got %d\nstderr: %s", r.ExitCode, r.Stderr)
 	}
-	harness.AssertContains(t, r.Stderr, "executing")
+	// Post-PR6b: el mensaje del flow menciona el label v2 (`che:state:applying:execute`).
+	harness.AssertContains(t, r.Stderr, "che:state:applying:execute")
 }
 
 // TestExecute_Idempotency_UpdatesExistingPR: segundo run con PR abierto
@@ -239,10 +240,10 @@ func TestExecute_AgentFails_Rollback(t *testing.T) {
 	}
 	// Lock: DELETE che:plan + POST che:executing. Rollback: DELETE
 	// che:executing + POST che:plan.
-	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:executing"); len(got) != 1 {
+	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:state:applying:execute"); len(got) != 1 {
 		t.Fatalf("expected 1 POST adding che:executing (lock), got %d", len(got))
 	}
-	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:plan"); len(got) != 1 {
+	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:state:explore"); len(got) != 1 {
 		t.Fatalf("expected 1 POST adding che:plan (rollback), got %d", len(got))
 	}
 }
@@ -275,10 +276,10 @@ func TestExecute_AgentFails_RollbackSkippedIfLockLost(t *testing.T) {
 	inv := env.Invocations()
 	// Lock: 1 POST adding che:executing. Rollback NO debe ocurrir → 0
 	// POSTs adding che:plan.
-	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:executing"); len(got) != 1 {
+	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:state:applying:execute"); len(got) != 1 {
 		t.Fatalf("expected 1 POST adding che:executing (lock), got %d", len(got))
 	}
-	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:plan"); len(got) != 0 {
+	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:state:explore"); len(got) != 0 {
 		t.Fatalf("expected 0 POST adding che:plan (rollback skipped), got %d", len(got))
 	}
 	harness.AssertContains(t, r.Stderr, "rollback abortado")
@@ -346,7 +347,7 @@ func TestExecute_NoChanges_ExistingPR_Rollback(t *testing.T) {
 		t.Fatalf("expected 0 gh pr create, got %d", len(creates))
 	}
 	// Ninguna transición debe agregar che:executed (POST con ese label).
-	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:executed"); len(got) != 0 {
+	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:state:execute"); len(got) != 0 {
 		t.Fatalf("rogue transition to che:executed: %v", got)
 	}
 }
@@ -520,10 +521,10 @@ func TestExecute_PreviousPRClosed_NoAutoReopen(t *testing.T) {
 	}
 	// Rollback aplicado: lock POST adds che:executing, rollback POST adds
 	// che:plan.
-	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:executing"); len(got) != 1 {
+	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:state:applying:execute"); len(got) != 1 {
 		t.Fatalf("expected 1 POST adding che:executing (lock), got %d", len(got))
 	}
-	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:plan"); len(got) != 1 {
+	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:state:explore"); len(got) != 1 {
 		t.Fatalf("expected 1 POST adding che:plan (rollback), got %d", len(got))
 	}
 }
@@ -590,10 +591,10 @@ func TestExecute_PRCreateFails_PostPush_CleanupCorrect(t *testing.T) {
 	inv := env.Invocations()
 	// Rollback del label aplicado: lock POST agrega che:executing, rollback
 	// POST agrega che:plan.
-	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:executing"); len(got) != 1 {
+	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:state:applying:execute"); len(got) != 1 {
 		t.Fatalf("expected 1 POST adding che:executing (lock), got %d", len(got))
 	}
-	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:plan"); len(got) != 1 {
+	if got := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:state:explore"); len(got) != 1 {
 		t.Fatalf("expected 1 POST adding che:plan (rollback), got %d", len(got))
 	}
 

--- a/e2e/explore_test.go
+++ b/e2e/explore_test.go
@@ -99,14 +99,14 @@ func TestExplore_IssueMissingCtPlan_ClassifiesAndContinues(t *testing.T) {
 	if len(posts) < 3 {
 		t.Fatalf("expected at least 3 POST labels (reclassify + lock + transition), got %d; calls=%v", len(posts), posts)
 	}
-	posts[0].AssertArgsContain(t, "labels[]=ct:plan", "labels[]=che:idea")
+	posts[0].AssertArgsContain(t, "labels[]=ct:plan", "labels[]=che:state:idea")
 	reclassArgs := strings.Join(posts[0].Args, " ")
 	if strings.Contains(reclassArgs, "type:feature") || strings.Contains(reclassArgs, "size:m") {
 		t.Fatalf("reclassify POST debería preservar type/size existentes; args=%v", posts[0].Args)
 	}
 	postsByLabel := findLabelPostsByLabel(inv, 99)
-	if postsByLabel["che:plan"] != 1 {
-		t.Fatalf("expected exactly 1 POST adding che:plan, got %d", postsByLabel["che:plan"])
+	if postsByLabel["che:state:explore"] != 1 {
+		t.Fatalf("expected exactly 1 POST adding che:state:explore, got %d", postsByLabel["che:state:explore"])
 	}
 }
 
@@ -142,7 +142,7 @@ func TestExplore_IssueMissingCtPlan_NoTypeSize_AppliesInferred(t *testing.T) {
 	}
 	posts[0].AssertArgsContain(t,
 		"labels[]=ct:plan",
-		"labels[]=che:idea",
+		"labels[]=che:state:idea",
 		"labels[]=type:feature",
 		"labels[]=size:m",
 	)
@@ -151,14 +151,14 @@ func TestExplore_IssueMissingCtPlan_NoTypeSize_AppliesInferred(t *testing.T) {
 	for _, c := range labelCreates {
 		joined += " " + strings.Join(c.Args, " ")
 	}
-	for _, expected := range []string{"ct:plan", "che:idea", "type:feature", "size:m"} {
+	for _, expected := range []string{"ct:plan", "che:state:idea", "type:feature", "size:m"} {
 		if !strings.Contains(joined, expected) {
 			t.Fatalf("expected gh label create for %q; calls=%v", expected, labelCreates)
 		}
 	}
 	postsByLabel := findLabelPostsByLabel(inv, 77)
-	if postsByLabel["che:plan"] != 1 {
-		t.Fatalf("expected exactly 1 POST adding che:plan, got %d", postsByLabel["che:plan"])
+	if postsByLabel["che:state:explore"] != 1 {
+		t.Fatalf("expected exactly 1 POST adding che:state:explore, got %d", postsByLabel["che:state:explore"])
 	}
 }
 
@@ -250,8 +250,8 @@ func TestExplore_IssueMissingCtPlan_WithPreexistingStatus_PreservesStatus(t *tes
 	}
 	posts[0].AssertArgsContain(t, "labels[]=ct:plan")
 	reclassArgs := strings.Join(posts[0].Args, " ")
-	if strings.Contains(reclassArgs, "che:idea") {
-		t.Fatalf("reclassify debería preservar che:plan y NO agregar che:idea; args=%v", posts[0].Args)
+	if strings.Contains(reclassArgs, "che:state:idea") {
+		t.Fatalf("reclassify debería preservar che:state:explore y NO agregar che:state:idea; args=%v", posts[0].Args)
 	}
 	for _, c := range inv.For("claude") {
 		joined := strings.Join(c.Args, " ")
@@ -334,14 +334,14 @@ func TestExplore_GoldenPath(t *testing.T) {
 	if len(deletes) != 2 {
 		t.Fatalf("expected 2 state-label DELETE (idea + planning), got %d", len(deletes))
 	}
-	deletes[0].AssertArgsContain(t, "issues/42/labels/che:idea")
-	deletes[1].AssertArgsContain(t, "issues/42/labels/che:planning")
+	deletes[0].AssertArgsContain(t, "issues/42/labels/che:state:idea")
+	deletes[1].AssertArgsContain(t, "issues/42/labels/che:state:applying:explore")
 	postsByLabel := findLabelPostsByLabel(inv, 42)
-	if postsByLabel["che:planning"] != 1 {
-		t.Fatalf("expected 1 POST adding che:planning, got %d", postsByLabel["che:planning"])
+	if postsByLabel["che:state:applying:explore"] != 1 {
+		t.Fatalf("expected 1 POST adding che:state:applying:explore, got %d", postsByLabel["che:state:applying:explore"])
 	}
-	if postsByLabel["che:plan"] != 1 {
-		t.Fatalf("expected 1 POST adding che:plan, got %d", postsByLabel["che:plan"])
+	if postsByLabel["che:state:explore"] != 1 {
+		t.Fatalf("expected 1 POST adding che:state:explore, got %d", postsByLabel["che:state:explore"])
 	}
 	// No aplicar ct:exec desde explore.
 	if postsByLabel["ct:exec"] != 0 {
@@ -379,11 +379,11 @@ func TestExplore_IssueCtPlanWithoutStatusIdea_EnsuresRemoveLabel(t *testing.T) {
 	// El bug: si no Ensure-amos el label que vamos a --remove-label, gh
 	// falla con "not found" y la transición nunca ocurre. El fix garantiza
 	// que ambos extremos (Add y Remove) existan en el repo.
-	createIdea := inv.FindCalls("gh", "label", "create", "che:idea")
+	createIdea := inv.FindCalls("gh", "label", "create", "che:state:idea")
 	if len(createIdea) == 0 {
 		t.Fatalf("expected `gh label create status:idea` before transition; calls=%v", inv.For("gh"))
 	}
-	createPlan := inv.FindCalls("gh", "label", "create", "che:plan")
+	createPlan := inv.FindCalls("gh", "label", "create", "che:state:explore")
 	if len(createPlan) == 0 {
 		t.Fatalf("expected `gh label create status:plan` before transition; calls=%v", inv.For("gh"))
 	}
@@ -392,14 +392,14 @@ func TestExplore_IssueCtPlanWithoutStatusIdea_EnsuresRemoveLabel(t *testing.T) {
 	if len(deletes) != 2 {
 		t.Fatalf("expected 2 state-label DELETE, got %d", len(deletes))
 	}
-	deletes[0].AssertArgsContain(t, "issues/115/labels/che:idea")
-	deletes[1].AssertArgsContain(t, "issues/115/labels/che:planning")
+	deletes[0].AssertArgsContain(t, "issues/115/labels/che:state:idea")
+	deletes[1].AssertArgsContain(t, "issues/115/labels/che:state:applying:explore")
 	postsByLabel := findLabelPostsByLabel(inv, 115)
-	if postsByLabel["che:planning"] != 1 {
-		t.Fatalf("expected 1 POST adding che:planning, got %d", postsByLabel["che:planning"])
+	if postsByLabel["che:state:applying:explore"] != 1 {
+		t.Fatalf("expected 1 POST adding che:state:applying:explore, got %d", postsByLabel["che:state:applying:explore"])
 	}
-	if postsByLabel["che:plan"] != 1 {
-		t.Fatalf("expected 1 POST adding che:plan, got %d", postsByLabel["che:plan"])
+	if postsByLabel["che:state:explore"] != 1 {
+		t.Fatalf("expected 1 POST adding che:state:explore, got %d", postsByLabel["che:state:explore"])
 	}
 }
 
@@ -562,7 +562,7 @@ func TestExplore_LabelEditFailsAfterComment_Exit2_WarnsOrphan(t *testing.T) {
 	// shadowea cualquier matcher de fallo registrado después. Consumable=true
 	// para que solo el POST adding che:plan falle, los demás (Lock/Unlock,
 	// transiciones previas) caen al catch-all subsiguiente.
-	env.ExpectGh(`^api -X POST repos/\{owner\}/\{repo\}/issues/42/labels.*labels\[\]=che:plan(\s|$)`).
+	env.ExpectGh(`^api -X POST repos/\{owner\}/\{repo\}/issues/42/labels.*labels\[\]=che:state:explore(\s|$)`).
 		Consumable().
 		RespondExitWithError(1, "422 validation failed\n")
 	scriptExplorePrechecks(env)
@@ -636,8 +636,8 @@ func TestExplore_MissingConsolidatedPlan_Exit3(t *testing.T) {
 	}
 	for _, e := range inv.For("gh") {
 		joined := strings.Join(e.Args, " ")
-		if strings.Contains(joined, "--add-label che:plan ") || strings.HasSuffix(joined, "--add-label che:plan") {
-			t.Fatalf("transition to che:plan should NOT happen on missing consolidated_plan: %v", e.Args)
+		if strings.Contains(joined, "--add-label che:state:explore ") || strings.HasSuffix(joined, "--add-label che:state:explore") {
+			t.Fatalf("transition to che:state:explore should NOT happen on missing consolidated_plan: %v", e.Args)
 		}
 	}
 }

--- a/e2e/explore_test.go
+++ b/e2e/explore_test.go
@@ -261,6 +261,54 @@ func TestExplore_IssueMissingCtPlan_WithPreexistingStatus_PreservesStatus(t *tes
 	}
 }
 
+// TestExplore_OldV1Label_Exit3_NoMixedState: issue de un repo no migrado a
+// labels v2 (tiene `che:idea` viejo en vez de `che:state:idea`). El gate
+// debe rechazarlo con un mensaje accionable que mencione la migración —
+// si lo dejara pasar, el `Apply(StateIdea, StateApplyingExplore)` siguiente
+// haría un remove no-op del label v2 inexistente y agregaría
+// `che:state:applying:explore`, dejando el issue con `che:idea` (v1) +
+// `che:state:applying:explore` (v2) simultáneos: estado mixto que no es
+// válido en ninguna de las dos máquinas.
+//
+// Asserts: exit 3, sin POST/DELETE de labels (no hay transición), sin
+// llamadas al agente. El stderr menciona "v1" y/o "migrate" para que el
+// operador sepa qué hacer.
+func TestExplore_OldV1Label_Exit3_NoMixedState(t *testing.T) {
+	t.Parallel()
+	env := harness.New(t)
+	scriptExplorePrechecks(env)
+	env.ExpectGh(`^issue view 88`).RespondStdoutFromFixture("explore/gh_issue_view_old_label_che_idea.json", 0)
+
+	r := env.Run("explore", "88")
+	if r.ExitCode != 3 {
+		t.Fatalf("expected exit 3 (gate rechaza labels v1), got %d\nstderr: %s", r.ExitCode, r.Stderr)
+	}
+	harness.AssertContains(t, r.Stderr, "v1")
+
+	inv := env.Invocations()
+	// Ningún agente invocado: el gate corta antes.
+	inv.AssertNotCalled(t, "claude")
+	inv.AssertNotCalled(t, "codex")
+	inv.AssertNotCalled(t, "gemini")
+	// Ninguna transición de máquina de estados (POST/DELETE labels al
+	// issue 88) — no queremos dejar el issue con labels mixtos v1+v2.
+	posts := inv.FindCalls("gh", "api", "-X", "POST", "issues/88/labels")
+	if len(posts) > 0 {
+		t.Fatalf("no debería haber POST de labels (gate rechaza); calls=%v", posts)
+	}
+	deletes := findLabelDeletes(inv, 88)
+	if len(deletes) > 0 {
+		t.Fatalf("no debería haber DELETE de labels (gate rechaza); calls=%v", deletes)
+	}
+	// Sin comment ni body edit.
+	if comments := inv.FindCalls("gh", "issue", "comment", "--body-file"); len(comments) > 0 {
+		t.Fatalf("no debería haber comment (gate rechaza); calls=%v", comments)
+	}
+	if edits := inv.FindCalls("gh", "issue", "edit", "88", "--body-file"); len(edits) > 0 {
+		t.Fatalf("no debería haber body edit (gate rechaza); calls=%v", edits)
+	}
+}
+
 // TestExplore_IssueClosed_Exit3: issue is CLOSED → exit 3.
 func TestExplore_IssueClosed_Exit3(t *testing.T) {
 	t.Parallel()

--- a/e2e/idea_test.go
+++ b/e2e/idea_test.go
@@ -55,7 +55,7 @@ func TestIdea_GoldenPath_Single(t *testing.T) {
 		WhenArgsMatch(`-p`).
 		CaptureStdin().
 		RespondStdoutFromFixture("idea/sonnet_single.json", 0)
-	env.ExpectGh(`^issue create .*che:idea`).
+	env.ExpectGh(`^issue create .*che:state:idea`).
 		Consumable().
 		RespondStdout("https://github.com/acme/demo/issues/47\n", 0)
 
@@ -70,7 +70,7 @@ func TestIdea_GoldenPath_Single(t *testing.T) {
 	creates[0].AssertArgsContain(t,
 		"--label", "type:feature",
 		"--label", "size:m",
-		"--label", "che:idea",
+		"--label", "che:state:idea",
 		"--label", "ct:plan")
 }
 

--- a/e2e/testdata/execute/gh_issue_view_executing.json
+++ b/e2e/testdata/execute/gh_issue_view_executing.json
@@ -6,6 +6,6 @@
   "state": "OPEN",
   "labels": [
     {"name": "ct:plan"},
-    {"name": "che:executing"}
+    {"name": "che:state:applying:execute"}
   ]
 }

--- a/e2e/testdata/execute/gh_issue_view_locked_executing.json
+++ b/e2e/testdata/execute/gh_issue_view_locked_executing.json
@@ -6,7 +6,7 @@
   "state": "OPEN",
   "labels": [
     {"name": "ct:plan"},
-    {"name": "che:executing"},
+    {"name": "che:state:applying:execute"},
     {"name": "type:feature"},
     {"name": "size:l"}
   ]

--- a/e2e/testdata/execute/gh_issue_view_no_longer_executing.json
+++ b/e2e/testdata/execute/gh_issue_view_no_longer_executing.json
@@ -6,7 +6,7 @@
   "state": "OPEN",
   "labels": [
     {"name": "ct:plan"},
-    {"name": "che:plan"},
+    {"name": "che:state:explore"},
     {"name": "type:feature"},
     {"name": "size:l"}
   ]

--- a/e2e/testdata/execute/gh_issue_view_plan_validated_changes_requested.json
+++ b/e2e/testdata/execute/gh_issue_view_plan_validated_changes_requested.json
@@ -6,7 +6,7 @@
   "state": "OPEN",
   "labels": [
     {"name": "ct:plan"},
-    {"name": "che:plan"},
+    {"name": "che:state:explore"},
     {"name": "plan-validated:changes-requested"}
   ]
 }

--- a/e2e/testdata/execute/gh_issue_view_plan_validated_needs_human.json
+++ b/e2e/testdata/execute/gh_issue_view_plan_validated_needs_human.json
@@ -6,7 +6,7 @@
   "state": "OPEN",
   "labels": [
     {"name": "ct:plan"},
-    {"name": "che:plan"},
+    {"name": "che:state:explore"},
     {"name": "plan-validated:needs-human"}
   ]
 }

--- a/e2e/testdata/execute/gh_issue_view_ready.json
+++ b/e2e/testdata/execute/gh_issue_view_ready.json
@@ -6,7 +6,7 @@
   "state": "OPEN",
   "labels": [
     {"name": "ct:plan"},
-    {"name": "che:plan"},
+    {"name": "che:state:explore"},
     {"name": "type:feature"},
     {"name": "size:l"}
   ]

--- a/e2e/testdata/explore/gh_issue_view_already_planned.json
+++ b/e2e/testdata/explore/gh_issue_view_already_planned.json
@@ -1,12 +1,12 @@
 {
   "number": 42,
   "title": "Ya fue explorado en un run anterior",
-  "body": "El flow explore ya corrió sobre este issue: tiene che:plan.\n",
+  "body": "El flow explore ya corrió sobre este issue: tiene che:state:explore.\n",
   "url": "https://github.com/acme/demo/issues/42",
   "state": "OPEN",
   "labels": [
     {"name": "ct:plan"},
-    {"name": "che:plan"},
+    {"name": "che:state:explore"},
     {"name": "type:feature"},
     {"name": "size:m"}
   ]

--- a/e2e/testdata/explore/gh_issue_view_closed.json
+++ b/e2e/testdata/explore/gh_issue_view_closed.json
@@ -6,7 +6,7 @@
   "state": "CLOSED",
   "labels": [
     {"name": "ct:plan"},
-    {"name": "che:idea"},
+    {"name": "che:state:idea"},
     {"name": "type:feature"},
     {"name": "size:m"}
   ]

--- a/e2e/testdata/explore/gh_issue_view_old_label_che_idea.json
+++ b/e2e/testdata/explore/gh_issue_view_old_label_che_idea.json
@@ -1,0 +1,13 @@
+{
+  "number": 88,
+  "title": "Issue de un repo no migrado: tiene che:idea (v1) en vez de che:state:idea",
+  "body": "## Idea\nUn repo que arrancó con la máquina vieja y todavía no corrió `migrate-labels-v2`.\n",
+  "url": "https://github.com/acme/demo/issues/88",
+  "state": "OPEN",
+  "labels": [
+    {"name": "ct:plan"},
+    {"name": "che:idea"},
+    {"name": "type:feature"},
+    {"name": "size:m"}
+  ]
+}

--- a/e2e/testdata/explore/gh_issue_view_status_without_ctplan.json
+++ b/e2e/testdata/explore/gh_issue_view_status_without_ctplan.json
@@ -1,12 +1,12 @@
 {
   "number": 55,
-  "title": "Issue con che:plan preexistente sin ct:plan",
-  "body": "Alguien editó labels a mano y dejó che:plan sin ct:plan.\n",
+  "title": "Issue con che:state:explore preexistente sin ct:plan",
+  "body": "Alguien editó labels a mano y dejó che:state:explore sin ct:plan.\n",
   "url": "https://github.com/acme/demo/issues/55",
   "state": "OPEN",
   "labels": [
     {"name": "type:feature"},
     {"name": "size:m"},
-    {"name": "che:plan"}
+    {"name": "che:state:explore"}
   ]
 }

--- a/e2e/testdata/explore/gh_issue_view_with_ctplan.json
+++ b/e2e/testdata/explore/gh_issue_view_with_ctplan.json
@@ -6,7 +6,7 @@
   "state": "OPEN",
   "labels": [
     {"name": "ct:plan"},
-    {"name": "che:idea"},
+    {"name": "che:state:idea"},
     {"name": "type:feature"},
     {"name": "size:m"}
   ]

--- a/internal/flow/execute/execute.go
+++ b/internal/flow/execute/execute.go
@@ -371,6 +371,14 @@ func Run(issueRef string, opts Opts) ExitCode {
 	// progreso: 2) git worktree remove --force, 3) git branch -D. Los
 	// errores de esos pasos se propagan para loguearlos — best-effort pero
 	// NO silencioso.
+	//
+	// TODO(coverage): las 3 ramas de label handling (executedApplied,
+	// prCreated, default rollback) hoy solo se ejercitan via los tests e2e
+	// que cubren los happy paths. Para tests unitarios directos hay que
+	// extraer cleanupLocal a una función a nivel paquete con dependencias
+	// inyectables (labels.Apply / fetchIssue / wt.Cleanup como interfaces o
+	// callbacks). El refactor toca muchas signatures y se quedó fuera del
+	// scope de PR6b; queda para un PR de coverage post-PR6c.
 	cleanupLocal := func(cause string) {
 		if cleanupDone {
 			return

--- a/internal/flow/execute/execute.go
+++ b/internal/flow/execute/execute.go
@@ -31,6 +31,7 @@ import (
 	"github.com/chichex/che/internal/agent"
 	"github.com/chichex/che/internal/labels"
 	"github.com/chichex/che/internal/output"
+	"github.com/chichex/che/internal/pipelinelabels"
 	planpkg "github.com/chichex/che/internal/plan"
 )
 
@@ -335,12 +336,12 @@ func Run(issueRef string, opts Opts) ExitCode {
 		}
 	}()
 
-	// Transition <from> → che:executing. Desde acá se lockea el issue
+	// Transition <from> → applying:execute. Desde acá se lockea el issue
 	// (también vía che:* — redundante con che:locked pero preservado porque
 	// el listado de candidatos y el gate ya dependen de la máquina de
 	// estados).
-	progress("transicionando issue a che:executing…")
-	if err := labels.Apply(issueRef, from, labels.CheExecuting); err != nil {
+	progress("transicionando issue a " + pipelinelabels.StateApplyingExecute + "…")
+	if err := labels.Apply(issueRef, from, pipelinelabels.StateApplyingExecute); err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return ExitRetry
 	}
@@ -381,9 +382,11 @@ func Run(issueRef string, opts Opts) ExitCode {
 		if cause != "" {
 			switch {
 			case executedApplied:
-				fmt.Fprintf(stderr, "%s — limpiando localmente (worktree, branch; label queda en che:executed)…\n", cause)
+				fmt.Fprintf(stderr, "%s — limpiando localmente (worktree, branch; label queda en %s)…\n",
+					cause, pipelinelabels.StateExecute)
 			case prCreated:
-				fmt.Fprintf(stderr, "%s — limpiando localmente (label → che:executed por PR vivo, worktree, branch)…\n", cause)
+				fmt.Fprintf(stderr, "%s — limpiando localmente (label → %s por PR vivo, worktree, branch)…\n",
+					cause, pipelinelabels.StateExecute)
 			default:
 				fmt.Fprintf(stderr, "%s — limpiando localmente (label → %s, worktree, branch)…\n", cause, from)
 			}
@@ -394,11 +397,12 @@ func Run(issueRef string, opts Opts) ExitCode {
 			rollbackCtx, rollbackCancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer rollbackCancel()
 			if prCreated {
-				// PR ya creado: dejar el issue en executed para preservar
+				// PR ya creado: dejar el issue en execute para preservar
 				// consistencia con el estado remoto. Best-effort; si falla,
 				// warneamos.
-				if err := labels.Apply(issueRef, labels.CheExecuting, labels.CheExecuted); err != nil {
-					fmt.Fprintf(stderr, "warning: no se pudo transicionar a che:executed tras señal post-PR: %v — revisá labels a mano\n", err)
+				if err := labels.Apply(issueRef, pipelinelabels.StateApplyingExecute, pipelinelabels.StateExecute); err != nil {
+					fmt.Fprintf(stderr, "warning: no se pudo transicionar a %s tras señal post-PR: %v — revisá labels a mano\n",
+						pipelinelabels.StateExecute, err)
 				}
 			} else {
 				// Sin PR todavía: rollback al `from`, pero solo si seguimos
@@ -407,10 +411,11 @@ func Run(issueRef string, opts Opts) ExitCode {
 				current, fetchErr := fetchIssue(rollbackCtx, issueRef)
 				if fetchErr != nil {
 					fmt.Fprintf(stderr, "warning: rollback no aplicado: no se pudo re-fetch el issue (%v) — revisá labels a mano\n", fetchErr)
-				} else if !current.HasLabel(labels.CheExecuting) {
-					fmt.Fprintln(stderr, "rollback abortado: el issue ya no está en che:executing (owner=otro)")
+				} else if !current.HasLabel(pipelinelabels.StateApplyingExecute) {
+					fmt.Fprintf(stderr, "rollback abortado: el issue ya no está en %s (owner=otro)\n",
+						pipelinelabels.StateApplyingExecute)
 				} else {
-					if err := labels.Apply(issueRef, labels.CheExecuting, from); err != nil {
+					if err := labels.Apply(issueRef, pipelinelabels.StateApplyingExecute, from); err != nil {
 						fmt.Fprintf(stderr, "warning: rollback failed: %v — revisá labels del issue a mano\n", err)
 					}
 				}
@@ -539,14 +544,14 @@ func Run(issueRef string, opts Opts) ExitCode {
 		prCreated = true
 	}
 
-	// Transición a che:executed. Sin validadores automáticos; el label
+	// Transición a execute (terminal). Sin validadores automáticos; el label
 	// refleja "ejecución terminada". Orden importante: una señal entre
 	// `prCreated=true` y `executedApplied=true` dejaría al cleanup en modo
-	// "PR vivo + label en executing", que forzaría un label fix-up en el
-	// defer. Transicionar ya mismo encoge la ventana a mínimo y deja al
+	// "PR vivo + label en applying:execute", que forzaría un label fix-up en
+	// el defer. Transicionar ya mismo encoge la ventana a mínimo y deja al
 	// issue en el estado consistente con el PR remoto.
-	progress("transicionando issue a che:executed…")
-	if err := labels.Apply(issueRef, labels.CheExecuting, labels.CheExecuted); err != nil {
+	progress("transicionando issue a " + pipelinelabels.StateExecute + "…")
+	if err := labels.Apply(issueRef, pipelinelabels.StateApplyingExecute, pipelinelabels.StateExecute); err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return ExitRetry
 	}
@@ -576,7 +581,7 @@ func Run(issueRef string, opts Opts) ExitCode {
 func ListCandidates() ([]Candidate, error) {
 	cmd := exec.Command("gh", "issue", "list",
 		"--label", labels.CtPlan,
-		"--label", labels.ChePlan,
+		"--label", pipelinelabels.StateExplore,
 		"--state", "open",
 		"--json", "number,title,labels",
 		"--limit", "50")
@@ -726,18 +731,18 @@ func gate(i *Issue) error {
 	if !i.HasLabel(labels.CtPlan) {
 		return fmt.Errorf("issue #%d is missing label ct:plan (not created by `che idea`?)", i.Number)
 	}
-	if i.HasLabel(labels.CheExecuting) {
-		return fmt.Errorf("issue #%d ya está en che:executing — otro run en curso o quedó colgado; quitá el label a mano si es lo segundo", i.Number)
+	if i.HasLabel(pipelinelabels.StateApplyingExecute) {
+		return fmt.Errorf("issue #%d ya está en %s — otro run en curso o quedó colgado; quitá el label a mano si es lo segundo", i.Number, pipelinelabels.StateApplyingExecute)
 	}
-	// "Más avanzado" post che:validated: estados donde execute no tiene
+	// "Más avanzado" post validate_pr: estados donde execute no tiene
 	// sentido porque ya hay PR abierto / mergeado / issue cerrado. NO
-	// incluimos CheValidated: ese es un punto de entrada válido al flow
+	// incluimos StateValidatePR: ese es un punto de entrada válido al flow
 	// post-validate plan (issue con plan-validated:approve).
 	for _, beyond := range []string{
-		labels.CheExecuted,
-		labels.CheValidating,
-		labels.CheClosing,
-		labels.CheClosed,
+		pipelinelabels.StateExecute,
+		pipelinelabels.StateApplyingValidatePR,
+		pipelinelabels.StateApplyingClose,
+		pipelinelabels.StateClose,
 	} {
 		if i.HasLabel(beyond) {
 			return fmt.Errorf("issue #%d ya avanzó en el pipeline (%s presente) — execute no aplica", i.Number, beyond)
@@ -752,8 +757,9 @@ func gate(i *Issue) error {
 	if i.HasLabel(labels.PlanValidatedNeedsHuman) {
 		return fmt.Errorf("issue #%d tiene plan-validated:needs-human — resolvé a mano antes de ejecutar", i.Number)
 	}
-	if !i.HasLabel(labels.CheIdea) && !i.HasLabel(labels.ChePlan) && !i.HasLabel(labels.CheValidated) {
-		return fmt.Errorf("issue #%d no está en che:idea, che:plan ni che:validated — corré `che explore %d` o `che validate %d` según el flow", i.Number, i.Number, i.Number)
+	if !i.HasLabel(pipelinelabels.StateIdea) && !i.HasLabel(pipelinelabels.StateExplore) && !i.HasLabel(pipelinelabels.StateValidatePR) {
+		return fmt.Errorf("issue #%d no está en %s, %s ni %s — corré `che explore %d` o `che validate %d` según el flow",
+			i.Number, pipelinelabels.StateIdea, pipelinelabels.StateExplore, pipelinelabels.StateValidatePR, i.Number, i.Number)
 	}
 	return nil
 }
@@ -777,7 +783,7 @@ func seedAdoptLabels(ref string, issue *Issue) error {
 	}
 	toAdd := []string{labels.CtPlan}
 	if !hasCheState {
-		toAdd = append(toAdd, labels.CheIdea)
+		toAdd = append(toAdd, pipelinelabels.StateIdea)
 	}
 	for _, l := range toAdd {
 		if err := labels.Ensure(l); err != nil {
@@ -798,21 +804,22 @@ func seedAdoptLabels(ref string, issue *Issue) error {
 }
 
 // fromState devuelve el estado de origen del issue al momento del gate
-// (che:idea, che:plan o che:validated). Prioridad en caso de ambigüedad
-// (issues con más de un label che:* — no debería pasar post-transición,
-// pero defensa): validated > plan > idea. El más avanzado gana para que
-// el rollback restaure el estado más útil y la transición de lock parta
-// de una clave válida en validTransitions. Los 3 tienen entry en la
-// máquina: che:idea → executing, che:plan → executing, che:validated →
-// executing; y los 3 rollbacks inversos.
+// (idea, explore o validate_pr — modelo v2). Prioridad en caso de
+// ambigüedad (issues con más de un label che:state:* — no debería pasar
+// post-transición, pero defensa): validate_pr > explore > idea. El más
+// avanzado gana para que el rollback restaure el estado más útil y la
+// transición de lock parta de una clave válida en validTransitions. Los 3
+// tienen entry en la máquina: idea → applying:execute, explore →
+// applying:execute, validate_pr → applying:execute; y los 3 rollbacks
+// inversos.
 func fromState(i *Issue) string {
-	if i.HasLabel(labels.CheValidated) {
-		return labels.CheValidated
+	if i.HasLabel(pipelinelabels.StateValidatePR) {
+		return pipelinelabels.StateValidatePR
 	}
-	if i.HasLabel(labels.ChePlan) {
-		return labels.ChePlan
+	if i.HasLabel(pipelinelabels.StateExplore) {
+		return pipelinelabels.StateExplore
 	}
-	return labels.CheIdea
+	return pipelinelabels.StateIdea
 }
 
 // ---- prompt builder ----

--- a/internal/flow/execute/execute_test.go
+++ b/internal/flow/execute/execute_test.go
@@ -27,35 +27,35 @@ func TestGate(t *testing.T) {
 		{
 			name: "ok plan",
 			issue: Issue{Number: 1, State: "OPEN", Labels: []Label{
-				{Name: "ct:plan"}, {Name: "che:plan"},
+				{Name: "ct:plan"}, {Name: "che:state:explore"},
 			}},
 			wantErr: "",
 		},
 		{
 			name: "ok idea (skip explore)",
 			issue: Issue{Number: 1, State: "OPEN", Labels: []Label{
-				{Name: "ct:plan"}, {Name: "che:idea"},
+				{Name: "ct:plan"}, {Name: "che:state:idea"},
 			}},
 			wantErr: "",
 		},
 		{
 			name: "ok with plan-validated:approve",
 			issue: Issue{Number: 1, State: "OPEN", Labels: []Label{
-				{Name: "ct:plan"}, {Name: "che:plan"}, {Name: "plan-validated:approve"},
+				{Name: "ct:plan"}, {Name: "che:state:explore"}, {Name: "plan-validated:approve"},
 			}},
 			wantErr: "",
 		},
 		{
 			name: "ok validated + plan-validated:approve (post-validate path)",
 			issue: Issue{Number: 1, State: "OPEN", Labels: []Label{
-				{Name: "ct:plan"}, {Name: "che:validated"}, {Name: "plan-validated:approve"},
+				{Name: "ct:plan"}, {Name: "che:state:validate_pr"}, {Name: "plan-validated:approve"},
 			}},
 			wantErr: "",
 		},
 		{
 			name: "ok validated sin plan-validated:* explícito (defensa)",
 			issue: Issue{Number: 1, State: "OPEN", Labels: []Label{
-				{Name: "ct:plan"}, {Name: "che:validated"},
+				{Name: "ct:plan"}, {Name: "che:state:validate_pr"},
 			}},
 			wantErr: "",
 		},
@@ -66,48 +66,48 @@ func TestGate(t *testing.T) {
 		},
 		{
 			name:    "missing ct:plan",
-			issue:   Issue{Number: 1, State: "OPEN", Labels: []Label{{Name: "che:plan"}}},
+			issue:   Issue{Number: 1, State: "OPEN", Labels: []Label{{Name: "che:state:explore"}}},
 			wantErr: "ct:plan",
 		},
 		{
 			name: "executing lock",
 			issue: Issue{Number: 1, State: "OPEN", Labels: []Label{
-				{Name: "ct:plan"}, {Name: "che:executing"},
+				{Name: "ct:plan"}, {Name: "che:state:applying:execute"},
 			}},
-			wantErr: "executing",
+			wantErr: "che:state:applying:execute",
 		},
 		{
 			name: "already executed",
 			issue: Issue{Number: 1, State: "OPEN", Labels: []Label{
-				{Name: "ct:plan"}, {Name: "che:executed"},
+				{Name: "ct:plan"}, {Name: "che:state:execute"},
 			}},
-			wantErr: "che:executed",
+			wantErr: "che:state:execute",
 		},
 		{
 			name: "already validating (otro flow en curso)",
 			issue: Issue{Number: 1, State: "OPEN", Labels: []Label{
-				{Name: "ct:plan"}, {Name: "che:validating"},
+				{Name: "ct:plan"}, {Name: "che:state:applying:validate_pr"},
 			}},
-			wantErr: "che:validating",
+			wantErr: "che:state:applying:validate_pr",
 		},
 		{
 			name: "already closing",
 			issue: Issue{Number: 1, State: "OPEN", Labels: []Label{
-				{Name: "ct:plan"}, {Name: "che:closing"},
+				{Name: "ct:plan"}, {Name: "che:state:applying:close"},
 			}},
-			wantErr: "che:closing",
+			wantErr: "che:state:applying:close",
 		},
 		{
 			name: "already closed",
 			issue: Issue{Number: 1, State: "OPEN", Labels: []Label{
-				{Name: "ct:plan"}, {Name: "che:closed"},
+				{Name: "ct:plan"}, {Name: "che:state:close"},
 			}},
-			wantErr: "che:closed",
+			wantErr: "che:state:close",
 		},
 		{
 			name: "plan-validated:changes-requested blocks",
 			issue: Issue{Number: 42, State: "OPEN", Labels: []Label{
-				{Name: "ct:plan"}, {Name: "che:plan"},
+				{Name: "ct:plan"}, {Name: "che:state:explore"},
 				{Name: "plan-validated:changes-requested"},
 			}},
 			wantErr: "plan-validated:changes-requested",
@@ -115,7 +115,7 @@ func TestGate(t *testing.T) {
 		{
 			name: "plan-validated:changes-requested blocks incluso en validated",
 			issue: Issue{Number: 42, State: "OPEN", Labels: []Label{
-				{Name: "ct:plan"}, {Name: "che:validated"},
+				{Name: "ct:plan"}, {Name: "che:state:validate_pr"},
 				{Name: "plan-validated:changes-requested"},
 			}},
 			wantErr: "plan-validated:changes-requested",
@@ -123,7 +123,7 @@ func TestGate(t *testing.T) {
 		{
 			name: "plan-validated:needs-human blocks",
 			issue: Issue{Number: 42, State: "OPEN", Labels: []Label{
-				{Name: "ct:plan"}, {Name: "che:plan"},
+				{Name: "ct:plan"}, {Name: "che:state:explore"},
 				{Name: "plan-validated:needs-human"},
 			}},
 			wantErr: "plan-validated:needs-human",
@@ -133,7 +133,7 @@ func TestGate(t *testing.T) {
 			issue: Issue{Number: 1, State: "OPEN", Labels: []Label{
 				{Name: "ct:plan"},
 			}},
-			wantErr: "no está en che:idea, che:plan ni che:validated",
+			wantErr: "no está en che:state:idea, che:state:explore ni che:state:validate_pr",
 		},
 	}
 	for _, c := range cases {
@@ -160,7 +160,7 @@ func TestGate(t *testing.T) {
 // rechazado — evita tener que consultar el manual.
 func TestGate_ChangesRequestedErrorMentionsIterate(t *testing.T) {
 	issue := Issue{Number: 42, State: "OPEN", Labels: []Label{
-		{Name: "ct:plan"}, {Name: "che:plan"},
+		{Name: "ct:plan"}, {Name: "che:state:explore"},
 		{Name: "plan-validated:changes-requested"},
 	}}
 	err := gate(&issue)
@@ -185,38 +185,38 @@ func TestFromState(t *testing.T) {
 	}{
 		{
 			name:   "solo idea",
-			issue:  Issue{Labels: []Label{{Name: "che:idea"}}},
-			wantFr: "che:idea",
+			issue:  Issue{Labels: []Label{{Name: "che:state:idea"}}},
+			wantFr: "che:state:idea",
 		},
 		{
 			name:   "solo plan",
-			issue:  Issue{Labels: []Label{{Name: "che:plan"}}},
-			wantFr: "che:plan",
+			issue:  Issue{Labels: []Label{{Name: "che:state:explore"}}},
+			wantFr: "che:state:explore",
 		},
 		{
 			name:   "solo validated",
-			issue:  Issue{Labels: []Label{{Name: "che:validated"}}},
-			wantFr: "che:validated",
+			issue:  Issue{Labels: []Label{{Name: "che:state:validate_pr"}}},
+			wantFr: "che:state:validate_pr",
 		},
 		{
 			name:   "validated gana sobre plan",
-			issue:  Issue{Labels: []Label{{Name: "che:plan"}, {Name: "che:validated"}}},
-			wantFr: "che:validated",
+			issue:  Issue{Labels: []Label{{Name: "che:state:explore"}, {Name: "che:state:validate_pr"}}},
+			wantFr: "che:state:validate_pr",
 		},
 		{
 			name:   "validated gana sobre idea",
-			issue:  Issue{Labels: []Label{{Name: "che:idea"}, {Name: "che:validated"}}},
-			wantFr: "che:validated",
+			issue:  Issue{Labels: []Label{{Name: "che:state:idea"}, {Name: "che:state:validate_pr"}}},
+			wantFr: "che:state:validate_pr",
 		},
 		{
 			name:   "plan gana sobre idea",
-			issue:  Issue{Labels: []Label{{Name: "che:idea"}, {Name: "che:plan"}}},
-			wantFr: "che:plan",
+			issue:  Issue{Labels: []Label{{Name: "che:state:idea"}, {Name: "che:state:explore"}}},
+			wantFr: "che:state:explore",
 		},
 		{
 			name:   "default idea si no hay ninguno (defensa, no debería pasar post-gate)",
 			issue:  Issue{Labels: []Label{}},
-			wantFr: "che:idea",
+			wantFr: "che:state:idea",
 		},
 	}
 	for _, c := range cases {

--- a/internal/flow/explore/explore.go
+++ b/internal/flow/explore/explore.go
@@ -657,12 +657,37 @@ func reclassifyIssue(ref string, issue *Issue, log *output.Logger) error {
 // gateBasic valida las precondiciones: open + ct:plan + NO está más allá
 // de che:idea (planning/plan/executing/executed/validating/validated/
 // closing/closed → el issue ya avanzó en el pipeline, explore no aplica).
+//
+// También rechaza issues con labels del modelo viejo (`che:idea`,
+// `che:plan`, …): el flow migrado a v2 escribe `che:state:*` y no sabe
+// hacer migración in-place del label viejo, así que dejarlo correr
+// produciría un estado mixto (v1 + v2 simultáneos) ilegal en ambas
+// máquinas. La migración de repos vivos vive en `migrate-labels-v2`
+// (subcomando dedicado, fuera del scope de PR6b).
 func gateBasic(i *Issue) error {
 	if i.State != "OPEN" {
 		return fmt.Errorf("issue #%d is closed", i.Number)
 	}
 	if !i.HasLabel(labels.CtPlan) {
 		return fmt.Errorf("issue #%d is missing label ct:plan (not created by `che idea`?)", i.Number)
+	}
+	// Detectar labels v1 (modelo viejo) antes de avanzar — si el repo
+	// no corrió migrate-labels-v2, mezclar v1+v2 deja al issue en estado
+	// inconsistente.
+	for _, v1 := range []string{
+		labels.CheIdea,
+		labels.ChePlanning,
+		labels.ChePlan,
+		labels.CheExecuting,
+		labels.CheExecuted,
+		labels.CheValidating,
+		labels.CheValidated,
+		labels.CheClosing,
+		labels.CheClosed,
+	} {
+		if i.HasLabel(v1) {
+			return fmt.Errorf("issue #%d tiene labels v1 (%s); este flow opera sobre el modelo v2 (`che:state:*`). Corré `migrate-labels-v2` (cuando exista) antes de explorar, o ajustá los labels a mano", i.Number, v1)
+		}
 	}
 	for _, beyond := range []string{
 		pipelinelabels.StateApplyingExplore,

--- a/internal/flow/explore/explore.go
+++ b/internal/flow/explore/explore.go
@@ -22,6 +22,7 @@ import (
 	"github.com/chichex/che/internal/flow/idea"
 	"github.com/chichex/che/internal/labels"
 	"github.com/chichex/che/internal/output"
+	"github.com/chichex/che/internal/pipelinelabels"
 	"github.com/chichex/che/internal/plan"
 )
 
@@ -354,10 +355,11 @@ func Run(issueRef string, opts Opts) ExitCode {
 		}
 	}()
 
-	// Transición idea → planning (lock de máquina de estados). El rollback
-	// (planning → idea) lo hace el defer si succeeded queda en false.
-	progress("transicionando label a che:planning…")
-	if err := labels.Apply(issueRef, labels.CheIdea, labels.ChePlanning); err != nil {
+	// Transición idea → applying:explore (lock de máquina de estados). El
+	// rollback (applying:explore → idea) lo hace el defer si succeeded queda
+	// en false.
+	progress("transicionando label a " + pipelinelabels.StateApplyingExplore + "…")
+	if err := labels.Apply(issueRef, pipelinelabels.StateIdea, pipelinelabels.StateApplyingExplore); err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return ExitRetry
 	}
@@ -366,8 +368,9 @@ func Run(issueRef string, opts Opts) ExitCode {
 		if succeeded {
 			return
 		}
-		if err := labels.Apply(issueRef, labels.ChePlanning, labels.CheIdea); err != nil {
-			fmt.Fprintf(stderr, "warning: rollback che:planning → che:idea fallo: %v — revisá labels a mano\n", err)
+		if err := labels.Apply(issueRef, pipelinelabels.StateApplyingExplore, pipelinelabels.StateIdea); err != nil {
+			fmt.Fprintf(stderr, "warning: rollback %s → %s fallo: %v — revisá labels a mano\n",
+				pipelinelabels.StateApplyingExplore, pipelinelabels.StateIdea, err)
 		}
 	}()
 
@@ -407,8 +410,8 @@ func Run(issueRef string, opts Opts) ExitCode {
 		return ExitRetry
 	}
 
-	progress("transicionando label a che:plan…")
-	if err := labels.Apply(issueRef, labels.ChePlanning, labels.ChePlan); err != nil {
+	progress("transicionando label a " + pipelinelabels.StateExplore + "…")
+	if err := labels.Apply(issueRef, pipelinelabels.StateApplyingExplore, pipelinelabels.StateExplore); err != nil {
 		fmt.Fprintf(stderr, "error: editing labels: %v\n", err)
 		fmt.Fprintf(stderr, "warning: comentario posteado (%s) pero label no cambió; corré de nuevo o editá a mano\n", commentURL)
 		return ExitRetry
@@ -488,14 +491,14 @@ func filterCandidates(issues []Issue) []Candidate {
 			continue // otro flow lo tiene agarrado.
 		}
 		if i.HasLabel(labels.CtPlan) {
-			if i.HasLabel(labels.ChePlanning) ||
-				i.HasLabel(labels.ChePlan) ||
-				i.HasLabel(labels.CheExecuting) ||
-				i.HasLabel(labels.CheExecuted) ||
-				i.HasLabel(labels.CheValidating) ||
-				i.HasLabel(labels.CheValidated) ||
-				i.HasLabel(labels.CheClosing) ||
-				i.HasLabel(labels.CheClosed) {
+			if i.HasLabel(pipelinelabels.StateApplyingExplore) ||
+				i.HasLabel(pipelinelabels.StateExplore) ||
+				i.HasLabel(pipelinelabels.StateApplyingExecute) ||
+				i.HasLabel(pipelinelabels.StateExecute) ||
+				i.HasLabel(pipelinelabels.StateApplyingValidatePR) ||
+				i.HasLabel(pipelinelabels.StateValidatePR) ||
+				i.HasLabel(pipelinelabels.StateApplyingClose) ||
+				i.HasLabel(pipelinelabels.StateClose) {
 				continue
 			}
 			cheIdeas = append(cheIdeas, Candidate{Number: i.Number, Title: i.Title})
@@ -614,7 +617,7 @@ func reclassifyIssue(ref string, issue *Issue, log *output.Logger) error {
 
 	toAdd := []string{labels.CtPlan}
 	if !hasStatus {
-		toAdd = append(toAdd, labels.CheIdea)
+		toAdd = append(toAdd, pipelinelabels.StateIdea)
 	} else {
 		log.Warn("issue con che:* preexistente sin ct:plan; preservando el estado actual",
 			output.F{Issue: issue.Number})
@@ -662,14 +665,14 @@ func gateBasic(i *Issue) error {
 		return fmt.Errorf("issue #%d is missing label ct:plan (not created by `che idea`?)", i.Number)
 	}
 	for _, beyond := range []string{
-		labels.ChePlanning,
-		labels.ChePlan,
-		labels.CheExecuting,
-		labels.CheExecuted,
-		labels.CheValidating,
-		labels.CheValidated,
-		labels.CheClosing,
-		labels.CheClosed,
+		pipelinelabels.StateApplyingExplore,
+		pipelinelabels.StateExplore,
+		pipelinelabels.StateApplyingExecute,
+		pipelinelabels.StateExecute,
+		pipelinelabels.StateApplyingValidatePR,
+		pipelinelabels.StateValidatePR,
+		pipelinelabels.StateApplyingClose,
+		pipelinelabels.StateClose,
 	} {
 		if i.HasLabel(beyond) {
 			return fmt.Errorf("issue #%d ya avanzó en el pipeline (%s presente) — explore no aplica", i.Number, beyond)

--- a/internal/flow/explore/explore_test.go
+++ b/internal/flow/explore/explore_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/chichex/che/internal/pipelinelabels"
 	"github.com/chichex/che/internal/plan"
 )
 
@@ -177,7 +178,8 @@ func TestGateBasic(t *testing.T) {
 		{
 			name: "ok",
 			issue: Issue{Number: 1, State: "OPEN", Labels: []Label{
-				{Name: "ct:plan"}, {Name: "che:idea"},
+				// Post-PR6b: el path feliz arranca con label v2.
+				{Name: "ct:plan"}, {Name: pipelinelabels.StateIdea},
 			}},
 			wantErr: "",
 		},
@@ -188,7 +190,7 @@ func TestGateBasic(t *testing.T) {
 		},
 		{
 			name:    "missing ct:plan",
-			issue:   Issue{Number: 1, State: "OPEN", Labels: []Label{{Name: "che:idea"}}},
+			issue:   Issue{Number: 1, State: "OPEN", Labels: []Label{{Name: pipelinelabels.StateIdea}}},
 			wantErr: "ct:plan",
 		},
 		{
@@ -199,6 +201,24 @@ func TestGateBasic(t *testing.T) {
 				{Name: "ct:plan"}, {Name: "che:state:explore"},
 			}},
 			wantErr: "ya avanzó en el pipeline",
+		},
+		{
+			name: "rechaza labels v1 viejos (che:idea) con ct:plan",
+			// Repo no migrado a v2: el issue trae solo `che:idea` (modelo
+			// viejo). Si el gate aceptara este caso, el Apply siguiente
+			// dejaría labels v1+v2 mezclados — por eso rechazamos con
+			// mensaje claro pidiendo `migrate-labels-v2`.
+			issue: Issue{Number: 1, State: "OPEN", Labels: []Label{
+				{Name: "ct:plan"}, {Name: "che:idea"},
+			}},
+			wantErr: "labels v1",
+		},
+		{
+			name: "rechaza labels v1 viejos (che:plan)",
+			issue: Issue{Number: 1, State: "OPEN", Labels: []Label{
+				{Name: "ct:plan"}, {Name: "che:plan"},
+			}},
+			wantErr: "labels v1",
 		},
 	}
 	for _, c := range cases {

--- a/internal/flow/explore/explore_test.go
+++ b/internal/flow/explore/explore_test.go
@@ -194,7 +194,9 @@ func TestGateBasic(t *testing.T) {
 		{
 			name: "already planned",
 			issue: Issue{Number: 1, State: "OPEN", Labels: []Label{
-				{Name: "ct:plan"}, {Name: "che:plan"},
+				// Post-PR6b: el flow chequea v2 (`che:state:explore`) en lugar
+				// del viejo `che:plan`.
+				{Name: "ct:plan"}, {Name: "che:state:explore"},
 			}},
 			wantErr: "ya avanzó en el pipeline",
 		},
@@ -281,15 +283,17 @@ func minimalResponseJSON() string {
 // pasaron por explore, y (b) issues "crudos" sin ningún label ct:* que
 // explore va a reclassificar antes de explorar. che:locked excluye siempre.
 func TestFilterCandidates(t *testing.T) {
+	// Post-PR6b: filterCandidates chequea labels v2 (`che:state:*` /
+	// `che:state:applying:*`) en lugar de los viejos `che:plan` / etc.
 	in := []Issue{
-		{Number: 1, Title: "idea clasica", Labels: []Label{{Name: "ct:plan"}, {Name: "che:idea"}}},
-		{Number: 2, Title: "ya explorada", Labels: []Label{{Name: "ct:plan"}, {Name: "che:plan"}}},
-		{Number: 3, Title: "ejecutandose", Labels: []Label{{Name: "ct:plan"}, {Name: "che:executing"}}},
-		{Number: 4, Title: "ejecutada", Labels: []Label{{Name: "ct:plan"}, {Name: "che:executed"}}},
-		{Number: 5, Title: "locked con ct:plan", Labels: []Label{{Name: "ct:plan"}, {Name: "che:idea"}, {Name: "che:locked"}}},
+		{Number: 1, Title: "idea clasica", Labels: []Label{{Name: "ct:plan"}, {Name: "che:state:idea"}}},
+		{Number: 2, Title: "ya explorada", Labels: []Label{{Name: "ct:plan"}, {Name: "che:state:explore"}}},
+		{Number: 3, Title: "ejecutandose", Labels: []Label{{Name: "ct:plan"}, {Name: "che:state:applying:execute"}}},
+		{Number: 4, Title: "ejecutada", Labels: []Label{{Name: "ct:plan"}, {Name: "che:state:execute"}}},
+		{Number: 5, Title: "locked con ct:plan", Labels: []Label{{Name: "ct:plan"}, {Name: "che:state:idea"}, {Name: "che:locked"}}},
 		{Number: 6, Title: "raw sin labels", Labels: nil},
 		{Number: 7, Title: "raw con type y size", Labels: []Label{{Name: "type:feature"}, {Name: "size:m"}}},
-		{Number: 8, Title: "raw con che preexistente", Labels: []Label{{Name: "che:plan"}}},
+		{Number: 8, Title: "raw con che preexistente", Labels: []Label{{Name: "che:state:explore"}}},
 		{Number: 9, Title: "raw locked", Labels: []Label{{Name: "che:locked"}}},
 	}
 	got := filterCandidates(in)

--- a/internal/flow/idea/idea.go
+++ b/internal/flow/idea/idea.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/chichex/che/internal/labels"
 	"github.com/chichex/che/internal/output"
+	"github.com/chichex/che/internal/pipelinelabels"
 )
 
 // ErrInvalidResponse indica que la respuesta del LLM parseó pero violó el
@@ -154,7 +155,7 @@ func Run(text string, opts Opts) ExitCode {
 			Labels: []string{
 				"type:" + item.Type,
 				"size:" + strings.ToLower(item.Size),
-				labels.CheIdea,
+				pipelinelabels.StateIdea,
 				labels.CtPlan,
 			},
 		})
@@ -331,7 +332,7 @@ func ensureLabels(items []Item, log *output.Logger) error {
 		for _, l := range []string{
 			"type:" + it.Type,
 			"size:" + strings.ToLower(it.Size),
-			labels.CheIdea,
+			pipelinelabels.StateIdea,
 			labels.CtPlan,
 		} {
 			if !seen[l] {
@@ -368,7 +369,7 @@ func createIssue(item Item) (string, error) {
 		"--body-file", bodyFile,
 		"--label", "type:" + item.Type,
 		"--label", "size:" + strings.ToLower(item.Size),
-		"--label", labels.CheIdea,
+		"--label", pipelinelabels.StateIdea,
 		"--label", labels.CtPlan,
 	}
 	cmd := exec.Command("gh", args...)

--- a/internal/labels/hardcoded_test.go
+++ b/internal/labels/hardcoded_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/chichex/che/internal/pipelinelabels"
 )
 
 // TestNoHardcodedLabelsOutsideThisPackage camina el árbol del módulo y falla
@@ -37,18 +39,35 @@ func TestNoHardcodedLabelsOutsideThisPackage(t *testing.T) {
 		`"` + CheClosed + `"`,
 	}
 
+	// Modelo v2 — los 9 estados nuevos (`che:state:*` / `che:state:applying:*`)
+	// solo deben aparecer literales en `internal/pipelinelabels` (su fuente
+	// de verdad). El resto del codebase debe usar `pipelinelabels.State*`.
+	forbiddenV2 := []string{
+		`"` + pipelinelabels.StateIdea + `"`,
+		`"` + pipelinelabels.StateApplyingExplore + `"`,
+		`"` + pipelinelabels.StateExplore + `"`,
+		`"` + pipelinelabels.StateApplyingExecute + `"`,
+		`"` + pipelinelabels.StateExecute + `"`,
+		`"` + pipelinelabels.StateApplyingValidatePR + `"`,
+		`"` + pipelinelabels.StateValidatePR + `"`,
+		`"` + pipelinelabels.StateApplyingClose + `"`,
+		`"` + pipelinelabels.StateClose + `"`,
+	}
+
 	var violations []string
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if d.IsDir() {
-			// Saltamos dot-dirs (.git, .worktrees, .github) y este paquete.
+			// Saltamos dot-dirs (.git, .worktrees, .github) y los dos paquetes
+			// que son fuente de verdad de labels.
 			name := d.Name()
 			if strings.HasPrefix(name, ".") {
 				return filepath.SkipDir
 			}
-			if name == "labels" && filepath.Base(filepath.Dir(path)) == "internal" {
+			parent := filepath.Base(filepath.Dir(path))
+			if parent == "internal" && (name == "labels" || name == "pipelinelabels") {
 				return filepath.SkipDir
 			}
 			return nil
@@ -72,6 +91,11 @@ func TestNoHardcodedLabelsOutsideThisPackage(t *testing.T) {
 				violations = append(violations, rel+": contiene "+lit)
 			}
 		}
+		for _, lit := range forbiddenV2 {
+			if strings.Contains(content, lit) {
+				violations = append(violations, rel+": contiene "+lit+" (usá pipelinelabels.State*)")
+			}
+		}
 		return nil
 	})
 	if err != nil {
@@ -79,7 +103,7 @@ func TestNoHardcodedLabelsOutsideThisPackage(t *testing.T) {
 	}
 
 	if len(violations) > 0 {
-		t.Fatalf("labels hardcoded fuera de internal/labels — usá las constantes del paquete:\n  %s",
+		t.Fatalf("labels hardcoded fuera de internal/labels|internal/pipelinelabels — usá las constantes del paquete:\n  %s",
 			strings.Join(violations, "\n  "))
 	}
 }

--- a/internal/labels/v2_transitions.go
+++ b/internal/labels/v2_transitions.go
@@ -1,3 +1,7 @@
+// REMOVE IN PR6c — este archivo entero (shim de coexistencia v1↔v2)
+// se elimina cuando todos los flows estén migrados al modelo v2 y se
+// borren las constantes viejas + 21 keys viejas en validTransitions.
+//
 // v2_transitions.go: shim de coexistencia entre el modelo viejo (9
 // estados `che:idea`…`che:closed`) y el modelo v2 derivado del pipeline
 // declarativo (`internal/pipelinelabels`).
@@ -24,7 +28,61 @@
 // fuera de este paquete (subcomando dedicado, fuera del scope de PR6b).
 package labels
 
-import "github.com/chichex/che/internal/pipelinelabels"
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/chichex/che/internal/pipelinelabels"
+)
+
+// ValidateNoMixedLabels reporta error si el set `labels` contiene
+// simultáneamente labels del modelo viejo (`che:idea`/`che:plan`/...) y del
+// modelo v2 (`che:state:*`/`che:state:applying:*`). Durante PR6b/PR6c los
+// flows migrados solo deberían operar sobre issues con labels v2; mezclar
+// con v1 es síntoma de un repo que no corrió `migrate-labels-v2` (futuro
+// feature) o de un flow no migrado pisando el estado.
+//
+// Ignora labels que no son `che:*` o que sí son `che:*` pero no pertenecen
+// a ninguna de las dos máquinas (p.ej. `che:locked`, `ct:plan`, `type:*`).
+//
+// Returns nil si todos los labels che:state:* son v2-only o todos los
+// che:* son v1-only (o si no hay ninguno de los dos). El error lista los
+// labels que mezclan, ordenados, para que el mensaje sea estable.
+//
+// REMOVE IN PR6c — junto con el shim, este helper desaparece: post-PR6c
+// el modelo viejo ya no existe y la mezcla es imposible.
+func ValidateNoMixedLabels(labels []string) error {
+	v1Set := map[string]bool{
+		CheIdea:       true,
+		ChePlanning:   true,
+		ChePlan:       true,
+		CheExecuting:  true,
+		CheExecuted:   true,
+		CheValidating: true,
+		CheValidated:  true,
+		CheClosing:    true,
+		CheClosed:     true,
+	}
+	var v1Found, v2Found []string
+	for _, l := range labels {
+		if v1Set[l] {
+			v1Found = append(v1Found, l)
+			continue
+		}
+		// Cualquier prefix `che:state:` o `che:state:applying:` es v2.
+		if strings.HasPrefix(l, pipelinelabels.PrefixState) {
+			v2Found = append(v2Found, l)
+		}
+	}
+	if len(v1Found) > 0 && len(v2Found) > 0 {
+		sort.Strings(v1Found)
+		sort.Strings(v2Found)
+		return fmt.Errorf("labels v1 (%s) y v2 (%s) presentes simultáneamente — corré `migrate-labels-v2` (cuando exista) o limpiá a mano",
+			strings.Join(v1Found, ","), strings.Join(v2Found, ","))
+	}
+	return nil
+}
 
 // init registra las 21 transiciones v2 en el mismo mapa que las viejas.
 // Usamos init() en lugar de un literal de mapa para que la lectura del

--- a/internal/labels/v2_transitions.go
+++ b/internal/labels/v2_transitions.go
@@ -1,0 +1,161 @@
+// v2_transitions.go: shim de coexistencia entre el modelo viejo (9
+// estados `che:idea`…`che:closed`) y el modelo v2 derivado del pipeline
+// declarativo (`internal/pipelinelabels`).
+//
+// PR6b migra los flows uno por uno de las constantes viejas a las
+// constantes v2 de `pipelinelabels`. Para que `labels.Apply(ref, from, to)`
+// siga funcionando con argumentos que ahora son strings v2 (p.ej.
+// `pipelinelabels.StateIdea` en lugar de `labels.CheIdea`), registramos
+// acá las mismas 21 transiciones en el mapa `validTransitions` con keys
+// formadas por los strings v2.
+//
+// Coexistencia: durante la migración hay flows que aún pasan strings
+// viejos (`labels.CheIdea`) y flows ya migrados que pasan strings v2
+// (`pipelinelabels.StateIdea`). Ambos sets de keys conviven en
+// `validTransitions` sin pisarse — son strings distintos. Cuando todos
+// los flows estén migrados (PR6c) se podrán borrar las keys viejas y la
+// importación de pipelinelabels se vuelve la única fuente de verdad.
+//
+// Importante: NO hay conversión automática entre modelos. Si un flow
+// migrado a v2 corre sobre un issue que aún tiene labels viejos
+// (porque nunca pasó por `migrate-labels-v2`), `Apply` va a fallar
+// con "label not found" — el caller debe haber visto el estado v2
+// previamente. La migración de labels existentes en repos vivos vive
+// fuera de este paquete (subcomando dedicado, fuera del scope de PR6b).
+package labels
+
+import "github.com/chichex/che/internal/pipelinelabels"
+
+// init registra las 21 transiciones v2 en el mismo mapa que las viejas.
+// Usamos init() en lugar de un literal de mapa para que la lectura del
+// mapeo viejo↔nuevo quede explícita acá sin repetir las keys viejas.
+//
+// Espejo exacto de `validTransitions` (ver labels.go) usando los strings
+// del modelo v2:
+//
+//	che:idea       ↔ pipelinelabels.StateIdea
+//	che:planning   ↔ pipelinelabels.StateApplyingExplore
+//	che:plan       ↔ pipelinelabels.StateExplore
+//	che:executing  ↔ pipelinelabels.StateApplyingExecute
+//	che:executed   ↔ pipelinelabels.StateExecute
+//	che:validating ↔ pipelinelabels.StateApplyingValidatePR
+//	che:validated  ↔ pipelinelabels.StateValidatePR
+//	che:closing    ↔ pipelinelabels.StateApplyingClose
+//	che:closed     ↔ pipelinelabels.StateClose
+func init() {
+	v2 := map[string]Transition{
+		// explore arranca: idea → applying:explore (lock).
+		pipelinelabels.StateIdea + "→" + pipelinelabels.StateApplyingExplore: {
+			Remove: []string{pipelinelabels.StateIdea},
+			Add:    []string{pipelinelabels.StateApplyingExplore},
+		},
+		// explore termina OK: applying:explore → explore.
+		pipelinelabels.StateApplyingExplore + "→" + pipelinelabels.StateExplore: {
+			Remove: []string{pipelinelabels.StateApplyingExplore},
+			Add:    []string{pipelinelabels.StateExplore},
+		},
+		// explore rollback: applying:explore → idea.
+		pipelinelabels.StateApplyingExplore + "→" + pipelinelabels.StateIdea: {
+			Remove: []string{pipelinelabels.StateApplyingExplore},
+			Add:    []string{pipelinelabels.StateIdea},
+		},
+		// iterate plan rollback: applying:explore → validate_pr.
+		pipelinelabels.StateApplyingExplore + "→" + pipelinelabels.StateValidatePR: {
+			Remove: []string{pipelinelabels.StateApplyingExplore},
+			Add:    []string{pipelinelabels.StateValidatePR},
+		},
+		// iterate plan start: validate_pr → applying:explore.
+		pipelinelabels.StateValidatePR + "→" + pipelinelabels.StateApplyingExplore: {
+			Remove: []string{pipelinelabels.StateValidatePR},
+			Add:    []string{pipelinelabels.StateApplyingExplore},
+		},
+		// execute desde idea (skip explore).
+		pipelinelabels.StateIdea + "→" + pipelinelabels.StateApplyingExecute: {
+			Remove: []string{pipelinelabels.StateIdea},
+			Add:    []string{pipelinelabels.StateApplyingExecute},
+		},
+		// execute desde explore (path normal post-explore).
+		pipelinelabels.StateExplore + "→" + pipelinelabels.StateApplyingExecute: {
+			Remove: []string{pipelinelabels.StateExplore},
+			Add:    []string{pipelinelabels.StateApplyingExecute},
+		},
+		// iterate PR start: validate_pr → applying:execute.
+		pipelinelabels.StateValidatePR + "→" + pipelinelabels.StateApplyingExecute: {
+			Remove: []string{pipelinelabels.StateValidatePR},
+			Add:    []string{pipelinelabels.StateApplyingExecute},
+		},
+		// execute / iterate PR termina OK: applying:execute → execute.
+		pipelinelabels.StateApplyingExecute + "→" + pipelinelabels.StateExecute: {
+			Remove: []string{pipelinelabels.StateApplyingExecute},
+			Add:    []string{pipelinelabels.StateExecute},
+		},
+		// execute rollback desde idea.
+		pipelinelabels.StateApplyingExecute + "→" + pipelinelabels.StateIdea: {
+			Remove: []string{pipelinelabels.StateApplyingExecute},
+			Add:    []string{pipelinelabels.StateIdea},
+		},
+		// execute rollback desde explore.
+		pipelinelabels.StateApplyingExecute + "→" + pipelinelabels.StateExplore: {
+			Remove: []string{pipelinelabels.StateApplyingExecute},
+			Add:    []string{pipelinelabels.StateExplore},
+		},
+		// iterate PR rollback: applying:execute → validate_pr.
+		pipelinelabels.StateApplyingExecute + "→" + pipelinelabels.StateValidatePR: {
+			Remove: []string{pipelinelabels.StateApplyingExecute},
+			Add:    []string{pipelinelabels.StateValidatePR},
+		},
+		// validate plan start: explore → applying:validate_pr.
+		pipelinelabels.StateExplore + "→" + pipelinelabels.StateApplyingValidatePR: {
+			Remove: []string{pipelinelabels.StateExplore},
+			Add:    []string{pipelinelabels.StateApplyingValidatePR},
+		},
+		// validate PR start: execute → applying:validate_pr.
+		pipelinelabels.StateExecute + "→" + pipelinelabels.StateApplyingValidatePR: {
+			Remove: []string{pipelinelabels.StateExecute},
+			Add:    []string{pipelinelabels.StateApplyingValidatePR},
+		},
+		// validate termina OK: applying:validate_pr → validate_pr.
+		pipelinelabels.StateApplyingValidatePR + "→" + pipelinelabels.StateValidatePR: {
+			Remove: []string{pipelinelabels.StateApplyingValidatePR},
+			Add:    []string{pipelinelabels.StateValidatePR},
+		},
+		// validate plan rollback: applying:validate_pr → explore.
+		pipelinelabels.StateApplyingValidatePR + "→" + pipelinelabels.StateExplore: {
+			Remove: []string{pipelinelabels.StateApplyingValidatePR},
+			Add:    []string{pipelinelabels.StateExplore},
+		},
+		// validate PR rollback: applying:validate_pr → execute.
+		pipelinelabels.StateApplyingValidatePR + "→" + pipelinelabels.StateExecute: {
+			Remove: []string{pipelinelabels.StateApplyingValidatePR},
+			Add:    []string{pipelinelabels.StateExecute},
+		},
+		// close PR sin validar: execute → applying:close.
+		pipelinelabels.StateExecute + "→" + pipelinelabels.StateApplyingClose: {
+			Remove: []string{pipelinelabels.StateExecute},
+			Add:    []string{pipelinelabels.StateApplyingClose},
+		},
+		// close PR validado: validate_pr → applying:close.
+		pipelinelabels.StateValidatePR + "→" + pipelinelabels.StateApplyingClose: {
+			Remove: []string{pipelinelabels.StateValidatePR},
+			Add:    []string{pipelinelabels.StateApplyingClose},
+		},
+		// close termina OK: applying:close → close.
+		pipelinelabels.StateApplyingClose + "→" + pipelinelabels.StateClose: {
+			Remove: []string{pipelinelabels.StateApplyingClose},
+			Add:    []string{pipelinelabels.StateClose},
+		},
+		// close rollback desde execute.
+		pipelinelabels.StateApplyingClose + "→" + pipelinelabels.StateExecute: {
+			Remove: []string{pipelinelabels.StateApplyingClose},
+			Add:    []string{pipelinelabels.StateExecute},
+		},
+		// close rollback desde validate_pr.
+		pipelinelabels.StateApplyingClose + "→" + pipelinelabels.StateValidatePR: {
+			Remove: []string{pipelinelabels.StateApplyingClose},
+			Add:    []string{pipelinelabels.StateValidatePR},
+		},
+	}
+	for k, v := range v2 {
+		validTransitions[k] = v
+	}
+}

--- a/internal/labels/v2_transitions_test.go
+++ b/internal/labels/v2_transitions_test.go
@@ -178,3 +178,71 @@ func TestTransitionFor_V2_Coexistence(t *testing.T) {
 		t.Errorf("v2 StateIdea → StateApplyingExplore no registrada: %v", err)
 	}
 }
+
+// TestValidateNoMixedLabels cubre la invariante de exclusividad v1↔v2:
+// ningún issue debería tener labels viejos (`che:idea`/...) y v2
+// (`che:state:*`) simultáneamente.
+//
+// La helper aún no está enganchada en flows/gates — ese cableado vive
+// en PR6c. Acá fijamos solo el contrato del helper.
+func TestValidateNoMixedLabels(t *testing.T) {
+	cases := []struct {
+		name    string
+		labels  []string
+		wantErr bool
+	}{
+		{
+			name:    "vacío",
+			labels:  nil,
+			wantErr: false,
+		},
+		{
+			name:    "solo labels orthogonales",
+			labels:  []string{"ct:plan", "type:feature", CheLocked, "size:m"},
+			wantErr: false,
+		},
+		{
+			name:    "v1 only",
+			labels:  []string{"ct:plan", CheIdea, "type:feature"},
+			wantErr: false,
+		},
+		{
+			name:    "v2 only",
+			labels:  []string{"ct:plan", pipelinelabels.StateIdea, "type:feature"},
+			wantErr: false,
+		},
+		{
+			name:    "v2 only — applying",
+			labels:  []string{pipelinelabels.StateApplyingExplore},
+			wantErr: false,
+		},
+		{
+			name: "mezcla — bug típico que el shim deja pasar",
+			labels: []string{
+				"ct:plan",
+				CheIdea,
+				pipelinelabels.StateApplyingExplore,
+			},
+			wantErr: true,
+		},
+		{
+			name: "mezcla — v1 y v2 ambos terminales",
+			labels: []string{
+				ChePlan,
+				pipelinelabels.StateExplore,
+			},
+			wantErr: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := ValidateNoMixedLabels(c.labels)
+			if c.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !c.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/labels/v2_transitions_test.go
+++ b/internal/labels/v2_transitions_test.go
@@ -1,0 +1,180 @@
+package labels
+
+import (
+	"testing"
+
+	"github.com/chichex/che/internal/pipelinelabels"
+)
+
+// TestTransitionFor_V2 verifica que las 21 transiciones del modelo v2
+// (registradas por v2_transitions.go) sean equivalentes al espejo de las
+// viejas — mismo Add/Remove pero con strings v2. Esto garantiza la
+// coexistencia: un flow ya migrado puede llamar `Apply(ref, v2From, v2To)`
+// y obtener exactamente los labels v2 esperados.
+func TestTransitionFor_V2(t *testing.T) {
+	cases := []struct {
+		from, to string
+		wantAdd  []string
+		wantRem  []string
+	}{
+		{
+			from:    pipelinelabels.StateIdea,
+			to:      pipelinelabels.StateApplyingExplore,
+			wantAdd: []string{pipelinelabels.StateApplyingExplore},
+			wantRem: []string{pipelinelabels.StateIdea},
+		},
+		{
+			from:    pipelinelabels.StateApplyingExplore,
+			to:      pipelinelabels.StateExplore,
+			wantAdd: []string{pipelinelabels.StateExplore},
+			wantRem: []string{pipelinelabels.StateApplyingExplore},
+		},
+		{
+			from:    pipelinelabels.StateApplyingExplore,
+			to:      pipelinelabels.StateIdea,
+			wantAdd: []string{pipelinelabels.StateIdea},
+			wantRem: []string{pipelinelabels.StateApplyingExplore},
+		},
+		{
+			from:    pipelinelabels.StateApplyingExplore,
+			to:      pipelinelabels.StateValidatePR,
+			wantAdd: []string{pipelinelabels.StateValidatePR},
+			wantRem: []string{pipelinelabels.StateApplyingExplore},
+		},
+		{
+			from:    pipelinelabels.StateValidatePR,
+			to:      pipelinelabels.StateApplyingExplore,
+			wantAdd: []string{pipelinelabels.StateApplyingExplore},
+			wantRem: []string{pipelinelabels.StateValidatePR},
+		},
+		{
+			from:    pipelinelabels.StateIdea,
+			to:      pipelinelabels.StateApplyingExecute,
+			wantAdd: []string{pipelinelabels.StateApplyingExecute},
+			wantRem: []string{pipelinelabels.StateIdea},
+		},
+		{
+			from:    pipelinelabels.StateExplore,
+			to:      pipelinelabels.StateApplyingExecute,
+			wantAdd: []string{pipelinelabels.StateApplyingExecute},
+			wantRem: []string{pipelinelabels.StateExplore},
+		},
+		{
+			from:    pipelinelabels.StateValidatePR,
+			to:      pipelinelabels.StateApplyingExecute,
+			wantAdd: []string{pipelinelabels.StateApplyingExecute},
+			wantRem: []string{pipelinelabels.StateValidatePR},
+		},
+		{
+			from:    pipelinelabels.StateApplyingExecute,
+			to:      pipelinelabels.StateExecute,
+			wantAdd: []string{pipelinelabels.StateExecute},
+			wantRem: []string{pipelinelabels.StateApplyingExecute},
+		},
+		{
+			from:    pipelinelabels.StateApplyingExecute,
+			to:      pipelinelabels.StateIdea,
+			wantAdd: []string{pipelinelabels.StateIdea},
+			wantRem: []string{pipelinelabels.StateApplyingExecute},
+		},
+		{
+			from:    pipelinelabels.StateApplyingExecute,
+			to:      pipelinelabels.StateExplore,
+			wantAdd: []string{pipelinelabels.StateExplore},
+			wantRem: []string{pipelinelabels.StateApplyingExecute},
+		},
+		{
+			from:    pipelinelabels.StateApplyingExecute,
+			to:      pipelinelabels.StateValidatePR,
+			wantAdd: []string{pipelinelabels.StateValidatePR},
+			wantRem: []string{pipelinelabels.StateApplyingExecute},
+		},
+		{
+			from:    pipelinelabels.StateExplore,
+			to:      pipelinelabels.StateApplyingValidatePR,
+			wantAdd: []string{pipelinelabels.StateApplyingValidatePR},
+			wantRem: []string{pipelinelabels.StateExplore},
+		},
+		{
+			from:    pipelinelabels.StateExecute,
+			to:      pipelinelabels.StateApplyingValidatePR,
+			wantAdd: []string{pipelinelabels.StateApplyingValidatePR},
+			wantRem: []string{pipelinelabels.StateExecute},
+		},
+		{
+			from:    pipelinelabels.StateApplyingValidatePR,
+			to:      pipelinelabels.StateValidatePR,
+			wantAdd: []string{pipelinelabels.StateValidatePR},
+			wantRem: []string{pipelinelabels.StateApplyingValidatePR},
+		},
+		{
+			from:    pipelinelabels.StateApplyingValidatePR,
+			to:      pipelinelabels.StateExplore,
+			wantAdd: []string{pipelinelabels.StateExplore},
+			wantRem: []string{pipelinelabels.StateApplyingValidatePR},
+		},
+		{
+			from:    pipelinelabels.StateApplyingValidatePR,
+			to:      pipelinelabels.StateExecute,
+			wantAdd: []string{pipelinelabels.StateExecute},
+			wantRem: []string{pipelinelabels.StateApplyingValidatePR},
+		},
+		{
+			from:    pipelinelabels.StateExecute,
+			to:      pipelinelabels.StateApplyingClose,
+			wantAdd: []string{pipelinelabels.StateApplyingClose},
+			wantRem: []string{pipelinelabels.StateExecute},
+		},
+		{
+			from:    pipelinelabels.StateValidatePR,
+			to:      pipelinelabels.StateApplyingClose,
+			wantAdd: []string{pipelinelabels.StateApplyingClose},
+			wantRem: []string{pipelinelabels.StateValidatePR},
+		},
+		{
+			from:    pipelinelabels.StateApplyingClose,
+			to:      pipelinelabels.StateClose,
+			wantAdd: []string{pipelinelabels.StateClose},
+			wantRem: []string{pipelinelabels.StateApplyingClose},
+		},
+		{
+			from:    pipelinelabels.StateApplyingClose,
+			to:      pipelinelabels.StateExecute,
+			wantAdd: []string{pipelinelabels.StateExecute},
+			wantRem: []string{pipelinelabels.StateApplyingClose},
+		},
+		{
+			from:    pipelinelabels.StateApplyingClose,
+			to:      pipelinelabels.StateValidatePR,
+			wantAdd: []string{pipelinelabels.StateValidatePR},
+			wantRem: []string{pipelinelabels.StateApplyingClose},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.from+"→"+c.to, func(t *testing.T) {
+			tr, err := TransitionFor(c.from, c.to)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !equal(tr.Add, c.wantAdd) {
+				t.Errorf("Add: got %v, want %v", tr.Add, c.wantAdd)
+			}
+			if !equal(tr.Remove, c.wantRem) {
+				t.Errorf("Remove: got %v, want %v", tr.Remove, c.wantRem)
+			}
+		})
+	}
+}
+
+// TestTransitionFor_V2_Coexistence garantiza que las viejas y las v2 no
+// se pisan: ambas siguen funcionando después de que init() registra v2.
+func TestTransitionFor_V2_Coexistence(t *testing.T) {
+	// Vieja (debe seguir funcionando).
+	if _, err := TransitionFor(CheIdea, ChePlanning); err != nil {
+		t.Errorf("vieja CheIdea → ChePlanning rota tras init v2: %v", err)
+	}
+	// V2 (registrada por init).
+	if _, err := TransitionFor(pipelinelabels.StateIdea, pipelinelabels.StateApplyingExplore); err != nil {
+		t.Errorf("v2 StateIdea → StateApplyingExplore no registrada: %v", err)
+	}
+}

--- a/internal/pipelinelabels/v2states.go
+++ b/internal/pipelinelabels/v2states.go
@@ -1,0 +1,93 @@
+// Constantes "v2" del modelo de labels derivado del pipeline declarativo
+// (PRD §6.c). Forman el mapeo 1:1 entre los 9 estados viejos del paquete
+// `internal/labels` (`che:idea` … `che:closed`) y los nuevos `che:state:*`
+// + `che:state:applying:*`.
+//
+// Existen para que la migración flow por flow del PR6b pueda referirse a
+// los estados v2 con nombres ergonómicos (StateIdea, StateApplyingExplore,
+// …) en lugar de inventar literales — el test
+// `internal/labels.TestNoHardcodedLabelsOutsideThisPackage` ya prohíbe
+// literales del modelo viejo, y queremos mantener la misma disciplina con
+// el modelo nuevo. Cada caller que reemplace `labels.CheIdea` debe usar
+// `pipelinelabels.StateIdea` en su lugar.
+//
+// Mapeo (PRD §6.c):
+//
+//	che:idea       → che:state:idea                       (StateIdea)
+//	che:planning   → che:state:applying:explore           (StateApplyingExplore)
+//	che:plan       → che:state:explore                    (StateExplore)
+//	che:executing  → che:state:applying:execute           (StateApplyingExecute)
+//	che:executed   → che:state:execute                    (StateExecute)
+//	che:validating → che:state:applying:validate_pr       (StateApplyingValidatePR)
+//	che:validated  → che:state:validate_pr                (StateValidatePR)
+//	che:closing    → che:state:applying:close             (StateApplyingClose)
+//	che:closed     → che:state:close                      (StateClose)
+//
+// Notar que la "validación del plan" del modelo viejo (validating/validated
+// sobre un issue, vs. sobre un PR) colapsa en el modelo nuevo a un solo
+// step `validate_pr` — el modelo nuevo deriva la entidad target del step
+// del pipeline, no del label. Para PR6b mantenemos el mapeo 1:1 con los 9
+// estados viejos para no cambiar semántica; refinar a steps separados
+// (`validate_plan` vs. `validate_pr`) queda para PRs siguientes cuando el
+// pipeline declarativo maneje ambos casos.
+package pipelinelabels
+
+// Nombres canónicos de los steps del modelo v2 derivado del pipeline
+// declarativo. Exportados para que callers no inventen strings y para que
+// test/golden puedan compararlos bit-perfect.
+const (
+	StepIdea       = "idea"
+	StepExplore    = "explore"
+	StepExecute    = "execute"
+	StepValidatePR = "validate_pr"
+	StepClose      = "close"
+)
+
+// Estados terminales (`che:state:<step>`) y aplicantes
+// (`che:state:applying:<step>`) generados a partir de los nombres de step.
+// Definidos como `var` (no `const`) porque se inicializan llamando a
+// StateLabel/ApplyingLabel — las funciones del paquete son la fuente de
+// verdad del prefijo.
+var (
+	// StateIdea es el estado terminal del step `idea`. Mapea al viejo
+	// `labels.CheIdea`. Forma: `che:state:idea`.
+	StateIdea = StateLabel(StepIdea)
+
+	// StateApplyingExplore es el lock optimista del step `explore`. Mapea al
+	// viejo `labels.ChePlanning` (estado transient mientras corre explore).
+	// Forma: `che:state:applying:explore`.
+	StateApplyingExplore = ApplyingLabel(StepExplore)
+
+	// StateExplore es el estado terminal del step `explore`. Mapea al viejo
+	// `labels.ChePlan` (explore terminó OK; existe un plan listo para
+	// ejecutar). Forma: `che:state:explore`.
+	StateExplore = StateLabel(StepExplore)
+
+	// StateApplyingExecute es el lock optimista del step `execute`. Mapea
+	// al viejo `labels.CheExecuting`. Forma: `che:state:applying:execute`.
+	StateApplyingExecute = ApplyingLabel(StepExecute)
+
+	// StateExecute es el estado terminal del step `execute`. Mapea al
+	// viejo `labels.CheExecuted` (execute terminó OK; PR abierto).
+	// Forma: `che:state:execute`.
+	StateExecute = StateLabel(StepExecute)
+
+	// StateApplyingValidatePR es el lock optimista del step `validate_pr`.
+	// Mapea al viejo `labels.CheValidating`. En el modelo v2 no
+	// distinguimos validate-de-plan vs. validate-de-PR — colapsan a un
+	// solo step `validate_pr` para PR6b; refinar es follow-up.
+	// Forma: `che:state:applying:validate_pr`.
+	StateApplyingValidatePR = ApplyingLabel(StepValidatePR)
+
+	// StateValidatePR es el estado terminal del step `validate_pr`. Mapea
+	// al viejo `labels.CheValidated`. Forma: `che:state:validate_pr`.
+	StateValidatePR = StateLabel(StepValidatePR)
+
+	// StateApplyingClose es el lock optimista del step `close`. Mapea al
+	// viejo `labels.CheClosing`. Forma: `che:state:applying:close`.
+	StateApplyingClose = ApplyingLabel(StepClose)
+
+	// StateClose es el estado terminal del step `close`. Mapea al viejo
+	// `labels.CheClosed`. Forma: `che:state:close`.
+	StateClose = StateLabel(StepClose)
+)

--- a/internal/pipelinelabels/v2states_test.go
+++ b/internal/pipelinelabels/v2states_test.go
@@ -1,0 +1,65 @@
+package pipelinelabels
+
+import "testing"
+
+// TestV2States_LiteralValues fija los strings literales de los 9 mapeos
+// del PRD §6.c. Si algún rename del modelo v2 ocurre, este test falla y
+// fuerza a auditar callers (los flows migrados en PR6b dependen de estos
+// strings exactos para que `labels.Apply` encuentre las transiciones
+// registradas con las mismas keys).
+func TestV2States_LiteralValues(t *testing.T) {
+	cases := []struct {
+		got, want string
+	}{
+		{StateIdea, "che:state:idea"},
+		{StateApplyingExplore, "che:state:applying:explore"},
+		{StateExplore, "che:state:explore"},
+		{StateApplyingExecute, "che:state:applying:execute"},
+		{StateExecute, "che:state:execute"},
+		{StateApplyingValidatePR, "che:state:applying:validate_pr"},
+		{StateValidatePR, "che:state:validate_pr"},
+		{StateApplyingClose, "che:state:applying:close"},
+		{StateClose, "che:state:close"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("got %q, want %q", c.got, c.want)
+		}
+	}
+}
+
+// TestV2States_RoundTripParse garantiza que las constantes v2 se parsean
+// correctamente por Parse (que clasifica entre KindState y KindApplying).
+// Ataja un futuro caller que rompa el prefijo `che:state:applying:` por
+// error y haga colisión con `che:state:`.
+func TestV2States_RoundTripParse(t *testing.T) {
+	cases := []struct {
+		label    string
+		wantKind Kind
+		wantStep string
+	}{
+		{StateIdea, KindState, "idea"},
+		{StateApplyingExplore, KindApplying, "explore"},
+		{StateExplore, KindState, "explore"},
+		{StateApplyingExecute, KindApplying, "execute"},
+		{StateExecute, KindState, "execute"},
+		{StateApplyingValidatePR, KindApplying, "validate_pr"},
+		{StateValidatePR, KindState, "validate_pr"},
+		{StateApplyingClose, KindApplying, "close"},
+		{StateClose, KindState, "close"},
+	}
+	for _, c := range cases {
+		t.Run(c.label, func(t *testing.T) {
+			p, err := Parse(c.label)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", c.label, err)
+			}
+			if p.Kind != c.wantKind {
+				t.Errorf("Kind: got %v, want %v", p.Kind, c.wantKind)
+			}
+			if p.Step != c.wantStep {
+				t.Errorf("Step: got %q, want %q", p.Step, c.wantStep)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implementa #67.

Closes #67

## ⚠️ Deploy gate (NO mergear standalone)

PR6b **no es deployable solo**. Migra 3 flows (idea/explore/execute) a labels v2, pero close/iterate/validate/dash siguen leyendo strings v1. Si entra a main y se cuts una release antes de PR6c+:

- `che validate` post-`che execute` migrado falla con "PR no está en che:executed" (lee `labels.CheExecuted` v1; execute escribe `che:state:execute` v2).
- `che iterate` y `che close` rompen análogamente para issues que pasaron por flows migrados.
- `internal/dash/gh_source.go` clasifica `che:state:execute` como `Status="state:execute"` → kanban roto, auto-loop no dispara, preflight gates en default.

**Mitigación parcial en este PR**: el gate de `explore` ahora detecta labels v1 en el issue y rechaza con mensaje claro pidiendo `migrate-labels-v2` (ver `internal/flow/explore/explore.go:gateBasic`). Esto evita que un repo vivo entre en estado mixto al primer `che explore`. **Pero close/iterate/validate todavía no tienen ese guard** — no agregarlos ahora es deuda intencional para mantener este PR focalizado en idea/explore/execute.

**Plan de release seguro**:
1. Mergear este PR a una branch larga `feat/labels-v2-migration` (no a `main`).
2. Encadenar PR6c (migrar close/iterate/validate) y `migrate-labels-v2` (subcomando para repos vivos) sobre esa branch.
3. Mergear la branch larga a `main` en una sola operación, cortar release.

Si igual se mergea standalone, agregar al CHANGELOG el warning explícito y bloquear release hasta PR6c+.

## Implementado

Migración flow por flow al modelo v2 de labels (`che:state:*` / `che:state:applying:*`). Coexistencia con el paquete viejo — NO se borra `internal/labels/`.

### Constantes v2 + tests
- `internal/pipelinelabels/v2states.go` — 9 mapeos del PRD §6.c (`StateIdea`, `StateApplyingExplore`, `StateExplore`, `StateApplyingExecute`, `StateExecute`, `StateApplyingValidatePR`, `StateValidatePR`, `StateApplyingClose`, `StateClose`) + 5 step names. Tests fijan literales y round-trip por `Parse`.

### Shim de transiciones v2
- `internal/labels/v2_transitions.go` con `init()` que registra las 21 transiciones del modelo viejo en `validTransitions` con keys formadas por strings v2. Coexisten con las viejas (no colisión, strings distintos). Marcado `// REMOVE IN PR6c` arriba del archivo.
- Helper `ValidateNoMixedLabels` agregada en el mismo archivo: detecta presencia simultánea de v1 + v2 en un set de labels. **No enganchada a flows todavía** (eso es PR6c+); por ahora solo expone la helper + test que la ejercita.

### Migrados 3 flows representativos
- `internal/flow/idea/idea.go` — solo constantes (Ensure/AddLabels/--label).
- `internal/flow/explore/explore.go` — constantes + `Apply(idea→applying:explore→explore)` con rollback + gate de "ya avanzó" + filterCandidates. **Gate ahora rechaza issues con labels v1** (`che:idea`/`che:plan`/...) con mensaje pidiendo `migrate-labels-v2`.
- `internal/flow/execute/execute.go` — el más complejo: gate con 5 chequeos, `fromState()` con prioridad validate_pr > explore > idea, rollback condicional según prCreated/executedApplied. Agregado `TODO(coverage)` para refactorear `cleanupLocal` a una función testeable post-PR6c.

### Tests + e2e
Unit + e2e + 11 fixtures JSON migrados (10 v2 + 1 fixture nueva v1 para test de rejection). Asserts ahora referencian `che:state:*` / `che:state:applying:*`.

- `e2e/explore_test.go` — `TestExplore_OldV1Label_Exit3_NoMixedState` valida que un issue con `che:idea` v1 + `ct:plan` se rechaza con exit 3 sin POST/DELETE de labels.
- `internal/labels/hardcoded_test.go` extendido a los 9 strings v2 (`forbiddenV2` list); fuente de verdad excluida sigue siendo `internal/pipelinelabels/`.

`go test ./...` 100% verde (24 paquetes); `go vet`, `gofmt` clean.

## Decisiones de diseño

- **Coexistencia con `init()`**: registrar las 21 transiciones v2 desde `v2_transitions.go` cumple "no borrar el paquete viejo" sin diff destructivo. Un futuro PR6c borra ese archivo en una sola operación junto con las constantes viejas.
- **`pipelinelabels.State*` como `var` (no `const`)**: las constantes v2 se inicializan llamando `StateLabel("idea")` para que las funciones del paquete (que usan los prefijos canónicos) sean la única fuente de verdad. Los tests de round-trip detectan drift inmediatamente.
- **Marker labels (`CtPlan`) y locks (`CheLocked`) NO migran**: viven en `internal/labels` y siguen referenciados desde flows migrados. Verdicts (`ValidatedApprove` etc.) tampoco migran. Solo los 9 estados de la state machine cambian a v2.
- **El test `TestNoHardcodedLabelsOutsideThisPackage`** sigue pasando porque ningún caller migrado usa literales viejos.
- **Rejection en `gateBasic` de explore como mitigación parcial**: la review identificó el agujero de estado mixto v1+v2; el fix correcto es enforcearlo en cada gate migrado, pero por scope de este PR solo se cubre `explore`. PR6c hereda la responsabilidad para `close`/`iterate`/`validate`.

## Pendiente

Flows que faltan migrar (intencional — preferí PR mediano sobre XL bigbang):
- `internal/flow/close` — gate ramifica por `che:executed`/`che:validated`, dos transiciones a closing/closed. **También necesita el guard v1-rejection que se agregó a explore.**
- `internal/flow/iterate` — dos modos (PR + plan), cada uno con su gate + Apply.
- `internal/flow/validate` — el más complejo (~1700 LOC tests, dos modos plan/PR, verdicts orthogonales que NO migran).
- Callers no-flow: `internal/dash/gh_source.go` (estados), TUI/unlock/startup (orthogonales).

PR6c (siguiente): borrar el shim `v2_transitions.go` + las 9 constantes viejas + 21 keys viejas en `validTransitions`. Esto es viable solo cuando todos los flows estén migrados, **y** después de wirear `ValidateNoMixedLabels` en los gates restantes.

Subcomando `migrate-labels-v2` para repos vivos (renombrar in-place `che:idea`→`che:state:idea` etc.) — feature aparte, no es flow-by-flow. Pre-requisito para que `gateBasic` v1-rejection no sea un dead-end UX para usuarios con repos pre-PR6b.
