### PR TITLE
feat(#82): [#50 PR6c] Terminar migración a labels v2

### DIFF
--- a/EXEC_NOTES.md
+++ b/EXEC_NOTES.md
@@ -1,198 +1,133 @@
-# PR6b — Migración flow por flow a labels v2: notas de ejecución
+# PR6c — Terminar migración a labels v2: notas de ejecución
 
 ## Scope cubierto
 
-PR mediano siguiendo la guidance del issue: "Si el alcance se vuelve XL …
-priorizar 2-3 flows mas representativos y dejar los demás como TODO".
-Migrados los 3 flows que cubren toda la combinatoria interesante:
+Migración completa de los flows restantes (validate / iterate / close +
+stateref + dash) a los strings v2 (`che:state:*`), guards v1-rejection
+wirecados en los 3 flows + `ValidateNoMixedLabels` enganchado, subcomando
+`migrate-labels-v2` listo para repos vivos. Tests + fixtures e2e migrados;
+`go test ./...` 100% verde, `go vet` clean, regresión `grep` solo deja los
+hits intencionales (guards + stateref legacy lookup + dash closed filter).
 
-1. **`internal/flow/idea`** — el más simple: solo `Ensure`/`AddLabels` +
-   `--label`. Demuestra que el reemplazo `labels.CheIdea` →
-   `pipelinelabels.StateIdea` es trivial cuando no hay máquina de
-   estados involucrada.
-2. **`internal/flow/explore`** — el primer flow con `labels.Apply(from,
-   to)` real (idea → applying:explore → explore + rollback). Prueba que
-   las transiciones v2 registradas en `internal/labels` funcionan
-   end-to-end (Lock + Apply + rollback + tests + e2e).
-3. **`internal/flow/execute`** — el flow más complejo que migra: 3
-   estados de origen aceptados (idea / explore / validate_pr), rollback
-   condicional según se haya creado PR o no, gate con 5 chequeos de
-   estado, fromState() para resolver ambigüedad. Cubre todos los
-   patrones de uso del modelo viejo.
+## Decisiones de diseño
 
-## Coexistencia (clave del PR)
+### 1. Helper `rejectV1Labels` por-flow, no centralizado
 
-El paquete viejo `internal/labels` se preserva intacto (no se borra ni
-se modifica el set de constantes / transiciones existentes). Lo único
-que se agregó es:
+Cada uno de los 3 flows (validate, iterate, close) define su propio
+`v1StateLabels` slice + helper `rejectV1Labels` con mensaje accionable
+contextualizado al flow ("antes de validar", "antes de iterar", "antes
+de cerrar"). Evaluamos centralizar en `internal/labels` pero cada
+mensaje incluye el verbo del flow — extraer pierde la pista textual.
+Patrón consistente con `gateBasic` de explore (PR6b). El helper wirea
+`labels.ValidateNoMixedLabels` adentro: cualquier mezcla v1+v2 fall por
+ahí antes que el loop sobre v1StateLabels, así no pisamos labels mezclados
+con un v2 nuevo.
 
-- `internal/pipelinelabels/v2states.go` — 9 constantes públicas
-  (`StateIdea`, `StateApplyingExplore`, `StateExplore`,
-  `StateApplyingExecute`, `StateExecute`, `StateApplyingValidatePR`,
-  `StateValidatePR`, `StateApplyingClose`, `StateClose`) que mapean los
-  9 estados viejos al modelo v2 según PRD §6.c. Más constantes de step
-  (`StepIdea`, `StepExplore`, `StepExecute`, `StepValidatePR`,
-  `StepClose`) que actúan de fuente de verdad para los nombres.
-- `internal/labels/v2_transitions.go` — `init()` que registra las 21
-  transiciones del modelo viejo en `validTransitions` con keys formadas
-  por strings v2. Esto permite que `labels.Apply(ref,
-  pipelinelabels.StateIdea, pipelinelabels.StateApplyingExplore)` funcione
-  sin tocar el código del paquete viejo. Ambos sets de keys (viejas +
-  v2) coexisten en el mismo mapa — ningún colisión porque los strings
-  son distintos (`"che:idea→che:planning"` vs.
-  `"che:state:idea→che:state:applying:explore"`).
-- Tests para ambos: `pipelinelabels/v2states_test.go` (literales fijos
-  + round-trip por `Parse`), `labels/v2_transitions_test.go` (las 21
-  transiciones v2 + coexistencia con las viejas).
+### 2. `stateref.stateLabelSet` mantiene AMBAS familias
 
-Los flows ya migrados (`idea`, `explore`, `execute`) usan
-**exclusivamente** los strings v2 en producción. Si un flow ya migrado
-corre sobre un issue/PR con labels viejos (`che:plan` etc.), `Apply`
-fallaría porque GitHub no encuentra el label viejo para borrar — la
-conversión runtime de labels existentes vive fuera del scope de PR6b
-(necesita un subcomando `migrate-labels-v2` similar al
-`migrate-labels` actual; queda para PR siguiente).
+`internal/flow/stateref/stateref.go:stateLabelSet` reconoce tanto los 9
+labels v1 como los 9 v2 durante PR6c. Esto es necesario para que un PR v2
+con `closingIssuesReferences` apuntando a un issue legacy v1 (típico de
+repos a medio migrar) siga resolviendo al issue. Los gates de los flows
+migrados rechazan los v1 con mensaje accionable, así que reconocer el
+label v1 en stateref no afloja la validación — solo evita falsos negativos
+en la resolución (caer al PR cuando el issue ESTÁ trackeado, solo que en
+v1).
 
-## Tests verdes en cada paquete migrado
+REMOVE IN PR6d: cuando ya no haya repos sin migrar, el set se reduce a
+solo v2.
+
+### 3. Dash `applyLabels`: prefix-aware con `v2StatusByLabel` map
+
+El parser ramifica por:
+1. `che:state:applying:*` o `che:state:*` (v2) → mapeo via
+   `v2StatusByLabel` a uno de los 9 strings canónicos del kanban
+   (idea/planning/plan/.../closed). El orden de chequeo es
+   `PrefixState` (que cubre ambos casos) primero; el TrimPrefix correcto
+   se elige por presencia de `PrefixApplying`.
+2. `che:*` (v1 legacy) → fallback que preserva el comportamiento
+   pre-PR6c (TrimPrefix → idea/planning/etc).
+3. `che:locked` se intercepta arriba con prioridad (es marker).
+
+El mapping es necesario porque los strings de columna del kanban del dash
+(`idea`, `planning`, etc) no se cambian en PR6c — preflight.go, loop.go,
+model.go esperan esos strings literales y ramifican por ellos. El
+modelo v2 los preserva via mapping en vez de cascadear el cambio a 8
+archivos del dash que están bien.
+
+Decisión sobre `validate_pr` v2 → `validating`/`validated` v1:
+preservamos las columnas legacy del kanban porque el modelo v1 colapsaba
+plan-validate y PR-validate en ese mismo bucket también — semánticamente
+no perdemos información.
+
+### 4. Dash `fetchClosedIssues` consulta AMBAS familias
+
+Antes filtraba por `che:closed` (v1) único. Ahora hace dos `gh issue
+list --state closed --label X`, una por v1 y otra por v2, y deduplica
+por número. Así repos a medio migrar (algunos issues cerrados con v1,
+otros con v2) muestran el set completo en la columna `closed`.
+
+REMOVE IN PR6d: dejar solo la query v2 cuando el v1 deje de existir.
+
+### 5. `migrate-labels-v2` aplica por-issue, no a nivel repo
+
+A diferencia de `migrate-labels` (renombra labels via `gh label edit`),
+v2 hace remove + add por cada issue. Razón: los strings v1 → v2 son
+totalmente distintos (`che:plan` vs `che:state:explore`), así que un
+rename a nivel repo no funciona — son dos labels distintos. Además
+preservamos los labels v1 en el repo (pueden referenciarse desde
+issues cerrados o ramas viejas) hasta el cleanup de PR6d.
+
+Implementación: ensure label v2 en el repo (idempotente) → DELETE v1
+(tolerante a 404, idempotente) → POST v2 (idempotente en GitHub). Si
+todo falla, paramos para no dejar labels parciales.
+
+### 6. Caveat de `che:validating` documentado pero no resuelto
+
+v1 colapsaba validate-de-plan y validate-de-PR en `che:validating`. v2
+solo tiene `applying:validate_pr`. El subcomando mapea
+`che:validating` → `che:state:applying:validate_pr` y emite un warning
+en stdout para que el operador sepa que puede ser semánticamente
+impreciso si el run en curso era plan-validate. En la práctica
+`validating` es transitorio (solo aparece durante un run) así que
+encontrarlo en migración bulk es raro. La alternativa "saltarlo y
+dejarlo manual" pierde info; la alternativa "no migrarlo" deja el repo
+con `che:validating` huérfano que ningún flow v2 entiende. El warn +
+mapping aproximado es el menos malo.
+
+## Lo que no se hizo (pendiente para PRs siguientes)
+
+- Borrar las constantes v1 viejas en `internal/labels/labels.go` y las
+  21 keys viejas en `validTransitions`. Eso es **PR6d**, después de
+  mergear este. Borrar también el shim `internal/labels/v2_transitions.go`
+  entero, las 4 listas `v1StateLabels` por flow, las ramas legacy de
+  `applyLabels` en dash y el segundo query de `fetchClosedIssues`. La
+  guía de cuáles archivos tienen `REMOVE IN PR6d:` está embebida en los
+  comentarios de los archivos respectivos.
+- Update del test `TestNoHardcodedLabelsOutsideThisPackage` para que
+  prohíba los strings v1 nuevos (post-cleanup). Hoy permite ambos
+  durante la transición.
+
+## Tests verdes
 
 ```
-internal/labels                  ok (incluye nuevos v2_transitions_test.go)
-internal/pipelinelabels          ok (incluye nuevos v2states_test.go)
-internal/flow/idea               ok (no test files; build verificada)
-internal/flow/explore            ok (fixtures en explore_test.go updated)
-internal/flow/execute            ok (fixtures en execute_test.go updated)
-e2e                              ok (idea/explore/execute fixtures + asserts updated)
+internal/flow/validate    ok (incluye TestPullRequest_PRLabelNames migrado)
+internal/flow/iterate     ok (incluye TestRunPRGate_StateFromIssue migrado)
+internal/flow/close       ok (incluye TestCloseFromStateRes migrado)
+internal/flow/stateref    ok
+internal/dash             ok (los tests existentes pasan; no se agregan nuevos
+                              porque applyLabels seguía funcionando con v1
+                              y ahora también con v2)
+cmd                       ok (TestMigrateV2_*, 8 casos cubriendo los 9
+                              labels, idempotencia, dry-run, mixed,
+                              short-circuit-resilient, output)
+e2e                       ok (incluye 3 nuevos tests v1-rejection: validate,
+                              iterate, close — paralelo al de explore)
 ```
 
-`go test ./...` 100% verde tras la migración. `go vet ./...` clean.
+`go build ./...` clean, `go vet ./...` clean, `go test ./...` 100% verde.
 
-## Pendiente (TODO para PR6c+)
-
-Por orden de complejidad ascendente:
-
-1. **`internal/flow/stateref`** — exporta el set `stateLabelSet` de los
-   9 estados viejos (usado por `che close` para detectar issues con
-   estado che:* aplicado). La migración es trivial (mapeo directo) pero
-   afecta el detector de drift entre `internal/labels` y el set de
-   estados que el dash/closing usan. Recomendado abordar **junto** con
-   el flow de close.
-2. **`internal/flow/close`** — gate ramifica por `che:executed` /
-   `che:validated`, transiciones a `che:closing` → `che:closed`,
-   resolución por `closingIssuesReferences` con fallback al PR. La
-   migración es mecánica pero atraviesa varias funciones (`prFrom`,
-   `groupCloseable`, `closeIssue`, `closeFromPR`). Tests: actualizar
-   `closing_test.go` (tiene fixtures con todos los estados viejos).
-3. **`internal/flow/iterate`** — dos modos (PR + plan), cada uno con su
-   propio gate + Apply. PR-mode usa `che:validated` /
-   `che:executing` / `che:executed`; plan-mode usa `che:validated` /
-   `che:planning` / `che:plan`. También toca verdicts
-   (`plan-validated:changes-requested`) que NO migran (esos labels
-   sobreviven al modelo v2). Tests: `iterate_test.go` espeja la
-   matriz; cuidado con la asimetría PR/plan.
-4. **`internal/flow/validate`** — el más complejo. PR-mode con
-   `executed → validating → validated` + rollback, plan-mode con
-   `plan → validating → validated` + rollback, además aplica labels
-   verdict (`validated:approve`, `plan-validated:approve`, etc.) que
-   NO se migran a v2 (los verdicts conviven con la máquina de estados
-   pero no son estados). El test file tiene ~1700 líneas con muchas
-   matrices.
-5. **Callers fuera de los flows** — todavía importan `internal/labels`
-   y usan las constantes viejas:
-   - `cmd/migrate_labels.go` (input del migrador viejo `status:*` →
-     `che:*`; queda como referencia histórica).
-   - `cmd/unlock.go` (usa `labels.Unlock` — orthogonal, NO migra).
-   - `internal/dash/gh_source.go` (usa `labels.CheClosed`,
-     `labels.CtPlan`, `labels.CheLocked` — algunos migrarían en PR6c
-     cuando dash hable v2; otros son orthogonal).
-   - `internal/tui/model.go` (usa `labels.LockedRef`, `labels.Unlock`,
-     `labels.ListLocked` — todos orthogonal, NO migran).
-   - `internal/startup/checks.go` (no usa estados, OK).
-   - `internal/flow/stateref/stateref.go` (mapeo del set de estados;
-     ver pendiente #1).
-
-6. **Nuevo subcomando `migrate-labels-v2`** — para repos vivos con
-   issues en estados viejos. Renombrar in-place `che:idea` →
-   `che:state:idea` etc. en todos los issues. Análogo a `cmd/migrate_labels.go`.
-   FUERA del scope del PR6b por la guidance "migración flow por flow".
-
-7. **Borrado de las constantes viejas** (`labels.CheIdea` etc.) y de
-   las keys viejas en `validTransitions` — eso es PR6c (post-migración
-   de TODOS los flows). El test `TestNoHardcodedLabelsOutsideThisPackage`
-   se actualizará para forbiddear los strings v2 también, garantizando
-   que ningún caller invente literales.
-
-## Decisiones / desviaciones
-
-### 1. `pipelinelabels.State*` como `var`, no `const`
-
-Los 9 estados v2 son `var` porque se inicializan llamando
-`StateLabel("idea")` / `ApplyingLabel("explore")` — las funciones del
-paquete son la fuente de verdad de los prefijos (`PrefixState`,
-`PrefixApplying`). Si en el futuro alguien renombrara los prefijos sin
-actualizar las constantes, los tests de round-trip
-(`TestV2States_LiteralValues` + `TestV2States_RoundTripParse`) lo
-detectarían inmediatamente.
-
-### 2. `labels/v2_transitions.go` usa `init()`
-
-En vez de incrustar el mapa v2 dentro del literal de `validTransitions`
-en `labels.go` (que requeriría tocar el archivo viejo y hacerlo
-depender de `pipelinelabels`), uso un archivo separado con `init()` que
-muta el mapa. Esto cumple "no borrar" + "coexistencia" con un solo
-file diff, y un futuro PR6c puede borrar este archivo entero (más las
-keys viejas) en un solo cambio.
-
-### 3. Mapeo de estados viejos → v2 (PRD §6.c)
-
-| viejo            | v2                              |
-|------------------|---------------------------------|
-| `che:idea`       | `che:state:idea`                |
-| `che:planning`   | `che:state:applying:explore`    |
-| `che:plan`       | `che:state:explore`             |
-| `che:executing`  | `che:state:applying:execute`    |
-| `che:executed`   | `che:state:execute`             |
-| `che:validating` | `che:state:applying:validate_pr`|
-| `che:validated`  | `che:state:validate_pr`         |
-| `che:closing`    | `che:state:applying:close`      |
-| `che:closed`     | `che:state:close`               |
-
-Notar que el modelo v2 colapsa "validate sobre plan" y "validate sobre
-PR" en un solo step (`validate_pr`). El modelo viejo tampoco
-distinguía a nivel de label (ambos usaban `che:validating` /
-`che:validated` — la distinción venía del tipo de entidad target). En
-PR6b mantenemos el mapeo 1:1; refinar a steps separados (`validate_plan`
-vs. `validate_pr`) requiere extender el pipeline declarativo
-(`internal/pipeline`) con dos steps de validate, fuera del scope de la
-migración.
-
-### 4. Fixtures de e2e usan literales v2 directamente
-
-Los archivos `e2e/testdata/{explore,execute,idea}/*.json` y los asserts
-en `e2e/{explore,execute,idea}_test.go` ahora contienen literales v2
-(`"che:state:idea"`, `"che:state:explore"`, etc.). Como los archivos
-`_test.go` y `testdata/` están excluidos de
-`TestNoHardcodedLabelsOutsideThisPackage`, esto es legal y evita
-arrastrar `pipelinelabels` como dependencia del harness e2e.
-
-### 5. Marker labels NO migran
-
-`labels.CtPlan` (y `labels.CheLocked`) son labels ortogonales — NO son
-parte de la máquina de estados, y el modelo v2 no los redefine. Siguen
-viviendo en `internal/labels` y siguen referenciándose como `labels.CtPlan`
-/ `labels.CheLocked` desde los flows migrados. Los verdicts
-(`labels.ValidatedApprove`, `labels.PlanValidatedChangesRequested`,
-etc.) son la misma situación: no son estados, no migran.
-
-## Cómo continuar (PR6c+)
-
-Recomendación de orden:
-1. Migrar `stateref` + `close` juntos (forman una unidad lógica).
-2. Migrar `iterate` (más complejo pero auto-contenido).
-3. Migrar `validate` (el más complejo, pero con todos los demás
-   migrados antes ya tenés el patrón resuelto).
-4. Migrar callers no-flow (`dash/gh_source.go` para los estados,
-   dejar TUI/unlock/migrate_labels en paz).
-5. Borrar el shim `v2_transitions.go` y las 9 constantes viejas en
-   `labels.go` (más sus 21 transiciones); actualizar
-   `TestNoHardcodedLabelsOutsideThisPackage` para que prohíba ambos
-   sets de literales.
+`grep -rn 'labels\\.\\(CheIdea\\|...\\)' internal/flow internal/dash` solo
+muestra los hits intencionales (guards + stateref legacy lookup + dash
+closed filter); todos comentados con `REMOVE IN PR6d` para señalizar el
+cleanup.

--- a/cmd/migrate_labels_v2.go
+++ b/cmd/migrate_labels_v2.go
@@ -1,0 +1,285 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"sort"
+	"strings"
+
+	"github.com/chichex/che/internal/labels"
+	"github.com/chichex/che/internal/pipelinelabels"
+	"github.com/spf13/cobra"
+)
+
+// v2Pair representa un mapping v1 → v2 que `che migrate-labels-v2` aplica
+// in-place sobre los issues abiertos. Distinto del `pair` de migrate-labels:
+// ese otro renombra labels a nivel repo (`gh label edit`); este aplica el
+// cambio por-issue (remove label viejo + add label nuevo) porque los strings
+// nuevos son TOTALMENTE distintos (`che:state:*` vs `che:*`) y queremos
+// preservar el valor histórico del label viejo si el operador lo necesita.
+type v2Pair struct {
+	V1, V2 string
+}
+
+// v2MigrationPairs devuelve el mapping de los 9 estados v1 → v2 según la
+// tabla canónica del PRD §6.c. El orden es el del embudo (idea → close)
+// para que el output del subcomando se lea como progresión natural.
+//
+// Caveat sobre `che:validating`: en v1 cubría tanto validate-de-plan como
+// validate-de-PR. En v2 hay un solo step (`validate_pr`). El mapping a
+// `applying:validate_pr` es el más cercano semánticamente, pero si el
+// repo tenía issues con `che:validating` originados desde plan-validate
+// (pre-v0.0.49 se usaba sobre el issue durante el run de validate plan),
+// el operador puede preferir saltar al estado terminal manualmente. El
+// estado validating es transitorio (solo aparece durante un run en curso)
+// así que en migración bulk es raro encontrarlo. Si lo encontramos
+// log.Warn pero mapeamos igual.
+func v2MigrationPairs() []v2Pair {
+	return []v2Pair{
+		{V1: labels.CheIdea, V2: pipelinelabels.StateIdea},
+		{V1: labels.ChePlanning, V2: pipelinelabels.StateApplyingExplore},
+		{V1: labels.ChePlan, V2: pipelinelabels.StateExplore},
+		{V1: labels.CheExecuting, V2: pipelinelabels.StateApplyingExecute},
+		{V1: labels.CheExecuted, V2: pipelinelabels.StateExecute},
+		{V1: labels.CheValidating, V2: pipelinelabels.StateApplyingValidatePR},
+		{V1: labels.CheValidated, V2: pipelinelabels.StateValidatePR},
+		{V1: labels.CheClosing, V2: pipelinelabels.StateApplyingClose},
+		{V1: labels.CheClosed, V2: pipelinelabels.StateClose},
+	}
+}
+
+var (
+	migrateLabelsV2Repo   string
+	migrateLabelsV2DryRun bool
+)
+
+var migrateLabelsV2Cmd = &cobra.Command{
+	Use:   "migrate-labels-v2",
+	Short: "migra los labels viejos che:* a la familia v2 che:state:*",
+	Long: `migrate-labels-v2 itera los issues abiertos del repo y por cada uno
+con un label de la máquina vieja (che:idea, che:planning, che:plan,
+che:executing, che:executed, che:validating, che:validated, che:closing,
+che:closed) lo reemplaza por el label v2 correspondiente
+(che:state:idea ... che:state:close, con `+"`applying:`"+` para los estados
+intermedios — ver tabla del PRD §6.c).
+
+A diferencia de ` + "`migrate-labels`" + ` (que renombra labels a nivel del
+repo via ` + "`gh label edit`" + `), esto opera por-issue: hace remove del
+label v1 y add del label v2 para cada caso. Los labels viejos (che:*) no
+se borran del repo — los flows migrados a v2 los rechazan vía guard
+v1-rejection con mensaje accionable.
+
+Idempotencia:
+  - Si un issue ya tiene el label v2 correspondiente, skip silencioso (no
+    se duplica).
+  - Si tiene MIXTO (label v1 y v2 presentes a la vez), warn y NO toca:
+    el operador resuelve a mano para no perder información.
+  - Si no tiene ningún label che:*, skip silencioso.
+
+Caveat de ` + "`che:validating`" + `: cubre AMBOS modos plan/PR en v1, en v2
+mapea a applying:validate_pr (el modelo v2 colapsa los dos modos en un
+solo step). Si lo encontramos logueamos un warning porque el mapping
+puede ser semánticamente impreciso para repos que estaban en validate
+plan en curso al momento de migrar.
+
+Flags:
+  --repo     path al repo git (default: cwd)
+  --dry-run  solo lista qué haría, sin tocar nada`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		return runMigrateLabelsV2(cmd.OutOrStdout(), migrateLabelsV2Repo, migrateLabelsV2DryRun)
+	},
+}
+
+func init() {
+	migrateLabelsV2Cmd.Flags().StringVar(&migrateLabelsV2Repo, "repo", "", "path al repo git (default: cwd)")
+	migrateLabelsV2Cmd.Flags().BoolVar(&migrateLabelsV2DryRun, "dry-run", false, "solo lista qué haría, sin tocar nada")
+	rootCmd.AddCommand(migrateLabelsV2Cmd)
+}
+
+// migrateIssue es una vista mínima del issue para el migrador. number +
+// labels es todo lo que necesitamos para decidir qué tocar.
+type migrateIssue struct {
+	Number int           `json:"number"`
+	Title  string        `json:"title"`
+	Labels []migrateLbl  `json:"labels"`
+}
+
+type migrateLbl struct {
+	Name string `json:"name"`
+}
+
+// listIssuesFn es el extractor de issues a migrar, variable para que los
+// tests lo stubeen sin shell-out a gh.
+var listIssuesFn = listIssuesViaGh
+
+// applyMigrationFn es el aplicador de un cambio (remove v1 + add v2),
+// variable para tests.
+var applyMigrationFn = applyMigrationViaGh
+
+// runMigrateLabelsV2 itera los issues abiertos del repo, decide qué
+// transformación aplicar a cada uno y emite el reporte. Devuelve el primer
+// error fatal — si un solo issue falla, paramos para no dejar el repo a
+// medias (un usuario que ve "ok 1 / fail 5 / skip 3" no sabe el estado real).
+func runMigrateLabelsV2(out io.Writer, repo string, dryRun bool) error {
+	issues, err := listIssuesFn(repo)
+	if err != nil {
+		return fmt.Errorf("listing issues: %w", err)
+	}
+
+	v1Set := make(map[string]string, 9) // v1 → v2
+	for _, p := range v2MigrationPairs() {
+		v1Set[p.V1] = p.V2
+	}
+	v2Set := make(map[string]bool, 9)
+	for _, p := range v2MigrationPairs() {
+		v2Set[p.V2] = true
+	}
+
+	fmt.Fprintf(out, "scanned %d open issue(s)\n", len(issues))
+
+	var modified, skipped, mixed int
+	var firstErr error
+	for _, iss := range issues {
+		v1Found := make(map[string]bool, 1)
+		v2Found := make(map[string]bool, 1)
+		for _, l := range iss.Labels {
+			if _, ok := v1Set[l.Name]; ok {
+				v1Found[l.Name] = true
+			}
+			if v2Set[l.Name] {
+				v2Found[l.Name] = true
+			}
+		}
+		// Sin labels v1: no hay nada que migrar acá. Saltamos silenciosamente.
+		if len(v1Found) == 0 {
+			continue
+		}
+		// MIXTO: tiene ambos modelos. No tocamos para no pisar lo que el
+		// operador armó a mano. Reporta pero no aborta — el resto del scan
+		// puede tener issues v1-only legítimos.
+		if len(v2Found) > 0 {
+			mixed++
+			v1Names := sortedKeys(v1Found)
+			v2Names := sortedKeys(v2Found)
+			fmt.Fprintf(out, "skip mixed: #%d %q tiene v1 (%s) + v2 (%s) — resolvelo a mano\n",
+				iss.Number, iss.Title, strings.Join(v1Names, ","), strings.Join(v2Names, ","))
+			continue
+		}
+		// Mapeo v1 → v2 ordenado por nombre del v1 para output estable.
+		actions := make([]v2Pair, 0, len(v1Found))
+		for v1 := range v1Found {
+			actions = append(actions, v2Pair{V1: v1, V2: v1Set[v1]})
+		}
+		sort.Slice(actions, func(i, j int) bool { return actions[i].V1 < actions[j].V1 })
+
+		fmt.Fprintf(out, "issue #%d %q\n", iss.Number, iss.Title)
+		for _, a := range actions {
+			// Caveat de validating: warn pero migra. Ver doc del paquete.
+			if a.V1 == labels.CheValidating {
+				fmt.Fprintf(out, "  warn: %s en v1 cubría plan+PR; mapeo a %s puede no encajar si el run era plan-validate\n", a.V1, a.V2)
+			}
+			if dryRun {
+				fmt.Fprintf(out, "  [dry-run] %s → %s\n", a.V1, a.V2)
+				continue
+			}
+			if err := applyMigrationFn(repo, iss.Number, a.V1, a.V2); err != nil {
+				if firstErr == nil {
+					firstErr = fmt.Errorf("issue #%d: %w", iss.Number, err)
+				}
+				fmt.Fprintf(out, "  FAIL %s → %s: %v\n", a.V1, a.V2, err)
+				continue
+			}
+			fmt.Fprintf(out, "  ok   %s → %s\n", a.V1, a.V2)
+		}
+		modified++
+	}
+
+	fmt.Fprintf(out, "summary: %d modified, %d skipped (mixed v1+v2)\n", modified, mixed)
+	_ = skipped // referencia futura: aún no diferenciamos skipped por categoría
+	if firstErr != nil {
+		return firstErr
+	}
+	return nil
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// listIssuesViaGh corre `gh issue list --state open --json number,title,labels
+// --limit 200`. El cap 200 cubre la mayoría de los repos; un repo con más
+// issues abiertos es excepcional y el operador puede correr el comando dos
+// veces tras migrar el primer batch.
+func listIssuesViaGh(repo string) ([]migrateIssue, error) {
+	cmd := exec.Command("gh", "issue", "list",
+		"--state", "open",
+		"--json", "number,title,labels",
+		"--limit", "200")
+	if repo != "" {
+		cmd.Dir = repo
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("gh issue list: %s", strings.TrimSpace(string(out)))
+	}
+	var issues []migrateIssue
+	if err := json.Unmarshal(out, &issues); err != nil {
+		return nil, fmt.Errorf("parse gh output: %w", err)
+	}
+	return issues, nil
+}
+
+// applyMigrationViaGh remueve `v1` y agrega `v2` sobre un issue concreto.
+// Sigue el mismo patrón que internal/labels.Apply: ensure (v2) primero,
+// luego remove + add via REST. No usamos labels.Apply porque eso exige una
+// transición registrada en validTransitions, y acá el "from" es un label
+// v1 huérfano (no hay transición v1→v2 registrada — el shim solo registra
+// v2→v2).
+func applyMigrationViaGh(repo string, issueNumber int, v1, v2 string) error {
+	// Ensure el v2 en el repo (idempotente). Sin esto, el POST falla si el
+	// repo nunca usó ese label (p.ej. nunca corrió un flow v2).
+	ensureCmd := exec.Command("gh", "label", "create", v2, "--force")
+	if repo != "" {
+		ensureCmd.Dir = repo
+	}
+	if out, err := ensureCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("ensure label %s: %s", v2, strings.TrimSpace(string(out)))
+	}
+
+	// Remove v1 vía REST. Tolerante a 404 (el label no estaba aplicado).
+	removeCmd := exec.Command("gh", "api",
+		"-X", "DELETE",
+		fmt.Sprintf("repos/{owner}/{repo}/issues/%d/labels/%s", issueNumber, v1),
+	)
+	if repo != "" {
+		removeCmd.Dir = repo
+	}
+	if out, err := removeCmd.CombinedOutput(); err != nil {
+		combined := string(out)
+		if !strings.Contains(combined, "Label does not exist") && !strings.Contains(combined, "HTTP 404") {
+			return fmt.Errorf("remove %s: %s", v1, strings.TrimSpace(combined))
+		}
+	}
+
+	// Add v2 vía REST.
+	addCmd := exec.Command("gh", "api",
+		"-X", "POST",
+		fmt.Sprintf("repos/{owner}/{repo}/issues/%d/labels", issueNumber),
+		"-f", "labels[]="+v2,
+	)
+	if repo != "" {
+		addCmd.Dir = repo
+	}
+	if out, err := addCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("add %s: %s", v2, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/cmd/migrate_labels_v2_test.go
+++ b/cmd/migrate_labels_v2_test.go
@@ -1,0 +1,287 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/chichex/che/internal/labels"
+	"github.com/chichex/che/internal/pipelinelabels"
+)
+
+// TestV2MigrationPairs valida el contrato del helper: los 9 pares v1 → v2
+// canónicos en el orden del embudo (idea → close), sin duplicados de V1 ni
+// de V2. Es el espejo de TestMigrationPairs para v1→v2.
+func TestV2MigrationPairs(t *testing.T) {
+	pairs := v2MigrationPairs()
+
+	want := []v2Pair{
+		{V1: labels.CheIdea, V2: pipelinelabels.StateIdea},
+		{V1: labels.ChePlanning, V2: pipelinelabels.StateApplyingExplore},
+		{V1: labels.ChePlan, V2: pipelinelabels.StateExplore},
+		{V1: labels.CheExecuting, V2: pipelinelabels.StateApplyingExecute},
+		{V1: labels.CheExecuted, V2: pipelinelabels.StateExecute},
+		{V1: labels.CheValidating, V2: pipelinelabels.StateApplyingValidatePR},
+		{V1: labels.CheValidated, V2: pipelinelabels.StateValidatePR},
+		{V1: labels.CheClosing, V2: pipelinelabels.StateApplyingClose},
+		{V1: labels.CheClosed, V2: pipelinelabels.StateClose},
+	}
+	if len(pairs) != len(want) {
+		t.Fatalf("len: got %d, want %d", len(pairs), len(want))
+	}
+	for i, w := range want {
+		if pairs[i] != w {
+			t.Errorf("pair[%d]: got %+v, want %+v", i, pairs[i], w)
+		}
+	}
+	seenV1 := map[string]bool{}
+	seenV2 := map[string]bool{}
+	for _, p := range pairs {
+		if seenV1[p.V1] {
+			t.Errorf("duplicate V1: %s", p.V1)
+		}
+		if seenV2[p.V2] {
+			t.Errorf("duplicate V2: %s", p.V2)
+		}
+		seenV1[p.V1] = true
+		seenV2[p.V2] = true
+	}
+}
+
+// fakeMigrate captura las llamadas a applyMigrationFn para que los tests
+// puedan asserts sin shell-out a gh.
+type fakeMigrate struct {
+	mu    sync.Mutex
+	calls []fakeMigrateCall
+}
+
+type fakeMigrateCall struct {
+	IssueNumber int
+	V1, V2      string
+}
+
+func (f *fakeMigrate) apply(repo string, issueNumber int, v1, v2 string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, fakeMigrateCall{issueNumber, v1, v2})
+	return nil
+}
+
+// withFakes instala fakes para listIssuesFn y applyMigrationFn por la
+// duración del test, restaurando los originales al volver. Devuelve el
+// recorder para asserts.
+func withFakes(t *testing.T, issues []migrateIssue) *fakeMigrate {
+	t.Helper()
+	prevList := listIssuesFn
+	prevApply := applyMigrationFn
+	rec := &fakeMigrate{}
+	listIssuesFn = func(repo string) ([]migrateIssue, error) {
+		return issues, nil
+	}
+	applyMigrationFn = rec.apply
+	t.Cleanup(func() {
+		listIssuesFn = prevList
+		applyMigrationFn = prevApply
+	})
+	return rec
+}
+
+// mkIssue es un constructor breve para reducir verbosidad en los casos de
+// test. labels acepta nombres directos (no requiere wrap struct).
+func mkIssue(num int, title string, lbls ...string) migrateIssue {
+	out := migrateIssue{Number: num, Title: title}
+	for _, l := range lbls {
+		out.Labels = append(out.Labels, migrateLbl{Name: l})
+	}
+	return out
+}
+
+// TestMigrateV2_NineLabels_OneToOne: un issue por cada uno de los 9 estados
+// v1 → genera los 9 mappings esperados, idempotente segundo run.
+func TestMigrateV2_NineLabels_OneToOne(t *testing.T) {
+	issues := []migrateIssue{
+		mkIssue(1, "idea", labels.CheIdea),
+		mkIssue(2, "planning", labels.ChePlanning),
+		mkIssue(3, "plan", labels.ChePlan),
+		mkIssue(4, "executing", labels.CheExecuting),
+		mkIssue(5, "executed", labels.CheExecuted),
+		mkIssue(6, "validating", labels.CheValidating),
+		mkIssue(7, "validated", labels.CheValidated),
+		mkIssue(8, "closing", labels.CheClosing),
+		mkIssue(9, "closed", labels.CheClosed),
+	}
+	rec := withFakes(t, issues)
+	var buf bytes.Buffer
+	if err := runMigrateLabelsV2(&buf, "", false /* dryRun */); err != nil {
+		t.Fatalf("unexpected error: %v\noutput:\n%s", err, buf.String())
+	}
+	if len(rec.calls) != 9 {
+		t.Fatalf("expected 9 apply calls, got %d", len(rec.calls))
+	}
+	// Mapping correcto por número de issue.
+	want := map[int][2]string{
+		1: {labels.CheIdea, pipelinelabels.StateIdea},
+		2: {labels.ChePlanning, pipelinelabels.StateApplyingExplore},
+		3: {labels.ChePlan, pipelinelabels.StateExplore},
+		4: {labels.CheExecuting, pipelinelabels.StateApplyingExecute},
+		5: {labels.CheExecuted, pipelinelabels.StateExecute},
+		6: {labels.CheValidating, pipelinelabels.StateApplyingValidatePR},
+		7: {labels.CheValidated, pipelinelabels.StateValidatePR},
+		8: {labels.CheClosing, pipelinelabels.StateApplyingClose},
+		9: {labels.CheClosed, pipelinelabels.StateClose},
+	}
+	for _, c := range rec.calls {
+		exp, ok := want[c.IssueNumber]
+		if !ok {
+			t.Errorf("unexpected call for issue #%d", c.IssueNumber)
+			continue
+		}
+		if c.V1 != exp[0] || c.V2 != exp[1] {
+			t.Errorf("issue #%d: got %s→%s, want %s→%s", c.IssueNumber, c.V1, c.V2, exp[0], exp[1])
+		}
+	}
+	// Caveat de validating debería aparecer en el output.
+	if !strings.Contains(buf.String(), "validating") || !strings.Contains(buf.String(), "warn:") {
+		t.Errorf("expected warning about che:validating mapping, got:\n%s", buf.String())
+	}
+	// Summary correcto.
+	if !strings.Contains(buf.String(), "9 modified") {
+		t.Errorf("expected '9 modified' summary, got:\n%s", buf.String())
+	}
+}
+
+// TestMigrateV2_AlreadyV2_Idempotent: issue ya migrado (solo v2 labels) →
+// skipeado silenciosamente (sin call al applier, sin fila en output).
+func TestMigrateV2_AlreadyV2_Idempotent(t *testing.T) {
+	issues := []migrateIssue{
+		mkIssue(1, "ya migrado", "ct:plan", pipelinelabels.StateExplore),
+	}
+	rec := withFakes(t, issues)
+	var buf bytes.Buffer
+	if err := runMigrateLabelsV2(&buf, "", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rec.calls) != 0 {
+		t.Errorf("expected 0 apply calls (issue ya migrado), got %d", len(rec.calls))
+	}
+	if !strings.Contains(buf.String(), "0 modified") {
+		t.Errorf("expected '0 modified' summary, got:\n%s", buf.String())
+	}
+}
+
+// TestMigrateV2_Mixed_SkipsAndWarns: issue con v1 y v2 simultáneos →
+// skipeado con warning, no se aplica nada.
+func TestMigrateV2_Mixed_SkipsAndWarns(t *testing.T) {
+	issues := []migrateIssue{
+		mkIssue(42, "mixto", "ct:plan", labels.ChePlan, pipelinelabels.StateExplore),
+	}
+	rec := withFakes(t, issues)
+	var buf bytes.Buffer
+	if err := runMigrateLabelsV2(&buf, "", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rec.calls) != 0 {
+		t.Fatalf("expected 0 apply calls (mixto skipeado), got %d", len(rec.calls))
+	}
+	if !strings.Contains(buf.String(), "skip mixed") {
+		t.Errorf("expected 'skip mixed' line, got:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "1 skipped") {
+		t.Errorf("expected '1 skipped (mixed v1+v2)' summary, got:\n%s", buf.String())
+	}
+}
+
+// TestMigrateV2_NoCheLabels_Skip: issue sin ningún label che:* → skipeado
+// silencioso (sin fila en output), no apply.
+func TestMigrateV2_NoCheLabels_Skip(t *testing.T) {
+	issues := []migrateIssue{
+		mkIssue(99, "sin che:*", "ct:plan", "type:feature"),
+	}
+	rec := withFakes(t, issues)
+	var buf bytes.Buffer
+	if err := runMigrateLabelsV2(&buf, "", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rec.calls) != 0 {
+		t.Errorf("expected 0 apply calls (sin che:*), got %d", len(rec.calls))
+	}
+	// El issue NO debería aparecer en output (skip silencioso).
+	if strings.Contains(buf.String(), "#99") {
+		t.Errorf("issue sin che:* no debería aparecer en output, got:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), "0 modified") {
+		t.Errorf("expected '0 modified' summary, got:\n%s", buf.String())
+	}
+}
+
+// TestMigrateV2_DryRun_NoApply: dry-run no llama a applyMigrationFn ni
+// modifica nada, solo lista qué haría.
+func TestMigrateV2_DryRun_NoApply(t *testing.T) {
+	issues := []migrateIssue{
+		mkIssue(1, "idea legacy", labels.CheIdea),
+		mkIssue(2, "plan legacy", labels.ChePlan),
+	}
+	rec := withFakes(t, issues)
+	var buf bytes.Buffer
+	if err := runMigrateLabelsV2(&buf, "", true /* dryRun */); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rec.calls) != 0 {
+		t.Fatalf("expected 0 apply calls (dry-run), got %d", len(rec.calls))
+	}
+	out := buf.String()
+	if !strings.Contains(out, "[dry-run]") {
+		t.Errorf("expected '[dry-run]' marker, got:\n%s", out)
+	}
+	if !strings.Contains(out, labels.CheIdea+" → "+pipelinelabels.StateIdea) {
+		t.Errorf("expected idea mapping in dry-run, got:\n%s", out)
+	}
+	if !strings.Contains(out, labels.ChePlan+" → "+pipelinelabels.StateExplore) {
+		t.Errorf("expected plan mapping in dry-run, got:\n%s", out)
+	}
+}
+
+// TestMigrateV2_Mixed_DoesNotShortCircuit: un issue mixto en el medio del
+// scan no debe abortar el procesamiento del resto.
+func TestMigrateV2_Mixed_DoesNotShortCircuit(t *testing.T) {
+	issues := []migrateIssue{
+		mkIssue(1, "ok", labels.CheIdea),
+		mkIssue(2, "mixto", labels.ChePlan, pipelinelabels.StateExplore),
+		mkIssue(3, "ok2", labels.CheExecuted),
+	}
+	rec := withFakes(t, issues)
+	var buf bytes.Buffer
+	if err := runMigrateLabelsV2(&buf, "", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rec.calls) != 2 {
+		t.Fatalf("expected 2 apply calls (issue mixto skipeado, otros 2 procesados), got %d", len(rec.calls))
+	}
+	if !strings.Contains(buf.String(), "2 modified") {
+		t.Errorf("expected '2 modified' summary, got:\n%s", buf.String())
+	}
+}
+
+// TestMigrateV2_OutputIncludesIssueTitleAndMappings: el output estructurado
+// nombra cada issue tocado con su número y título, y cada mapping aplicado.
+func TestMigrateV2_OutputIncludesIssueTitleAndMappings(t *testing.T) {
+	issues := []migrateIssue{
+		mkIssue(7, "Mi issue cool", labels.CheExecuted),
+	}
+	withFakes(t, issues)
+	var buf bytes.Buffer
+	if err := runMigrateLabelsV2(&buf, "", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "#7") {
+		t.Errorf("expected issue #7 in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Mi issue cool") {
+		t.Errorf("expected issue title in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, labels.CheExecuted+" → "+pipelinelabels.StateExecute) {
+		t.Errorf("expected mapping in output, got:\n%s", out)
+	}
+}

--- a/e2e/close_test.go
+++ b/e2e/close_test.go
@@ -41,6 +41,29 @@ func TestClose_InvalidPRRef_Exit3(t *testing.T) {
 	env.Invocations().AssertNotCalled(t, "claude")
 }
 
+// TestClose_OldV1Label_Exit3: PR de un repo no migrado con `che:executed`
+// (v1) en vez de `che:state:execute` (v2). El gate v1-rejection rechaza con
+// exit 3 + mensaje accionable apuntando a `che migrate-labels-v2` antes
+// de aplicar lock o transiciones.
+func TestClose_OldV1Label_Exit3(t *testing.T) {
+	env := setupCloseEnv(t)
+	scriptClosePrechecks(env)
+
+	env.ExpectGh(`^pr view 7`).RespondStdoutFromFixture("close/gh_pr_view_old_label_che_executed.json", 0)
+
+	r := env.Run("close", "7")
+	if r.ExitCode != 3 {
+		t.Fatalf("expected exit 3 (gate v1 rechaza), got %d\nstderr: %s", r.ExitCode, r.Stderr)
+	}
+	harness.AssertContains(t, r.Stderr, "v1")
+	harness.AssertContains(t, r.Stderr, "migrate-labels-v2")
+	env.Invocations().AssertNotCalled(t, "claude")
+	// Sin merge.
+	if merges := env.Invocations().FindCalls("gh", "pr merge"); len(merges) != 0 {
+		t.Fatalf("no debería haber merge (gate rechaza); calls=%v", merges)
+	}
+}
+
 // TestClose_ClosedPR_Exit3: PR con state=MERGED → exit 3, no invoca opus.
 func TestClose_ClosedPR_Exit3(t *testing.T) {
 	env := setupCloseEnv(t)
@@ -131,7 +154,7 @@ func TestClose_GoldenPath_DraftToReadyAndMerge(t *testing.T) {
 
 	inv := env.Invocations()
 	// Needles compuestos: "pr merge" y "issue close" evitan que
-	// "mergeable" y "che:closed" (substrings en otras calls) metan
+	// "mergeable" y "che:state:close" (substrings en otras calls) metan
 	// falsos positivos.
 	if reads := inv.FindCalls("gh", "pr ready 7"); len(reads) != 1 {
 		t.Fatalf("expected 1 gh pr ready call, got %d", len(reads))
@@ -151,19 +174,19 @@ func TestClose_GoldenPath_DraftToReadyAndMerge(t *testing.T) {
 	if closes := inv.FindCalls("gh", "issue close 42"); len(closes) != 1 {
 		t.Fatalf("expected 1 gh issue close call, got %d", len(closes))
 	}
-	// labels.Apply hace 2 transiciones sobre el issue (executed→closing→
-	// closed). Con REST cada una se descompone en 1 DELETE + 1 POST.
-	if dels := inv.FindCalls("gh", "api", "-X", "DELETE", "issues/42/labels/che:executed"); len(dels) != 1 {
-		t.Fatalf("expected 1 DELETE che:executed, got %d", len(dels))
+	// labels.Apply hace 2 transiciones sobre el issue (execute→applying:close→
+	// close). Con REST cada una se descompone en 1 DELETE + 1 POST.
+	if dels := inv.FindCalls("gh", "api", "-X", "DELETE", "issues/42/labels/che:state:execute"); len(dels) != 1 {
+		t.Fatalf("expected 1 DELETE che:state:execute, got %d", len(dels))
 	}
-	if posts := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:closing"); len(posts) != 1 {
-		t.Fatalf("expected 1 POST adding che:closing, got %d", len(posts))
+	if posts := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:state:applying:close"); len(posts) != 1 {
+		t.Fatalf("expected 1 POST adding che:state:applying:close, got %d", len(posts))
 	}
-	if dels := inv.FindCalls("gh", "api", "-X", "DELETE", "issues/42/labels/che:closing"); len(dels) != 1 {
-		t.Fatalf("expected 1 DELETE che:closing, got %d", len(dels))
+	if dels := inv.FindCalls("gh", "api", "-X", "DELETE", "issues/42/labels/che:state:applying:close"); len(dels) != 1 {
+		t.Fatalf("expected 1 DELETE che:state:applying:close, got %d", len(dels))
 	}
-	if posts := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:closed"); len(posts) != 1 {
-		t.Fatalf("expected 1 POST adding che:closed, got %d", len(posts))
+	if posts := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels", "labels[]=che:state:close"); len(posts) != 1 {
+		t.Fatalf("expected 1 POST adding che:state:close, got %d", len(posts))
 	}
 	env.Invocations().AssertNotCalled(t, "claude")
 }
@@ -187,7 +210,7 @@ func TestClose_NotDraft_SkipsReady(t *testing.T) {
   "mergeStateStatus": "CLEAN",
   "author": {"login": "acme-bot"},
   "closingIssuesReferences": [{"number": 42, "state": "OPEN"}],
-  "labels": [{"name": "che:executed"}]
+  "labels": [{"name": "che:state:execute"}]
 }`, 0)
 
 	env.ExpectGh(`^pr checks 7`).RespondStdoutFromFixture("close/gh_pr_checks_pass.json", 0)
@@ -221,7 +244,7 @@ func TestClose_KeepBranch_PreservesBranchAndWorktree(t *testing.T) {
   "mergeStateStatus": "CLEAN",
   "author": {"login": "acme-bot"},
   "closingIssuesReferences": [{"number": 42, "state": "OPEN"}],
-  "labels": [{"name": "che:executed"}]
+  "labels": [{"name": "che:state:execute"}]
 }`, 0)
 
 	env.ExpectGh(`^pr checks 7`).RespondStdoutFromFixture("close/gh_pr_checks_pass.json", 0)
@@ -268,7 +291,7 @@ func TestClose_Default_CleansCheManagedWorktree(t *testing.T) {
   "mergeStateStatus": "CLEAN",
   "author": {"login": "acme-bot"},
   "closingIssuesReferences": [{"number": 42, "state": "OPEN"}],
-  "labels": [{"name": "che:executed"}]
+  "labels": [{"name": "che:state:execute"}]
 }`, 0)
 	env.ExpectGh(`^pr checks 7`).RespondStdoutFromFixture("close/gh_pr_checks_pass.json", 0)
 	env.ExpectGh(`^pr merge 7 --merge$`).RespondStdout("Merged\n", 0)
@@ -313,7 +336,7 @@ func TestClose_KeepBranch_PreservesCheManagedWorktree(t *testing.T) {
   "mergeStateStatus": "CLEAN",
   "author": {"login": "acme-bot"},
   "closingIssuesReferences": [{"number": 42, "state": "OPEN"}],
-  "labels": [{"name": "che:executed"}]
+  "labels": [{"name": "che:state:execute"}]
 }`, 0)
 	env.ExpectGh(`^pr checks 7`).RespondStdoutFromFixture("close/gh_pr_checks_pass.json", 0)
 	env.ExpectGh(`^pr merge 7 --merge$`).RespondStdout("Merged\n", 0)
@@ -356,7 +379,7 @@ func TestClose_Default_DoesNotTouchMainWorktree(t *testing.T) {
   "mergeStateStatus": "CLEAN",
   "author": {"login": "acme-bot"},
   "closingIssuesReferences": [{"number": 42, "state": "OPEN"}],
-  "labels": [{"name": "che:executed"}]
+  "labels": [{"name": "che:state:execute"}]
 }`, 0)
 	env.ExpectGh(`^pr checks 7`).RespondStdoutFromFixture("close/gh_pr_checks_pass.json", 0)
 	env.ExpectGh(`^pr merge 7 --merge$`).RespondStdout("Merged\n", 0)
@@ -402,7 +425,7 @@ func TestClose_Default_DoesNotTouchExternalWorktree(t *testing.T) {
   "mergeStateStatus": "CLEAN",
   "author": {"login": "acme-bot"},
   "closingIssuesReferences": [{"number": 42, "state": "OPEN"}],
-  "labels": [{"name": "che:executed"}]
+  "labels": [{"name": "che:state:execute"}]
 }`, 0)
 	env.ExpectGh(`^pr checks 7`).RespondStdoutFromFixture("close/gh_pr_checks_pass.json", 0)
 	env.ExpectGh(`^pr merge 7 --merge$`).RespondStdout("Merged\n", 0)
@@ -445,7 +468,7 @@ func TestClose_RemoteDeleteFails_WarnsButExitsOK(t *testing.T) {
   "mergeStateStatus": "CLEAN",
   "author": {"login": "acme-bot"},
   "closingIssuesReferences": [{"number": 42, "state": "OPEN"}],
-  "labels": [{"name": "che:executed"}]
+  "labels": [{"name": "che:state:execute"}]
 }`, 0)
 	env.ExpectGh(`^pr checks 7`).RespondStdoutFromFixture("close/gh_pr_checks_pass.json", 0)
 	env.ExpectGh(`^pr merge 7 --merge$`).RespondStdout("Merged\n", 0)

--- a/e2e/iterate_test.go
+++ b/e2e/iterate_test.go
@@ -140,6 +140,31 @@ func TestIterate_PlanGoldenPath(t *testing.T) {
 	}
 }
 
+// TestIterate_Plan_OldV1Label_Exit3: issue de un repo no migrado con
+// `che:validated` (v1) en vez de `che:state:validate_pr` (v2). El gate
+// v1-rejection rechaza con exit 3 + mensaje accionable apuntando a
+// `che migrate-labels-v2` antes de tocar el state machine.
+func TestIterate_Plan_OldV1Label_Exit3(t *testing.T) {
+	env := setupIterateEnv(t)
+	scriptIteratePrechecks(env)
+	scriptIterateDetectTargetPlan(env, 88)
+
+	env.ExpectGh(`^issue view 88 --json number,title,body,labels,url,state$`).
+		RespondStdoutFromFixture("iterate/gh_issue_view_old_label_che_validated.json", 0)
+
+	r := env.Run("iterate", "88")
+	if r.ExitCode != 3 {
+		t.Fatalf("expected exit 3 (gate v1 rechaza), got %d\nstderr: %s", r.ExitCode, r.Stderr)
+	}
+	harness.AssertContains(t, r.Stderr, "v1")
+	harness.AssertContains(t, r.Stderr, "migrate-labels-v2")
+	env.Invocations().AssertNotCalled(t, "claude")
+	posts := env.Invocations().FindCalls("gh", "api", "-X", "POST", "issues/88/labels")
+	if len(posts) > 0 {
+		t.Fatalf("no debería haber POST de labels (gate rechaza); calls=%v", posts)
+	}
+}
+
 // TestIterate_Plan_NoLabel_Exit3: issue sin plan-validated:changes-requested
 // → exit semantic, no llama opus.
 func TestIterate_Plan_NoLabel_Exit3(t *testing.T) {

--- a/e2e/testdata/close/gh_pr_view_changes_requested.json
+++ b/e2e/testdata/close/gh_pr_view_changes_requested.json
@@ -9,5 +9,5 @@
   "mergeStateStatus": "CLEAN",
   "author": {"login": "acme-bot"},
   "closingIssuesReferences": [{"number": 42, "state": "OPEN"}],
-  "labels": [{"name": "che:validated"}, {"name": "validated:changes-requested"}]
+  "labels": [{"name": "che:state:validate_pr"}, {"name": "validated:changes-requested"}]
 }

--- a/e2e/testdata/close/gh_pr_view_conflicting.json
+++ b/e2e/testdata/close/gh_pr_view_conflicting.json
@@ -9,5 +9,5 @@
   "mergeStateStatus": "DIRTY",
   "author": {"login": "acme-bot"},
   "closingIssuesReferences": [{"number": 42, "state": "OPEN"}],
-  "labels": [{"name": "che:executed"}]
+  "labels": [{"name": "che:state:execute"}]
 }

--- a/e2e/testdata/close/gh_pr_view_draft_clean.json
+++ b/e2e/testdata/close/gh_pr_view_draft_clean.json
@@ -9,5 +9,5 @@
   "mergeStateStatus": "CLEAN",
   "author": {"login": "acme-bot"},
   "closingIssuesReferences": [{"number": 42, "state": "OPEN"}],
-  "labels": [{"name": "che:executed"}]
+  "labels": [{"name": "che:state:execute"}]
 }

--- a/e2e/testdata/close/gh_pr_view_old_label_che_executed.json
+++ b/e2e/testdata/close/gh_pr_view_old_label_che_executed.json
@@ -1,0 +1,13 @@
+{
+  "number": 7,
+  "title": "PR de un repo no migrado: tiene che:executed (v1) en vez de che:state:execute",
+  "url": "https://github.com/acme/demo/pull/7",
+  "state": "OPEN",
+  "isDraft": false,
+  "headRefName": "feat/legacy",
+  "mergeable": "MERGEABLE",
+  "mergeStateStatus": "CLEAN",
+  "author": {"login": "acme-bot"},
+  "closingIssuesReferences": [],
+  "labels": [{"name": "che:executed"}]
+}

--- a/e2e/testdata/iterate/gh_issue_view_old_label_che_validated.json
+++ b/e2e/testdata/iterate/gh_issue_view_old_label_che_validated.json
@@ -1,0 +1,12 @@
+{
+  "number": 88,
+  "title": "Issue de un repo no migrado: tiene che:validated (v1) en vez de che:state:validate_pr",
+  "body": "## Plan consolidado\n\n**Resumen:** algo.\n",
+  "url": "https://github.com/acme/demo/issues/88",
+  "state": "OPEN",
+  "labels": [
+    {"name": "ct:plan"},
+    {"name": "che:validated"},
+    {"name": "plan-validated:changes-requested"}
+  ]
+}

--- a/e2e/testdata/iterate/gh_issue_view_plan_changes_requested.json
+++ b/e2e/testdata/iterate/gh_issue_view_plan_changes_requested.json
@@ -6,7 +6,7 @@
   "state": "OPEN",
   "labels": [
     {"name": "ct:plan"},
-    {"name": "che:validated"},
+    {"name": "che:state:validate_pr"},
     {"name": "plan-validated:changes-requested"}
   ]
 }

--- a/e2e/testdata/iterate/gh_issue_view_plan_executing.json
+++ b/e2e/testdata/iterate/gh_issue_view_plan_executing.json
@@ -6,8 +6,8 @@
   "state": "OPEN",
   "labels": [
     {"name": "ct:plan"},
-    {"name": "che:validated"},
-    {"name": "che:executing"},
+    {"name": "che:state:validate_pr"},
+    {"name": "che:state:applying:execute"},
     {"name": "plan-validated:changes-requested"}
   ]
 }

--- a/e2e/testdata/iterate/gh_issue_view_plan_no_consolidated.json
+++ b/e2e/testdata/iterate/gh_issue_view_plan_no_consolidated.json
@@ -6,7 +6,7 @@
   "state": "OPEN",
   "labels": [
     {"name": "ct:plan"},
-    {"name": "che:validated"},
+    {"name": "che:state:validate_pr"},
     {"name": "plan-validated:changes-requested"}
   ]
 }

--- a/e2e/testdata/iterate/gh_issue_view_plan_no_label.json
+++ b/e2e/testdata/iterate/gh_issue_view_plan_no_label.json
@@ -6,6 +6,6 @@
   "state": "OPEN",
   "labels": [
     {"name": "ct:plan"},
-    {"name": "che:validated"}
+    {"name": "che:state:validate_pr"}
   ]
 }

--- a/e2e/testdata/iterate/gh_pr_view_changes_requested.json
+++ b/e2e/testdata/iterate/gh_pr_view_changes_requested.json
@@ -7,5 +7,5 @@
   "headRefName": "feat/x",
   "author": {"login": "acme-bot"},
   "closingIssuesReferences": [{"number": 42}],
-  "labels": [{"name": "che:validated"}, {"name": "validated:changes-requested"}]
+  "labels": [{"name": "che:state:validate_pr"}, {"name": "validated:changes-requested"}]
 }

--- a/e2e/testdata/validate/gh_issue_view_no_status_plan.json
+++ b/e2e/testdata/validate/gh_issue_view_no_status_plan.json
@@ -6,7 +6,7 @@
   "state": "OPEN",
   "labels": [
     {"name": "ct:plan"},
-    {"name": "che:idea"},
+    {"name": "che:state:idea"},
     {"name": "type:feat"},
     {"name": "size:m"}
   ]

--- a/e2e/testdata/validate/gh_issue_view_old_label_che_plan.json
+++ b/e2e/testdata/validate/gh_issue_view_old_label_che_plan.json
@@ -1,0 +1,11 @@
+{
+  "number": 88,
+  "title": "Issue de un repo no migrado: tiene che:plan (v1) en vez de che:state:explore",
+  "body": "## Plan consolidado\n\n**Resumen:** algo.\n",
+  "url": "https://github.com/acme/demo/issues/88",
+  "state": "OPEN",
+  "labels": [
+    {"name": "ct:plan"},
+    {"name": "che:plan"}
+  ]
+}

--- a/e2e/testdata/validate/gh_issue_view_plan_consolidated.json
+++ b/e2e/testdata/validate/gh_issue_view_plan_consolidated.json
@@ -6,7 +6,7 @@
   "state": "OPEN",
   "labels": [
     {"name": "ct:plan"},
-    {"name": "che:plan"},
+    {"name": "che:state:explore"},
     {"name": "type:feat"},
     {"name": "size:s"}
   ]

--- a/e2e/testdata/validate/gh_issue_view_status_plan_no_consolidated.json
+++ b/e2e/testdata/validate/gh_issue_view_status_plan_no_consolidated.json
@@ -1,11 +1,11 @@
 {
   "number": 42,
-  "title": "Issue con che:plan pero sin plan consolidado",
+  "title": "Issue con che:state:explore pero sin plan consolidado",
   "body": "alguien puso el label a mano pero el body es solo texto libre sin header de plan consolidado.",
   "url": "https://github.com/acme/demo/issues/42",
   "state": "OPEN",
   "labels": [
     {"name": "ct:plan"},
-    {"name": "che:plan"}
+    {"name": "che:state:explore"}
   ]
 }

--- a/e2e/validate_test.go
+++ b/e2e/validate_test.go
@@ -279,7 +279,7 @@ func TestValidate_Plan_NoStatusPlan_Exit3(t *testing.T) {
 	if r.ExitCode != 3 {
 		t.Fatalf("expected exit 3, got %d\nstderr: %s", r.ExitCode, r.Stderr)
 	}
-	harness.AssertContains(t, r.Stderr, "che:plan")
+	harness.AssertContains(t, r.Stderr, "che:state:explore")
 	harness.AssertContains(t, r.Stderr, "che explore")
 	env.Invocations().AssertNotCalled(t, "claude")
 }
@@ -300,6 +300,32 @@ func TestValidate_Plan_NoConsolidatedPlan_Exit3(t *testing.T) {
 	}
 	harness.AssertContains(t, r.Stderr, "plan consolidado")
 	env.Invocations().AssertNotCalled(t, "claude")
+}
+
+// TestValidate_Plan_OldV1Label_Exit3: issue de un repo no migrado con labels
+// v1 (`che:plan` viejo). El gate v1-rejection debe rechazarlo con exit 3 y
+// mensaje accionable apuntando a `che migrate-labels-v2` ANTES de tocar el
+// state machine — sino dejaríamos el issue con v1+v2 mezclado.
+func TestValidate_Plan_OldV1Label_Exit3(t *testing.T) {
+	env := setupValidateEnv(t)
+	scriptValidatePrechecks(env)
+	scriptDetectTargetPlan(env, 88)
+
+	env.ExpectGh(`^issue view 88 --json number,title,body,labels,url,state$`).
+		RespondStdoutFromFixture("validate/gh_issue_view_old_label_che_plan.json", 0)
+
+	r := env.Run("validate", "--validators", "opus", "88")
+	if r.ExitCode != 3 {
+		t.Fatalf("expected exit 3 (gate v1 rechaza), got %d\nstderr: %s", r.ExitCode, r.Stderr)
+	}
+	harness.AssertContains(t, r.Stderr, "v1")
+	harness.AssertContains(t, r.Stderr, "migrate-labels-v2")
+	// Sin transiciones ni validador.
+	env.Invocations().AssertNotCalled(t, "claude")
+	posts := env.Invocations().FindCalls("gh", "api", "-X", "POST", "issues/88/labels")
+	if len(posts) > 0 {
+		t.Fatalf("no debería haber POST de labels (gate rechaza); calls=%v", posts)
+	}
 }
 
 // ---- helpers ----

--- a/internal/dash/gh_source.go
+++ b/internal/dash/gh_source.go
@@ -36,7 +36,32 @@ import (
 	"time"
 
 	"github.com/chichex/che/internal/labels"
+	"github.com/chichex/che/internal/pipelinelabels"
 )
+
+// v2StatusByLabel mapea cada label terminal/applying del modelo v2
+// (`che:state:*` y `che:state:applying:*`) al string canónico de Status que
+// el resto del paquete dash espera (idea, planning, plan, executing,
+// executed, validating, validated, closing, closed). Es la fuente de verdad
+// del parser en applyLabels — agregar un step nuevo al pipeline declarativo
+// implica agregar acá su entrada (terminal + applying si corresponde).
+//
+// Decisión: aunque v1 colapsaba "validate sobre plan" y "validate sobre PR"
+// en `che:validating`/`che:validated`, v2 solo tiene un step `validate_pr`.
+// Mapeamos `che:state:validate_pr` → `validated` y
+// `che:state:applying:validate_pr` → `validating` para preservar las
+// columnas históricas del kanban (loop.go/preflight.go usan esos strings).
+var v2StatusByLabel = map[string]string{
+	pipelinelabels.StateIdea:               "idea",
+	pipelinelabels.StateApplyingExplore:    "planning",
+	pipelinelabels.StateExplore:            "plan",
+	pipelinelabels.StateApplyingExecute:    "executing",
+	pipelinelabels.StateExecute:            "executed",
+	pipelinelabels.StateApplyingValidatePR: "validating",
+	pipelinelabels.StateValidatePR:         "validated",
+	pipelinelabels.StateApplyingClose:      "closing",
+	pipelinelabels.StateClose:              "closed",
+}
 
 // defaultClosedCap es el cap default de issues closed que el poller trae al
 // snapshot. Se elige 20 como compromiso: suficiente para mostrar continuidad
@@ -366,35 +391,68 @@ func (g *GhSource) fetchIssues(ctx context.Context) ([]ghIssue, error) {
 	return parseIssues(out)
 }
 
-// fetchClosedIssues corre `gh issue list --state closed --label che:closed`
-// con el cap del poller. Permite que la columna closed muestre los últimos
-// N issues completados sin traer todo el histórico del repo (que en un
-// proyecto activo puede ser miles).
+// fetchClosedIssues corre `gh issue list --state closed` filtrando por
+// label de cierre — v2 (`che:state:close`) o v1 (`che:closed` legacy) — con
+// el cap del poller. Permite que la columna closed muestre los últimos N
+// issues completados sin traer todo el histórico del repo (en un proyecto
+// activo puede ser miles).
 //
-// Si el repo no usa el label che:closed (proyecto recién migrado), gh
-// devuelve [] y este path es no-op.
+// Combina ambas familias en un solo slice deduplicado por número. Si el
+// repo nunca usó ninguno de los dos labels (recién migrado y nada cerrado
+// todavía) gh devuelve [] y este path es no-op.
+//
+// REMOVE IN PR6d: cuando todos los repos usen v2, el label v1 deja de
+// existir y queda solo la primera query.
 func (g *GhSource) fetchClosedIssues(ctx context.Context) ([]ghIssue, error) {
 	limit := g.ClosedCap
 	if limit <= 0 {
 		limit = defaultClosedCap
 	}
-	cmd := exec.CommandContext(ctx, "gh", "issue", "list",
-		"--state", "closed",
-		"--label", labels.CheClosed,
-		"--limit", fmt.Sprintf("%d", limit),
-		"--json", "number,title,labels,state,body,createdAt",
-	)
-	if g.repoDir != "" {
-		cmd.Dir = g.repoDir
-	}
-	out, err := cmd.Output()
-	if err != nil {
-		if ee, ok := err.(*exec.ExitError); ok {
-			return nil, fmt.Errorf("gh issue list (closed): %s", strings.TrimSpace(string(ee.Stderr)))
+	fetch := func(label string) ([]ghIssue, error) {
+		cmd := exec.CommandContext(ctx, "gh", "issue", "list",
+			"--state", "closed",
+			"--label", label,
+			"--limit", fmt.Sprintf("%d", limit),
+			"--json", "number,title,labels,state,body,createdAt",
+		)
+		if g.repoDir != "" {
+			cmd.Dir = g.repoDir
 		}
-		return nil, fmt.Errorf("gh issue list (closed): %w", err)
+		out, err := cmd.Output()
+		if err != nil {
+			if ee, ok := err.(*exec.ExitError); ok {
+				return nil, fmt.Errorf("gh issue list (closed, %s): %s", label, strings.TrimSpace(string(ee.Stderr)))
+			}
+			return nil, fmt.Errorf("gh issue list (closed, %s): %w", label, err)
+		}
+		return parseIssues(out)
 	}
-	return parseIssues(out)
+	v2Issues, err := fetch(pipelinelabels.StateClose)
+	if err != nil {
+		return nil, err
+	}
+	v1Issues, err := fetch(labels.CheClosed)
+	if err != nil {
+		return nil, err
+	}
+	// Dedup por número (un issue migrado a medias podría tener ambos).
+	seen := make(map[int]struct{}, len(v2Issues)+len(v1Issues))
+	out := make([]ghIssue, 0, len(v2Issues)+len(v1Issues))
+	for _, i := range v2Issues {
+		if _, ok := seen[i.Number]; ok {
+			continue
+		}
+		seen[i.Number] = struct{}{}
+		out = append(out, i)
+	}
+	for _, i := range v1Issues {
+		if _, ok := seen[i.Number]; ok {
+			continue
+		}
+		seen[i.Number] = struct{}{}
+		out = append(out, i)
+	}
+	return out, nil
 }
 
 // fetchPRs corre `gh pr list` y parsea el JSON.
@@ -623,11 +681,18 @@ func laterOf(a, b time.Time) time.Time {
 // Status, PlanVerdict, PRVerdict, Locked. Es aditivo — se puede llamar dos
 // veces (issue + PR) y los labels más recientes ganan.
 //
-// Status se deriva del prefijo `che:` (post-PR1/PR2): che:idea → "idea",
-// che:planning → "planning", etc. El label `che:locked` es la única
-// excepción — es un marker, no un estado, y prende e.Locked en vez de
-// pisar Status. plan-validated:* / validated:* son los verdicts de los
-// validadores (no son estados).
+// Status soporta DOS modelos durante la transición v1→v2:
+//   - v2 (canónico post-PR6c): `che:state:<step>` (terminal) y
+//     `che:state:applying:<step>` (lock óptimista). Los strings de Status
+//     del kanban (idea/planning/plan/executing/executed/validating/
+//     validated/closing/closed) se preservan via v2StatusByLabel.
+//   - v1 (legacy): `che:idea` / `che:plan` / etc. Para que repos no migrados
+//     no se queden sin Status en el dash. Cuando todos los repos corran
+//     `che migrate-labels-v2` esta rama queda como dead code (REMOVE IN
+//     PR6d).
+//
+// `che:locked` prende e.Locked, no pisa Status. plan-validated:* / validated:*
+// son verdicts de los validadores (no son estados).
 func applyLabels(e *Entity, ls []ghLabel) {
 	for _, l := range ls {
 		name := l.Name
@@ -644,11 +709,23 @@ func applyLabels(e *Entity, ls []ghLabel) {
 			e.PlanVerdict = strings.TrimPrefix(name, "plan-validated:")
 		case strings.HasPrefix(name, "validated:"):
 			e.PRVerdict = strings.TrimPrefix(name, "validated:")
+		case strings.HasPrefix(name, pipelinelabels.PrefixState):
+			// v2: `che:state:<step>` o `che:state:applying:<step>`.
+			// Mapeamos via v2StatusByLabel; si el label no está en el
+			// mapa (por ej. step nuevo no registrado), preservamos
+			// best-effort el sufijo TrimPrefix.
+			if s, ok := v2StatusByLabel[name]; ok {
+				e.Status = s
+			} else if strings.HasPrefix(name, pipelinelabels.PrefixApplying) {
+				e.Status = strings.TrimPrefix(name, pipelinelabels.PrefixApplying)
+			} else {
+				e.Status = strings.TrimPrefix(name, pipelinelabels.PrefixState)
+			}
 		case strings.HasPrefix(name, "che:"):
-			// che:idea / che:planning / che:plan / che:executing /
+			// v1 legacy: che:idea / che:planning / che:plan / che:executing /
 			// che:executed / che:validating / che:validated / che:closing /
-			// che:closed → sufijo va a Status. che:locked se intercepta
-			// arriba (no llega acá).
+			// che:closed. che:locked y che:state:* se interceptan arriba.
+			// REMOVE IN PR6d cuando ya no haya repos sin migrar.
 			e.Status = strings.TrimPrefix(name, "che:")
 		}
 	}

--- a/internal/flow/close/closing.go
+++ b/internal/flow/close/closing.go
@@ -32,7 +32,38 @@ import (
 	"github.com/chichex/che/internal/flow/validate"
 	"github.com/chichex/che/internal/labels"
 	"github.com/chichex/che/internal/output"
+	"github.com/chichex/che/internal/pipelinelabels"
 )
+
+// v1StateLabels son los 9 labels del modelo viejo. El gate los rechaza con
+// mensaje accionable apuntando a `che migrate-labels-v2`. REMOVE IN PR6d.
+var v1StateLabels = []string{
+	labels.CheIdea,
+	labels.ChePlanning,
+	labels.ChePlan,
+	labels.CheExecuting,
+	labels.CheExecuted,
+	labels.CheValidating,
+	labels.CheValidated,
+	labels.CheClosing,
+	labels.CheClosed,
+}
+
+// rejectV1Labels devuelve un error accionable si la lista contiene labels
+// del modelo viejo. Wirea ValidateNoMixedLabels para detectar mezcla v1+v2.
+func rejectV1Labels(kind string, number int, current []string) error {
+	if err := labels.ValidateNoMixedLabels(current); err != nil {
+		return fmt.Errorf("%s #%d: %w", kind, number, err)
+	}
+	for _, v1 := range v1StateLabels {
+		for _, l := range current {
+			if l == v1 {
+				return fmt.Errorf("%s #%d tiene labels v1 (%s); este flow opera sobre el modelo v2 (`che:state:*`). Corré `che migrate-labels-v2` antes de cerrar, o ajustá los labels a mano", kind, number, v1)
+			}
+		}
+	}
+	return nil
+}
 
 // ExitCode es el código de salida semántico para el caller.
 type ExitCode int
@@ -267,24 +298,24 @@ func BlockingVerdict(pr *PullRequest) string {
 // Compat shim: sigue leyendo del PR. Nuevos call-sites usan
 // closeFromStateRes que lee del issue cuando corresponde.
 func closeFromState(p *PullRequest) string {
-	if p.HasLabel(labels.CheValidated) {
-		return labels.CheValidated
+	if p.HasLabel(pipelinelabels.StateValidatePR) {
+		return pipelinelabels.StateValidatePR
 	}
-	if p.HasLabel(labels.CheExecuted) {
-		return labels.CheExecuted
+	if p.HasLabel(pipelinelabels.StateExecute) {
+		return pipelinelabels.StateExecute
 	}
 	return ""
 }
 
 // closeFromStateRes es la versión state-ref-aware: decide el from-state
 // leyendo los labels desde el Resolution (issue si hay linkeado, PR si no).
-// Misma preferencia: che:validated gana sobre che:executed.
+// Misma preferencia: che:state:validate_pr gana sobre che:state:execute.
 func closeFromStateRes(r stateref.Resolution) string {
-	if r.HasLabel(labels.CheValidated) {
-		return labels.CheValidated
+	if r.HasLabel(pipelinelabels.StateValidatePR) {
+		return pipelinelabels.StateValidatePR
 	}
-	if r.HasLabel(labels.CheExecuted) {
-		return labels.CheExecuted
+	if r.HasLabel(pipelinelabels.StateExecute) {
+		return pipelinelabels.StateExecute
 	}
 	return ""
 }
@@ -424,6 +455,13 @@ func Run(prRef string, opts Opts) ExitCode {
 		return ExitSemantic
 	}
 
+	// Rechazar v1 en el PR antes de stateref (corta antes del fetch del
+	// issue linkeado si los labels del PR ya están en estado mixto / v1).
+	if err := rejectV1Labels("PR", pr.Number, pr.PRLabelNames()); err != nil {
+		log.Error("gate v1 falló", output.F{PR: pr.Number, Cause: err})
+		return ExitSemantic
+	}
+
 	// Resolver dónde viven los labels che:* de máquina de estados. Los
 	// che:* para un PR creado por `che execute` viven en el issue linkeado
 	// (closingIssuesReferences); si el PR no tiene issue linkeado (PR
@@ -431,15 +469,24 @@ func Run(prRef string, opts Opts) ExitCode {
 	stateRes := pr.ResolveStateRef(prRef)
 	stateRef := stateRes.Ref
 
-	// Gate de máquina de estados: aceptamos che:executed o che:validated.
+	// Si stateref cayó al issue, repetimos el guard sobre los labels del
+	// issue — un repo a medio migrar puede tener el issue v1 y el PR v2.
+	if stateRes.ResolvedToIssue {
+		if err := rejectV1Labels("issue", stateRes.IssueNumber, stateRes.Labels); err != nil {
+			log.Error("gate v1 falló", output.F{Issue: stateRes.IssueNumber, Cause: err})
+			return ExitSemantic
+		}
+	}
+
+	// Gate de máquina de estados: aceptamos che:state:execute o che:state:validate_pr.
 	// `from` se captura para que el lock + el rollback usen el mismo
-	// origen (executed por path normal, validated post-validate).
+	// origen (execute por path normal, validate_pr post-validate).
 	prFrom := closeFromStateRes(stateRes)
 	if prFrom == "" {
 		if stateRes.ResolvedToIssue {
-			log.Error(fmt.Sprintf("issue #%d (linkeado al PR #%d) no está en che:executed ni che:validated — corré `che execute` o `che validate` antes", stateRes.IssueNumber, pr.Number))
+			log.Error(fmt.Sprintf("issue #%d (linkeado al PR #%d) no está en %s ni %s — corré `che execute` o `che validate` antes", stateRes.IssueNumber, pr.Number, pipelinelabels.StateExecute, pipelinelabels.StateValidatePR))
 		} else {
-			log.Error(fmt.Sprintf("PR #%d no está en che:executed ni che:validated — corré `che execute` o `che validate` antes", pr.Number))
+			log.Error(fmt.Sprintf("PR #%d no está en %s ni %s — corré `che execute` o `che validate` antes", pr.Number, pipelinelabels.StateExecute, pipelinelabels.StateValidatePR))
 		}
 		return ExitSemantic
 	}
@@ -455,16 +502,16 @@ func Run(prRef string, opts Opts) ExitCode {
 		}
 	}()
 
-	// Transición <prFrom> → che:closing. Rollback en defer LIFO si
+	// Transición <prFrom> → che:state:applying:close. Rollback en defer LIFO si
 	// stateClosed queda en false. Target: issue si hay linkeado con che:*,
 	// PR si no.
 	if stateRes.ResolvedToIssue {
-		log.Step("transicionando issue a che:closing", output.F{Issue: stateRes.IssueNumber})
+		log.Step("transicionando issue a "+pipelinelabels.StateApplyingClose, output.F{Issue: stateRes.IssueNumber})
 	} else {
-		log.Step("transicionando a che:closing", output.F{PR: pr.Number})
+		log.Step("transicionando a "+pipelinelabels.StateApplyingClose, output.F{PR: pr.Number})
 	}
-	if err := labels.Apply(stateRef, prFrom, labels.CheClosing); err != nil {
-		log.Error("no pude transicionar a che:closing", output.F{Cause: err})
+	if err := labels.Apply(stateRef, prFrom, pipelinelabels.StateApplyingClose); err != nil {
+		log.Error("no pude transicionar a "+pipelinelabels.StateApplyingClose, output.F{Cause: err})
 		return ExitRetry
 	}
 	var stateClosed bool
@@ -472,8 +519,8 @@ func Run(prRef string, opts Opts) ExitCode {
 		if stateClosed {
 			return
 		}
-		if err := labels.Apply(stateRef, labels.CheClosing, prFrom); err != nil {
-			log.Warn(fmt.Sprintf("rollback che:closing → %s fallo: %v — revisá labels a mano", prFrom, err))
+		if err := labels.Apply(stateRef, pipelinelabels.StateApplyingClose, prFrom); err != nil {
+			log.Warn(fmt.Sprintf("rollback %s → %s fallo: %v — revisá labels a mano", pipelinelabels.StateApplyingClose, prFrom, err))
 		}
 	}()
 
@@ -625,17 +672,17 @@ func Run(prRef string, opts Opts) ExitCode {
 
 	fmt.Fprintln(stdout, branchOutcomeMessage(pr.HeadBranch, keepBranch, preRemoteKnown, preRemoteMissing, remoteDeleteFailed))
 
-	// Cierre de la transición de máquina de estados: che:closing → che:closed.
-	// El target queda en estado terminal `che:closed`, consistente con el
+	// Cierre de la transición de máquina de estados: che:state:applying:close → che:state:close.
+	// El target queda en estado terminal `che:state:close`, consistente con el
 	// merge remoto. Best-effort: si falla, warneamos pero el merge ya
 	// ocurrió. Target: issue si hay linkeado con che:*, PR si no.
 	if stateRes.ResolvedToIssue {
-		log.Step("transicionando issue a che:closed", output.F{Issue: stateRes.IssueNumber})
+		log.Step("transicionando issue a "+pipelinelabels.StateClose, output.F{Issue: stateRes.IssueNumber})
 	} else {
-		log.Step("transicionando PR a che:closed", output.F{PR: pr.Number})
+		log.Step("transicionando PR a "+pipelinelabels.StateClose, output.F{PR: pr.Number})
 	}
-	if err := labels.Apply(stateRef, labels.CheClosing, labels.CheClosed); err != nil {
-		log.Warn(fmt.Sprintf("no pude transicionar a che:closed: %v — revisá labels a mano", err))
+	if err := labels.Apply(stateRef, pipelinelabels.StateApplyingClose, pipelinelabels.StateClose); err != nil {
+		log.Warn(fmt.Sprintf("no pude transicionar a %s: %v — revisá labels a mano", pipelinelabels.StateClose, err))
 	} else {
 		stateClosed = true
 	}
@@ -721,27 +768,27 @@ func closeAssociatedIssues(pr *PullRequest, stateRes stateref.Resolution, log *o
 				output.F{Issue: ref.Number, Cause: err})
 		} else {
 			closed = append(closed, ref.Number)
-			log.Success("issue cerrado", output.F{Issue: ref.Number, Labels: []string{labels.CheClosed}})
+			log.Success("issue cerrado", output.F{Issue: ref.Number, Labels: []string{pipelinelabels.StateClose}})
 		}
 		// Si el Run ya aplicó la transición sobre este issue, no re-corremos
-		// — quedó en che:closed; aplicar "che:executed → che:closing" acá
-		// fallaría porque el label origen ya no está.
+		// — quedó en che:state:close; aplicar "che:state:execute → che:state:applying:close"
+		// acá fallaría porque el label origen ya no está.
 		if stateRes.ResolvedToIssue && stateRes.IssueNumber == ref.Number {
 			continue
 		}
-		// Transición de labels best-effort. Probamos primero che:executed y
-		// si falla che:validated. Si el issue no tiene ninguno (ej.
+		// Transición de labels best-effort. Probamos primero che:state:execute y
+		// si falla che:state:validate_pr. Si el issue no tiene ninguno (ej.
 		// referenciado pero no manejado por che) los dos fallan y warneamos.
-		if err := labels.Apply(refStr, labels.CheExecuted, labels.CheClosing); err != nil {
-			if err2 := labels.Apply(refStr, labels.CheValidated, labels.CheClosing); err2 != nil {
-				log.Warn(fmt.Sprintf("warning: labels del issue #%d no transicionaron a che:closing (executed: %v · validated: %v)",
-					ref.Number, err, err2),
+		if err := labels.Apply(refStr, pipelinelabels.StateExecute, pipelinelabels.StateApplyingClose); err != nil {
+			if err2 := labels.Apply(refStr, pipelinelabels.StateValidatePR, pipelinelabels.StateApplyingClose); err2 != nil {
+				log.Warn(fmt.Sprintf("warning: labels del issue #%d no transicionaron a %s (execute: %v · validate_pr: %v)",
+					ref.Number, pipelinelabels.StateApplyingClose, err, err2),
 					output.F{Issue: ref.Number})
 				continue
 			}
 		}
-		if err := labels.Apply(refStr, labels.CheClosing, labels.CheClosed); err != nil {
-			log.Warn(fmt.Sprintf("warning: labels del issue #%d no transicionaron a che:closed", ref.Number),
+		if err := labels.Apply(refStr, pipelinelabels.StateApplyingClose, pipelinelabels.StateClose); err != nil {
+			log.Warn(fmt.Sprintf("warning: labels del issue #%d no transicionaron a %s", ref.Number, pipelinelabels.StateClose),
 				output.F{Issue: ref.Number, Cause: err})
 		}
 	}

--- a/internal/flow/close/closing_test.go
+++ b/internal/flow/close/closing_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/chichex/che/internal/flow/stateref"
 	"github.com/chichex/che/internal/flow/validate"
 	"github.com/chichex/che/internal/labels"
+	"github.com/chichex/che/internal/pipelinelabels"
 )
 
 // Helper para construir PRs con labels/refs sin repetir struct literal.
@@ -347,16 +348,16 @@ func TestCloseFromStateRes(t *testing.T) {
 		want string
 	}{
 		{"empty", stateref.Resolution{}, ""},
-		{"executed only", stateref.Resolution{Labels: []string{labels.CheExecuted}}, labels.CheExecuted},
-		{"validated only", stateref.Resolution{Labels: []string{labels.CheValidated}}, labels.CheValidated},
-		{"both → validated wins", stateref.Resolution{Labels: []string{labels.CheExecuted, labels.CheValidated}}, labels.CheValidated},
+		{"execute only", stateref.Resolution{Labels: []string{pipelinelabels.StateExecute}}, pipelinelabels.StateExecute},
+		{"validate_pr only", stateref.Resolution{Labels: []string{pipelinelabels.StateValidatePR}}, pipelinelabels.StateValidatePR},
+		{"both → validate_pr wins", stateref.Resolution{Labels: []string{pipelinelabels.StateExecute, pipelinelabels.StateValidatePR}}, pipelinelabels.StateValidatePR},
 		{"noise labels don't interfere", stateref.Resolution{Labels: []string{"ct:plan", "priority:high"}}, ""},
-		{"validated from issue", stateref.Resolution{
+		{"validate_pr from issue", stateref.Resolution{
 			Ref:             "122",
-			Labels:          []string{labels.CheValidated, "ct:plan"},
+			Labels:          []string{pipelinelabels.StateValidatePR, "ct:plan"},
 			ResolvedToIssue: true,
 			IssueNumber:     122,
-		}, labels.CheValidated},
+		}, pipelinelabels.StateValidatePR},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -375,7 +376,7 @@ func TestPullRequest_ResolveStateRef_ViaIssue(t *testing.T) {
 		if n != 122 {
 			return nil, fmt.Errorf("unexpected n=%d", n)
 		}
-		return []string{"ct:plan", labels.CheExecuted}, nil
+		return []string{"ct:plan", pipelinelabels.StateExecute}, nil
 	})()
 
 	pr := mkPR(140, withLabel(labels.ValidatedChangesRequested), withClosing(122))
@@ -389,8 +390,8 @@ func TestPullRequest_ResolveStateRef_ViaIssue(t *testing.T) {
 	if r.Ref != "122" {
 		t.Fatalf("expected Ref=122, got %q", r.Ref)
 	}
-	if !r.HasLabel(labels.CheExecuted) {
-		t.Fatalf("expected issue's che:executed to be in Labels: %v", r.Labels)
+	if !r.HasLabel(pipelinelabels.StateExecute) {
+		t.Fatalf("expected issue's %s to be in Labels: %v", pipelinelabels.StateExecute, r.Labels)
 	}
 	if r.HasLabel(labels.ValidatedChangesRequested) {
 		t.Fatalf("PR's validated:changes-requested shouldn't be on the issue-resolution")
@@ -405,7 +406,7 @@ func TestPullRequest_ResolveStateRef_Fallback(t *testing.T) {
 		return nil, nil
 	})()
 
-	pr := mkPR(140, withLabel(labels.CheExecuted))
+	pr := mkPR(140, withLabel(pipelinelabels.StateExecute))
 	r := pr.ResolveStateRef("140")
 	if r.ResolvedToIssue {
 		t.Fatalf("expected fallback to PR, got %+v", r)
@@ -413,8 +414,8 @@ func TestPullRequest_ResolveStateRef_Fallback(t *testing.T) {
 	if r.Ref != "140" {
 		t.Fatalf("expected Ref=140 (PR), got %q", r.Ref)
 	}
-	if !r.HasLabel(labels.CheExecuted) {
-		t.Fatalf("expected PR's che:executed in Labels: %v", r.Labels)
+	if !r.HasLabel(pipelinelabels.StateExecute) {
+		t.Fatalf("expected PR's %s in Labels: %v", pipelinelabels.StateExecute, r.Labels)
 	}
 }
 

--- a/internal/flow/explore/explore.go
+++ b/internal/flow/explore/explore.go
@@ -686,7 +686,7 @@ func gateBasic(i *Issue) error {
 		labels.CheClosed,
 	} {
 		if i.HasLabel(v1) {
-			return fmt.Errorf("issue #%d tiene labels v1 (%s); este flow opera sobre el modelo v2 (`che:state:*`). Corré `migrate-labels-v2` (cuando exista) antes de explorar, o ajustá los labels a mano", i.Number, v1)
+			return fmt.Errorf("issue #%d tiene labels v1 (%s); este flow opera sobre el modelo v2 (`che:state:*`). Corré `che migrate-labels-v2` antes de explorar, o ajustá los labels a mano", i.Number, v1)
 		}
 	}
 	for _, beyond := range []string{

--- a/internal/flow/iterate/iterate.go
+++ b/internal/flow/iterate/iterate.go
@@ -39,8 +39,41 @@ import (
 	"github.com/chichex/che/internal/flow/validate"
 	"github.com/chichex/che/internal/labels"
 	"github.com/chichex/che/internal/output"
+	"github.com/chichex/che/internal/pipelinelabels"
 	planpkg "github.com/chichex/che/internal/plan"
 )
+
+// v1StateLabels son los 9 labels del modelo viejo. El gate los rechaza con
+// mensaje accionable apuntando a `che migrate-labels-v2` antes de tocar
+// labels v2 (sino el repo queda en estado mixto). REMOVE IN PR6d.
+var v1StateLabels = []string{
+	labels.CheIdea,
+	labels.ChePlanning,
+	labels.ChePlan,
+	labels.CheExecuting,
+	labels.CheExecuted,
+	labels.CheValidating,
+	labels.CheValidated,
+	labels.CheClosing,
+	labels.CheClosed,
+}
+
+// rejectV1Labels devuelve un error accionable si la lista contiene algún
+// label v1. Wirea `ValidateNoMixedLabels` para detectar mezcla v1+v2 antes
+// de gritar "no está en che:state:validate_pr".
+func rejectV1Labels(kind string, number int, current []string) error {
+	if err := labels.ValidateNoMixedLabels(current); err != nil {
+		return fmt.Errorf("%s #%d: %w", kind, number, err)
+	}
+	for _, v1 := range v1StateLabels {
+		for _, l := range current {
+			if l == v1 {
+				return fmt.Errorf("%s #%d tiene labels v1 (%s); este flow opera sobre el modelo v2 (`che:state:*`). Corré `che migrate-labels-v2` antes de iterar, o ajustá los labels a mano", kind, number, v1)
+			}
+		}
+	}
+	return nil
+}
 
 // ExitCode es el código de salida semántico.
 type ExitCode int
@@ -95,7 +128,7 @@ func filterIterable(raw []validate.PullRequest) []validate.Candidate {
 		if !hasChangesRequested(p) {
 			continue
 		}
-		if !p.HasLabel(labels.CheValidated) {
+		if !p.HasLabel(pipelinelabels.StateValidatePR) {
 			continue
 		}
 		if p.HasLabel(labels.CheLocked) {
@@ -213,17 +246,31 @@ func runPR(prRef string, opts Opts, stdout io.Writer, log *output.Logger) ExitCo
 		log.Error(fmt.Sprintf("PR #%d no tiene head branch (¿fork?) — iterate no soporta ese caso", pr.Number))
 		return ExitSemantic
 	}
+	// Rechazar v1 en el PR antes de stateref (más rápido: no fetch del issue
+	// linkeado si ya falla acá). Si stateref cae al issue, repetimos abajo.
+	if err := rejectV1Labels("PR", pr.Number, pr.PRLabelNames()); err != nil {
+		log.Error("gate v1 falló", output.F{PR: pr.Number, Cause: err})
+		return ExitSemantic
+	}
+
 	// Resolver dónde viven los labels che:* de máquina de estados. Si el
 	// PR tiene issue linkeado con algún che:*, los gates leen del issue y
 	// las transiciones van al issue; si no, al PR mismo (compat).
 	stateRes := pr.ResolveStateRef(prRef)
 	stateRef := stateRes.Ref
 
-	if !stateRes.HasLabel(labels.CheValidated) {
+	if stateRes.ResolvedToIssue {
+		if err := rejectV1Labels("issue", stateRes.IssueNumber, stateRes.Labels); err != nil {
+			log.Error("gate v1 falló", output.F{Issue: stateRes.IssueNumber, Cause: err})
+			return ExitSemantic
+		}
+	}
+
+	if !stateRes.HasLabel(pipelinelabels.StateValidatePR) {
 		if stateRes.ResolvedToIssue {
-			log.Error(fmt.Sprintf("issue #%d (linkeado al PR #%d) no está en che:validated — corré `che validate %d` primero", stateRes.IssueNumber, pr.Number, pr.Number))
+			log.Error(fmt.Sprintf("issue #%d (linkeado al PR #%d) no está en %s — corré `che validate %d` primero", stateRes.IssueNumber, pr.Number, pipelinelabels.StateValidatePR, pr.Number))
 		} else {
-			log.Error(fmt.Sprintf("PR #%d no está en che:validated — corré `che validate %d` primero", pr.Number, pr.Number))
+			log.Error(fmt.Sprintf("PR #%d no está en %s — corré `che validate %d` primero", pr.Number, pipelinelabels.StateValidatePR, pr.Number))
 		}
 		return ExitSemantic
 	}
@@ -247,15 +294,15 @@ func runPR(prRef string, opts Opts, stdout io.Writer, log *output.Logger) ExitCo
 		}
 	}()
 
-	// Transición che:validated → che:executing. Rollback en defer LIFO.
+	// Transición che:state:validate_pr → che:state:applying:execute. Rollback en defer LIFO.
 	// Target: issue si hay linkeado con che:*, PR si no.
 	if stateRes.ResolvedToIssue {
-		log.Step("transicionando issue a che:executing", output.F{Issue: stateRes.IssueNumber})
+		log.Step("transicionando issue a "+pipelinelabels.StateApplyingExecute, output.F{Issue: stateRes.IssueNumber})
 	} else {
-		log.Step("transicionando a che:executing", output.F{PR: pr.Number})
+		log.Step("transicionando a "+pipelinelabels.StateApplyingExecute, output.F{PR: pr.Number})
 	}
-	if err := labels.Apply(stateRef, labels.CheValidated, labels.CheExecuting); err != nil {
-		log.Error("no pude transicionar a che:executing", output.F{Cause: err})
+	if err := labels.Apply(stateRef, pipelinelabels.StateValidatePR, pipelinelabels.StateApplyingExecute); err != nil {
+		log.Error("no pude transicionar a "+pipelinelabels.StateApplyingExecute, output.F{Cause: err})
 		return ExitRetry
 	}
 	var stateExecuted bool
@@ -263,8 +310,8 @@ func runPR(prRef string, opts Opts, stdout io.Writer, log *output.Logger) ExitCo
 		if stateExecuted {
 			return
 		}
-		if err := labels.Apply(stateRef, labels.CheExecuting, labels.CheValidated); err != nil {
-			log.Warn(fmt.Sprintf("rollback che:executing → che:validated fallo: %v — revisá labels a mano", err))
+		if err := labels.Apply(stateRef, pipelinelabels.StateApplyingExecute, pipelinelabels.StateValidatePR); err != nil {
+			log.Warn(fmt.Sprintf("rollback %s → %s fallo: %v — revisá labels a mano", pipelinelabels.StateApplyingExecute, pipelinelabels.StateValidatePR, err))
 		}
 	}()
 
@@ -345,15 +392,15 @@ func runPR(prRef string, opts Opts, stdout io.Writer, log *output.Logger) ExitCo
 		log.Warn("warning: no se pudo remover label — removelo a mano", output.F{Cause: err})
 	}
 
-	// Cierre de la transición: che:executing → che:executed. Target: el
+	// Cierre de la transición: che:state:applying:execute → che:state:execute. Target: el
 	// mismo ref que usamos para abrir la transición (issue si corresponde).
 	if stateRes.ResolvedToIssue {
-		log.Step("transicionando issue a che:executed", output.F{Issue: stateRes.IssueNumber})
+		log.Step("transicionando issue a "+pipelinelabels.StateExecute, output.F{Issue: stateRes.IssueNumber})
 	} else {
-		log.Step("transicionando a che:executed", output.F{PR: pr.Number})
+		log.Step("transicionando a "+pipelinelabels.StateExecute, output.F{PR: pr.Number})
 	}
-	if err := labels.Apply(stateRef, labels.CheExecuting, labels.CheExecuted); err != nil {
-		log.Warn(fmt.Sprintf("no pude transicionar a che:executed: %v — revisá labels a mano", err))
+	if err := labels.Apply(stateRef, pipelinelabels.StateApplyingExecute, pipelinelabels.StateExecute); err != nil {
+		log.Warn(fmt.Sprintf("no pude transicionar a %s: %v — revisá labels a mano", pipelinelabels.StateExecute, err))
 	} else {
 		stateExecuted = true
 	}
@@ -392,8 +439,14 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 		log.Error(fmt.Sprintf("issue #%d is not OPEN (state=%s)", issue.Number, issue.State))
 		return ExitSemantic
 	}
-	if !issue.HasLabel(labels.CheValidated) {
-		log.Error(fmt.Sprintf("issue #%d no está en che:validated — corré `che validate %d` primero", issue.Number, issue.Number))
+	// Rechazar v1 antes de chequear v2 — error más útil que "no está en
+	// che:state:validate_pr" cuando el repo no migró todavía.
+	if err := rejectV1Labels("issue", issue.Number, issue.LabelNames()); err != nil {
+		log.Error("gate v1 falló", output.F{Issue: issue.Number, Cause: err})
+		return ExitSemantic
+	}
+	if !issue.HasLabel(pipelinelabels.StateValidatePR) {
+		log.Error(fmt.Sprintf("issue #%d no está en %s — corré `che validate %d` primero", issue.Number, pipelinelabels.StateValidatePR, issue.Number))
 		return ExitSemantic
 	}
 	if !issue.HasLabel(labels.PlanValidatedChangesRequested) {
@@ -401,7 +454,7 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 		return ExitSemantic
 	}
 	// Execute ya corrió → iterar el plan no tiene efecto sobre el PR.
-	if issue.HasLabel(labels.CheExecuting) || issue.HasLabel(labels.CheExecuted) {
+	if issue.HasLabel(pipelinelabels.StateApplyingExecute) || issue.HasLabel(pipelinelabels.StateExecute) {
 		log.Error(fmt.Sprintf("issue #%d ya pasó por execute — iterar el plan no tiene efecto sobre el PR asociado. Iterar el PR directamente con `che iterate <pr>`.", issue.Number))
 		return ExitSemantic
 	}
@@ -421,10 +474,10 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 		}
 	}()
 
-	// Transición che:validated → che:planning. Rollback en defer LIFO.
-	log.Step("transicionando a che:planning", output.F{Issue: issue.Number})
-	if err := labels.Apply(issueRef, labels.CheValidated, labels.ChePlanning); err != nil {
-		log.Error("no pude transicionar a che:planning", output.F{Cause: err})
+	// Transición che:state:validate_pr → che:state:applying:explore. Rollback en defer LIFO.
+	log.Step("transicionando a "+pipelinelabels.StateApplyingExplore, output.F{Issue: issue.Number})
+	if err := labels.Apply(issueRef, pipelinelabels.StateValidatePR, pipelinelabels.StateApplyingExplore); err != nil {
+		log.Error("no pude transicionar a "+pipelinelabels.StateApplyingExplore, output.F{Cause: err})
 		return ExitRetry
 	}
 	var statePlan bool
@@ -432,8 +485,8 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 		if statePlan {
 			return
 		}
-		if err := labels.Apply(issueRef, labels.ChePlanning, labels.CheValidated); err != nil {
-			log.Warn(fmt.Sprintf("rollback che:planning → che:validated fallo: %v — revisá labels a mano", err))
+		if err := labels.Apply(issueRef, pipelinelabels.StateApplyingExplore, pipelinelabels.StateValidatePR); err != nil {
+			log.Warn(fmt.Sprintf("rollback %s → %s fallo: %v — revisá labels a mano", pipelinelabels.StateApplyingExplore, pipelinelabels.StateValidatePR, err))
 		}
 	}()
 
@@ -505,10 +558,10 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 		log.Warn("warning: no se pudo remover label — removelo a mano", output.F{Cause: err})
 	}
 
-	// Cierre de la transición: che:planning → che:plan.
-	log.Step("transicionando a che:plan", output.F{Issue: issue.Number})
-	if err := labels.Apply(issueRef, labels.ChePlanning, labels.ChePlan); err != nil {
-		log.Warn(fmt.Sprintf("no pude transicionar a che:plan: %v — revisá labels a mano", err))
+	// Cierre de la transición: che:state:applying:explore → che:state:explore.
+	log.Step("transicionando a "+pipelinelabels.StateExplore, output.F{Issue: issue.Number})
+	if err := labels.Apply(issueRef, pipelinelabels.StateApplyingExplore, pipelinelabels.StateExplore); err != nil {
+		log.Warn(fmt.Sprintf("no pude transicionar a %s: %v — revisá labels a mano", pipelinelabels.StateExplore, err))
 	} else {
 		statePlan = true
 	}
@@ -772,7 +825,7 @@ func removeIssueLabel(issueRef, name string) error {
 // que filtrado por un label distinto.
 func ListIterablePlanCandidates() ([]validate.PlanCandidate, error) {
 	cmd := exec.Command("gh", "issue", "list",
-		"--label", labels.CheValidated,
+		"--label", pipelinelabels.StateValidatePR,
 		"--label", labels.PlanValidatedChangesRequested,
 		"--state", "open",
 		"--json", "number,title,url,labels",

--- a/internal/flow/iterate/iterate_test.go
+++ b/internal/flow/iterate/iterate_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/chichex/che/internal/flow/stateref"
 	"github.com/chichex/che/internal/flow/validate"
 	"github.com/chichex/che/internal/labels"
+	"github.com/chichex/che/internal/pipelinelabels"
 	planpkg "github.com/chichex/che/internal/plan"
 )
 
@@ -38,19 +39,19 @@ func TestFilterIterable(t *testing.T) {
 		{"empty", nil, nil},
 		{"sin labels excluido", []validate.PullRequest{mk(1), mk(2)}, nil},
 		{"changes-requested + validated incluido",
-			[]validate.PullRequest{mk(1, labels.ValidatedChangesRequested, labels.CheValidated)}, []int{1}},
-		{"changes-requested sin che:validated excluido",
+			[]validate.PullRequest{mk(1, labels.ValidatedChangesRequested, pipelinelabels.StateValidatePR)}, []int{1}},
+		{"changes-requested sin che:state:validate_pr excluido",
 			[]validate.PullRequest{mk(1, labels.ValidatedChangesRequested)}, nil},
 		{"approve excluido (no pidió cambios)",
-			[]validate.PullRequest{mk(1, labels.ValidatedApprove, labels.CheValidated)}, nil},
+			[]validate.PullRequest{mk(1, labels.ValidatedApprove, pipelinelabels.StateValidatePR)}, nil},
 		{"needs-human excluido (decisión humana, no técnica)",
-			[]validate.PullRequest{mk(1, labels.ValidatedNeedsHuman, labels.CheValidated)}, nil},
+			[]validate.PullRequest{mk(1, labels.ValidatedNeedsHuman, pipelinelabels.StateValidatePR)}, nil},
 		{"mix",
 			[]validate.PullRequest{
-				mk(1, labels.ValidatedApprove, labels.CheValidated),
-				mk(2, labels.ValidatedChangesRequested, labels.CheValidated),
-				mk(3, labels.ValidatedNeedsHuman, labels.CheValidated),
-				mk(4, labels.ValidatedChangesRequested, labels.CheValidated),
+				mk(1, labels.ValidatedApprove, pipelinelabels.StateValidatePR),
+				mk(2, labels.ValidatedChangesRequested, pipelinelabels.StateValidatePR),
+				mk(3, labels.ValidatedNeedsHuman, pipelinelabels.StateValidatePR),
+				mk(4, labels.ValidatedChangesRequested, pipelinelabels.StateValidatePR),
 				mk(5),
 			},
 			[]int{2, 4}},
@@ -468,8 +469,8 @@ func TestRunPRGate_StateFromIssue(t *testing.T) {
 		if n != 122 {
 			return nil, fmt.Errorf("unexpected n=%d", n)
 		}
-		// Escenario post-validate exitoso: issue en che:validated.
-		return []string{"ct:plan", "pricing-modes", labels.CheValidated}, nil
+		// Escenario post-validate exitoso: issue en che:state:validate_pr.
+		return []string{"ct:plan", "pricing-modes", pipelinelabels.StateValidatePR}, nil
 	})()
 
 	pr := validate.PullRequest{
@@ -486,16 +487,16 @@ func TestRunPRGate_StateFromIssue(t *testing.T) {
 
 	r := pr.ResolveStateRef("140")
 
-	// El gate de runPR lee che:validated desde stateRes.HasLabel(...). Si
-	// la resolución resolvió al issue con che:validated, el gate pasa.
+	// El gate de runPR lee che:state:validate_pr desde stateRes.HasLabel(...).
+	// Si la resolución resolvió al issue con ese label, el gate pasa.
 	if !r.ResolvedToIssue {
 		t.Fatalf("expected resolution to go to issue, got %+v", r)
 	}
 	if r.IssueNumber != 122 {
 		t.Fatalf("expected IssueNumber=122, got %d", r.IssueNumber)
 	}
-	if !r.HasLabel(labels.CheValidated) {
-		t.Fatalf("gate should see che:validated on the issue: %v", r.Labels)
+	if !r.HasLabel(pipelinelabels.StateValidatePR) {
+		t.Fatalf("gate should see %s on the issue: %v", pipelinelabels.StateValidatePR, r.Labels)
 	}
 	if r.Ref != "122" {
 		t.Fatalf("transitions should target issue ref '122', got %q", r.Ref)
@@ -516,11 +517,11 @@ func TestRunPRGate_StateFallbackToPR(t *testing.T) {
 		State:      "OPEN",
 		HeadBranch: "feat/x",
 	}
-	// PR ajeno: usuario aplicó che:validated a mano.
+	// PR ajeno: usuario aplicó che:state:validate_pr a mano.
 	pr.Labels = append(pr.Labels,
 		struct {
 			Name string `json:"name"`
-		}{Name: labels.CheValidated},
+		}{Name: pipelinelabels.StateValidatePR},
 		struct {
 			Name string `json:"name"`
 		}{Name: labels.ValidatedChangesRequested},
@@ -533,8 +534,8 @@ func TestRunPRGate_StateFallbackToPR(t *testing.T) {
 	if r.Ref != "140" {
 		t.Fatalf("expected Ref=140, got %q", r.Ref)
 	}
-	if !r.HasLabel(labels.CheValidated) {
-		t.Fatalf("gate should see che:validated on the PR: %v", r.Labels)
+	if !r.HasLabel(pipelinelabels.StateValidatePR) {
+		t.Fatalf("gate should see %s on the PR: %v", pipelinelabels.StateValidatePR, r.Labels)
 	}
 }
 

--- a/internal/flow/stateref/stateref.go
+++ b/internal/flow/stateref/stateref.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	"github.com/chichex/che/internal/labels"
+	"github.com/chichex/che/internal/pipelinelabels"
 )
 
 // Resolution describe dónde aplicar las transiciones che:* para un PR.
@@ -131,11 +132,19 @@ func (r Resolution) HasLabel(name string) bool {
 	return false
 }
 
-// stateLabelSet es el set de labels de máquina de estados (9 estados
-// prefix che:*). No incluye che:locked — ese es lock del recurso, no
-// estado — ni marker labels (ct:plan) ni verdicts (validated:*).
-// Construimos un map al init para lookup O(1) en hasCheStateLabel.
+// stateLabelSet es el set de labels de máquina de estados. Incluye AMBAS
+// familias (v1 y v2) durante PR6c para que stateref siga reconociendo issues
+// linkeados de repos no migrados (un PR creado por `che execute` v2 puede
+// tener `closingIssuesReferences` apuntando a un issue legacy v1; sin esto
+// validate/iterate/close PR-mode caerían al PR como si el issue no estuviera
+// trackeado por che). Los gates de los flows migrados rechazan los v1 con
+// mensaje accionable, así que reconocer el label v1 acá no afloja la
+// validación — solo evita falsos negativos en la resolución.
+//
+// REMOVE IN PR6d: junto con las constantes v1 viejas, este set se reduce a
+// solo v2.
 var stateLabelSet = map[string]struct{}{
+	// v1 (legacy — REMOVE IN PR6d)
 	labels.CheIdea:       {},
 	labels.ChePlanning:   {},
 	labels.ChePlan:       {},
@@ -145,6 +154,16 @@ var stateLabelSet = map[string]struct{}{
 	labels.CheValidated:  {},
 	labels.CheClosing:    {},
 	labels.CheClosed:     {},
+	// v2 (modelo derivado del pipeline declarativo)
+	pipelinelabels.StateIdea:               {},
+	pipelinelabels.StateApplyingExplore:    {},
+	pipelinelabels.StateExplore:            {},
+	pipelinelabels.StateApplyingExecute:    {},
+	pipelinelabels.StateExecute:            {},
+	pipelinelabels.StateApplyingValidatePR: {},
+	pipelinelabels.StateValidatePR:         {},
+	pipelinelabels.StateApplyingClose:      {},
+	pipelinelabels.StateClose:              {},
 }
 
 // hasCheStateLabel devuelve true si names contiene al menos uno de los

--- a/internal/flow/validate/validate.go
+++ b/internal/flow/validate/validate.go
@@ -30,8 +30,44 @@ import (
 	"github.com/chichex/che/internal/flow/stateref"
 	"github.com/chichex/che/internal/labels"
 	"github.com/chichex/che/internal/output"
+	"github.com/chichex/che/internal/pipelinelabels"
 	planpkg "github.com/chichex/che/internal/plan"
 )
+
+// v1StateLabels son los 9 labels del modelo viejo. Los gates de los flows
+// migrados a v2 los rechazan con mensaje accionable que sugiere
+// `che migrate-labels-v2` — si avanzaran, mezclaríamos v1+v2 en el issue/PR
+// (estado ilegal en ambas máquinas). REMOVE IN PR6d junto con el shim.
+var v1StateLabels = []string{
+	labels.CheIdea,
+	labels.ChePlanning,
+	labels.ChePlan,
+	labels.CheExecuting,
+	labels.CheExecuted,
+	labels.CheValidating,
+	labels.CheValidated,
+	labels.CheClosing,
+	labels.CheClosed,
+}
+
+// rejectV1Labels devuelve un error accionable si la lista contiene algún
+// label v1 del modelo viejo. Wirea ValidateNoMixedLabels para detectar
+// mezclas v1+v2 (caso intermedio: alguien aplicó che:state:* a mano sobre
+// un issue v1) y, si todo es v1-only, devuelve un error apuntando a
+// migrate-labels-v2.
+func rejectV1Labels(kind string, number int, current []string) error {
+	if err := labels.ValidateNoMixedLabels(current); err != nil {
+		return fmt.Errorf("%s #%d: %w", kind, number, err)
+	}
+	for _, v1 := range v1StateLabels {
+		for _, l := range current {
+			if l == v1 {
+				return fmt.Errorf("%s #%d tiene labels v1 (%s); este flow opera sobre el modelo v2 (`che:state:*`). Corré `che migrate-labels-v2` antes de validar, o ajustá los labels a mano", kind, number, v1)
+			}
+		}
+	}
+	return nil
+}
 
 // Target discrimina el tipo de ref que recibió `che validate`. La detección
 // corre contra `gh api repos/{owner}/{repo}/issues/{n}`: ese endpoint devuelve
@@ -409,6 +445,14 @@ func runPR(prRef string, opts Opts, stdout io.Writer, log *output.Logger) ExitCo
 		return ExitSemantic
 	}
 
+	// Rechazar labels v1: si el PR tiene `che:executed` viejo (modelo v1)
+	// el flow no puede transicionar (no hay key v1+v2 cruzada en
+	// validTransitions, además aplicar v2 dejaría mixto). Mensaje accionable.
+	if err := rejectV1Labels("PR", pr.Number, pr.PRLabelNames()); err != nil {
+		log.Error("gate v1 falló", output.F{PR: pr.Number, Cause: err})
+		return ExitSemantic
+	}
+
 	log.Step("aplicando lock che:locked", output.F{PR: pr.Number})
 	if err := labels.Lock(prRef); err != nil {
 		log.Error("no pude aplicar che:locked", output.F{Cause: err})
@@ -426,28 +470,39 @@ func runPR(prRef string, opts Opts, stdout io.Writer, log *output.Logger) ExitCo
 	stateRes := pr.ResolveStateRef(prRef)
 	stateRef := stateRes.Ref
 
-	// Transición de máquina de estados: che:executed → che:validating.
-	// Si el target no tiene che:executed (humano corrió validate sobre un
+	// Si la resolución cayó al issue, repetimos el guard v1 sobre los
+	// labels del issue — `che migrate-labels-v2` puede haber dejado
+	// algún issue mezclado/sin migrar. Si fall back al PR ya validamos
+	// arriba con pr.PRLabelNames().
+	if stateRes.ResolvedToIssue {
+		if err := rejectV1Labels("issue", stateRes.IssueNumber, stateRes.Labels); err != nil {
+			log.Error("gate v1 falló", output.F{Issue: stateRes.IssueNumber, Cause: err})
+			return ExitSemantic
+		}
+	}
+
+	// Transición de máquina de estados: che:state:execute → che:state:applying:validate_pr.
+	// Si el target no tiene che:state:execute (humano corrió validate sobre un
 	// PR no creado por execute, o execute no terminó OK) saltamos la
 	// transición — solo aplicamos los labels validated:* al final.
-	hasExecutedState := stateRes.HasLabel(labels.CheExecuted)
+	hasExecutedState := stateRes.HasLabel(pipelinelabels.StateExecute)
 	var stateValidated bool
 	if hasExecutedState {
 		if stateRes.ResolvedToIssue {
-			log.Step("transicionando issue a che:validating", output.F{Issue: stateRes.IssueNumber})
+			log.Step("transicionando issue a "+pipelinelabels.StateApplyingValidatePR, output.F{Issue: stateRes.IssueNumber})
 		} else {
-			log.Step("transicionando a che:validating", output.F{PR: pr.Number})
+			log.Step("transicionando a "+pipelinelabels.StateApplyingValidatePR, output.F{PR: pr.Number})
 		}
-		if err := labels.Apply(stateRef, labels.CheExecuted, labels.CheValidating); err != nil {
-			log.Error("no pude transicionar a che:validating", output.F{Cause: err})
+		if err := labels.Apply(stateRef, pipelinelabels.StateExecute, pipelinelabels.StateApplyingValidatePR); err != nil {
+			log.Error("no pude transicionar a "+pipelinelabels.StateApplyingValidatePR, output.F{Cause: err})
 			return ExitRetry
 		}
 		defer func() {
 			if stateValidated {
 				return
 			}
-			if err := labels.Apply(stateRef, labels.CheValidating, labels.CheExecuted); err != nil {
-				log.Warn(fmt.Sprintf("rollback che:validating → che:executed fallo: %v — revisá labels a mano", err))
+			if err := labels.Apply(stateRef, pipelinelabels.StateApplyingValidatePR, pipelinelabels.StateExecute); err != nil {
+				log.Warn(fmt.Sprintf("rollback %s → %s fallo: %v — revisá labels a mano", pipelinelabels.StateApplyingValidatePR, pipelinelabels.StateExecute, err))
 			}
 		}()
 	}
@@ -511,40 +566,40 @@ func runPR(prRef string, opts Opts, stdout io.Writer, log *output.Logger) ExitCo
 		}
 	}
 
-	// Cierre de la transición de máquina de estados: che:validating →
-	// che:validated. Solo aplica si arrancamos con che:executed. El
+	// Cierre de la transición de máquina de estados: che:state:applying:validate_pr →
+	// che:state:validate_pr. Solo aplica si arrancamos con che:state:execute. El
 	// target es el mismo que usamos para abrir la transición (issue si
 	// había closing issue con che:*, PR si no).
 	switch {
 	case hasExecutedState:
 		if stateRes.ResolvedToIssue {
-			log.Step("transicionando issue a che:validated", output.F{Issue: stateRes.IssueNumber})
+			log.Step("transicionando issue a "+pipelinelabels.StateValidatePR, output.F{Issue: stateRes.IssueNumber})
 		} else {
-			log.Step("transicionando a che:validated", output.F{PR: pr.Number})
+			log.Step("transicionando a "+pipelinelabels.StateValidatePR, output.F{PR: pr.Number})
 		}
-		if err := labels.Apply(stateRef, labels.CheValidating, labels.CheValidated); err != nil {
-			log.Warn(fmt.Sprintf("no pude transicionar a che:validated: %v — revisá labels a mano", err))
+		if err := labels.Apply(stateRef, pipelinelabels.StateApplyingValidatePR, pipelinelabels.StateValidatePR); err != nil {
+			log.Warn(fmt.Sprintf("no pude transicionar a %s: %v — revisá labels a mano", pipelinelabels.StateValidatePR, err))
 		} else {
 			stateValidated = true
 		}
 	case verdict != "" && !stateRes.ResolvedToIssue:
 		// Adopt mode: validate es la puerta de entrada al state machine
 		// para PRs sin che:* previo (v0.0.79 / commit 881c964). No hubo
-		// transición desde che:executed, pero el flow cerró OK con
-		// verdict, así que aplicamos che:validated directo al PR para que
+		// transición desde che:state:execute, pero el flow cerró OK con
+		// verdict, así que aplicamos che:state:validate_pr directo al PR para que
 		// el dash lo mueva fuera de la columna de adopt.
-		log.Step("adopt mode: aplicando che:validated al PR", output.F{PR: pr.Number})
-		if err := labels.Ensure(labels.CheValidated); err != nil {
-			log.Warn(fmt.Sprintf("no pude crear label che:validated en el repo: %v — revisá labels a mano", err))
-		} else if err := labels.AddLabels(pr.Number, labels.CheValidated); err != nil {
-			log.Warn(fmt.Sprintf("no pude aplicar che:validated al PR: %v — revisá labels a mano", err))
+		log.Step("adopt mode: aplicando "+pipelinelabels.StateValidatePR+" al PR", output.F{PR: pr.Number})
+		if err := labels.Ensure(pipelinelabels.StateValidatePR); err != nil {
+			log.Warn(fmt.Sprintf("no pude crear label %s en el repo: %v — revisá labels a mano", pipelinelabels.StateValidatePR, err))
+		} else if err := labels.AddLabels(pr.Number, pipelinelabels.StateValidatePR); err != nil {
+			log.Warn(fmt.Sprintf("no pude aplicar %s al PR: %v — revisá labels a mano", pipelinelabels.StateValidatePR, err))
 		}
 	case verdict != "" && stateRes.ResolvedToIssue:
-		// PR linkeado a un issue con che:* pero NO en che:executed (ej.
-		// che:idea / che:plan). No saltamos estados de la máquina por
+		// PR linkeado a un issue con che:* pero NO en che:state:execute (ej.
+		// che:state:idea / che:state:explore). No saltamos estados de la máquina por
 		// nuestra cuenta: dejamos el verdict aplicado y warnea para que
 		// el humano resuelva.
-		log.Warn(fmt.Sprintf("issue #%d linkeado no estaba en che:executed; aplique che:validated manualmente si corresponde", stateRes.IssueNumber))
+		log.Warn(fmt.Sprintf("issue #%d linkeado no estaba en %s; aplique %s manualmente si corresponde", stateRes.IssueNumber, pipelinelabels.StateExecute, pipelinelabels.StateValidatePR))
 	}
 
 	fmt.Fprintln(stdout, renderReport(results))
@@ -576,8 +631,14 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 		log.Error(fmt.Sprintf("issue #%d is not OPEN (state=%s)", issue.Number, issue.State))
 		return ExitSemantic
 	}
-	if !issue.HasLabel(labels.ChePlan) {
-		log.Error(fmt.Sprintf("issue #%d no está en che:plan — corré `che explore %d` primero", issue.Number, issue.Number))
+	// Rechazar v1 antes de chequear la presencia del label v2 — el mensaje
+	// es más útil ("corré migrate-labels-v2") que "no está en che:state:explore".
+	if err := rejectV1Labels("issue", issue.Number, issue.LabelNames()); err != nil {
+		log.Error("gate v1 falló", output.F{Issue: issue.Number, Cause: err})
+		return ExitSemantic
+	}
+	if !issue.HasLabel(pipelinelabels.StateExplore) {
+		log.Error(fmt.Sprintf("issue #%d no está en %s — corré `che explore %d` primero", issue.Number, pipelinelabels.StateExplore, issue.Number))
 		return ExitSemantic
 	}
 	if issue.HasLabel(labels.CheLocked) {
@@ -596,12 +657,12 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 		}
 	}()
 
-	// Transición: che:plan → che:validating. El defer revierte si succeded
-	// queda en false al final (rollback a che:plan). LIFO: el unlock corre
-	// después del rollback, garantizando que el lock cubre toda la ventana.
-	log.Step("transicionando a che:validating", output.F{Issue: issue.Number})
-	if err := labels.Apply(issueRef, labels.ChePlan, labels.CheValidating); err != nil {
-		log.Error("no pude transicionar a che:validating", output.F{Cause: err})
+	// Transición: che:state:explore → che:state:applying:validate_pr. El defer revierte
+	// si succeded queda en false al final (rollback a che:state:explore). LIFO: el
+	// unlock corre después del rollback, garantizando que el lock cubre toda la ventana.
+	log.Step("transicionando a "+pipelinelabels.StateApplyingValidatePR, output.F{Issue: issue.Number})
+	if err := labels.Apply(issueRef, pipelinelabels.StateExplore, pipelinelabels.StateApplyingValidatePR); err != nil {
+		log.Error("no pude transicionar a "+pipelinelabels.StateApplyingValidatePR, output.F{Cause: err})
 		return ExitRetry
 	}
 	var stateValidated bool
@@ -609,8 +670,8 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 		if stateValidated {
 			return
 		}
-		if err := labels.Apply(issueRef, labels.CheValidating, labels.ChePlan); err != nil {
-			log.Warn(fmt.Sprintf("rollback che:validating → che:plan fallo: %v — revisá labels a mano", err))
+		if err := labels.Apply(issueRef, pipelinelabels.StateApplyingValidatePR, pipelinelabels.StateExplore); err != nil {
+			log.Warn(fmt.Sprintf("rollback %s → %s fallo: %v — revisá labels a mano", pipelinelabels.StateApplyingValidatePR, pipelinelabels.StateExplore, err))
 		}
 	}()
 
@@ -677,10 +738,10 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 		}
 	}
 
-	// Cierre de la transición: che:validating → che:validated.
-	log.Step("transicionando a che:validated", output.F{Issue: issue.Number})
-	if err := labels.Apply(issueRef, labels.CheValidating, labels.CheValidated); err != nil {
-		log.Warn(fmt.Sprintf("no pude transicionar a che:validated: %v — revisá labels a mano", err))
+	// Cierre de la transición: che:state:applying:validate_pr → che:state:validate_pr.
+	log.Step("transicionando a "+pipelinelabels.StateValidatePR, output.F{Issue: issue.Number})
+	if err := labels.Apply(issueRef, pipelinelabels.StateApplyingValidatePR, pipelinelabels.StateValidatePR); err != nil {
+		log.Warn(fmt.Sprintf("no pude transicionar a %s: %v — revisá labels a mano", pipelinelabels.StateValidatePR, err))
 	} else {
 		stateValidated = true
 	}
@@ -1376,6 +1437,19 @@ func (i *Issue) HasLabel(name string) bool {
 	return false
 }
 
+// LabelNames proyecta i.Labels al slice de nombres. Útil para alimentar
+// helpers de validación como rejectV1Labels y ValidateNoMixedLabels.
+func (i *Issue) LabelNames() []string {
+	if i == nil {
+		return nil
+	}
+	out := make([]string, 0, len(i.Labels))
+	for _, l := range i.Labels {
+		out = append(out, l.Name)
+	}
+	return out
+}
+
 // FetchIssue corre `gh issue view <ref> --json ...` para el modo plan. Trae
 // un superset mínimo: number/title/body/labels/url/state. Los comments se
 // fetchean aparte con FetchIssueComments porque es consistente con cómo se
@@ -1632,7 +1706,7 @@ type PlanCandidate struct {
 // :needs-human visibles: el humano puede re-validar tras editar el plan.
 func ListPlanCandidates() ([]PlanCandidate, error) {
 	cmd := exec.Command("gh", "issue", "list",
-		"--label", labels.ChePlan,
+		"--label", pipelinelabels.StateExplore,
 		"--state", "open",
 		"--json", "number,title,url,labels",
 		"--limit", "50")

--- a/internal/flow/validate/validate_test.go
+++ b/internal/flow/validate/validate_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/chichex/che/internal/labels"
+	"github.com/chichex/che/internal/pipelinelabels"
 	planpkg "github.com/chichex/che/internal/plan"
 )
 
@@ -429,12 +430,12 @@ func TestPullRequest_PRLabelNames(t *testing.T) {
 	pr := &PullRequest{}
 	pr.Labels = append(pr.Labels, struct {
 		Name string `json:"name"`
-	}{Name: labels.CheExecuted})
+	}{Name: pipelinelabels.StateExecute})
 	pr.Labels = append(pr.Labels, struct {
 		Name string `json:"name"`
 	}{Name: labels.ValidatedApprove})
 	got := pr.PRLabelNames()
-	if len(got) != 2 || got[0] != labels.CheExecuted || got[1] != labels.ValidatedApprove {
+	if len(got) != 2 || got[0] != pipelinelabels.StateExecute || got[1] != labels.ValidatedApprove {
 		t.Fatalf("got %v", got)
 	}
 }
@@ -732,7 +733,7 @@ func TestFilterPlanCandidates(t *testing.T) {
 		},
 		{
 			"otros labels no interfieren",
-			[]Issue{mk(1, labels.ChePlan, "ct:plan")},
+			[]Issue{mk(1, pipelinelabels.StateExplore, "ct:plan")},
 			[]int{1},
 		},
 	}

--- a/internal/labels/v2_transitions.go
+++ b/internal/labels/v2_transitions.go
@@ -78,7 +78,7 @@ func ValidateNoMixedLabels(labels []string) error {
 	if len(v1Found) > 0 && len(v2Found) > 0 {
 		sort.Strings(v1Found)
 		sort.Strings(v2Found)
-		return fmt.Errorf("labels v1 (%s) y v2 (%s) presentes simultáneamente — corré `migrate-labels-v2` (cuando exista) o limpiá a mano",
+		return fmt.Errorf("labels v1 (%s) y v2 (%s) presentes simultáneamente — corré `che migrate-labels-v2` o limpiá a mano",
 			strings.Join(v1Found, ","), strings.Join(v2Found, ","))
 	}
 	return nil


### PR DESCRIPTION
Implementa #82.

Closes #82

## Implementado

Cierra la migración de labels v1 → v2 sobre la branch larga `feat/labels-v2-migration` (PR6b ya integrado vía PR #81).

### Flows migrados a v2

- **`internal/flow/validate/validate.go`** + tests — ambos modos (plan + PR). Verdicts (`validated:*`) sin tocar (orthogonales). Guard v1-rejection en cada gate, wirea `ValidateNoMixedLabels` antes del loop v1.
- **`internal/flow/iterate/iterate.go`** + tests — ambos modos (PR + plan). Mismo patrón.
- **`internal/flow/close/closing.go`** + tests — gate ramifica por `StateValidatePR` / `StateExecute`, dos transitions (closing/closed). Guard v1.

### Stateref migrado (high-leverage)

- **`internal/flow/stateref/stateref.go`** — `stateLabelSet` ahora reconoce **ambas familias** (v1 + v2) durante PR6c. Necesario para que un PR v2 con `closingIssuesReferences` apuntando a un issue legacy v1 (típico de repos a medio migrar) siga resolviendo bien. Los gates de los flows migrados rechazan los v1 con mensaje accionable, así que reconocerlos en stateref no afloja la validación — solo evita falsos negativos en la resolución. **Marcado `REMOVE IN PR6d`**: cuando ya no haya repos sin migrar, el set se reduce a solo v2.

### Dash reader migrado

- **`internal/dash/gh_source.go`** — nuevo map `v2StatusByLabel` que mapea cada label v2 al string canónico de Status (`idea`, `plan`, `executed`, etc.) que el resto del paquete dash espera (`loop.go`, `model.go`, `preflight.go` ramifican por esos strings literales). Esto preserva el contrato existente del dash y centraliza el "vocabulario v1↔v2" en un solo lugar — un step nuevo del pipeline implica una entrada nueva acá, no un cambio cascadeante a 8 archivos.
- `applyLabels` ramifica por `pipelinelabels.PrefixState` (v2) primero, fallback a `che:*` (v1 legacy). `che:locked` se intercepta arriba (es marker, no state).
- `fetchClosedIssues` ahora consulta tanto `che:state:close` como `che:closed` y deduplica por número, para soportar repos a medio migrar.

### Nuevo subcomando `migrate-labels-v2`

`cmd/migrate_labels_v2.go` (nuevo, +tests). Mapping de los 9 estados:
```
che:idea       → che:state:idea
che:planning   → che:state:applying:explore
che:plan       → che:state:explore
che:executing  → che:state:applying:execute
che:executed   → che:state:execute
che:validating → che:state:applying:validate_pr  (caveat: warn ante run en curso)
che:validated  → che:state:validate_pr
che:closing    → che:state:applying:close
che:closed     → che:state:close
```

- Flags: `--dry-run` (default false), `--repo <owner/repo>` (default current).
- Idempotencia: skip silencioso si ya está en v2; warn + skip si está MIXTO (v1+v2 simultáneos); aplica si solo tiene v1.
- Output: header con total escaneados, por issue mapping de label changes, footer con totales + errores.
- Operación por-issue (DELETE v1 + POST v2), no rename a nivel repo: los strings v1 vs v2 son distintos en estructura (no es un rename, es reemplazar uno por otro). Esto preserva v1 en el repo para issues cerrados / referencias históricas hasta el cleanup de PR6d.

8 tests unitarios cubriendo los 9 labels, idempotencia, mixto, sin che:*, dry-run, output con title/mappings.

### Mensaje del guard de explore actualizado

`internal/flow/explore/explore.go:689` ya no dice `(cuando exista)` — ahora referencia `che migrate-labels-v2`. Mensaje de `ValidateNoMixedLabels` también actualizado.

### Tests + e2e

- Fixtures e2e migradas a v2: `e2e/testdata/{validate,iterate,close}/*.json` (10 archivos modificados).
- Fixtures v1-rejection nuevas: `gh_issue_view_old_label_che_plan.json` (validate), `gh_issue_view_old_label_che_validated.json` (iterate), `gh_pr_view_old_label_che_executed.json` (close).
- Tests e2e nuevos: `TestValidate_Plan_OldV1Label_Exit3`, `TestIterate_Plan_OldV1Label_Exit3`, `TestClose_OldV1Label_Exit3`.

## Verificación

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` 100% verde (todos los paquetes)
- `grep -rn 'labels\.\(CheIdea\|ChePlan\|...\)' internal/flow internal/dash` solo deja hits intencionales (4 listas `v1StateLabels` para guards + stateref legacy lookup + dash closed filter), todos marcados `REMOVE IN PR6d`.

## Pendiente (PR6d, fuera de scope)

- Borrar las 9 constantes v1 viejas en `internal/labels/labels.go` y las 21 keys viejas en `validTransitions`.
- Borrar el shim `internal/labels/v2_transitions.go` entero.
- Borrar las 4 listas `v1StateLabels` por flow.
- Borrar las ramas legacy de `applyLabels` en dash y el segundo query de `fetchClosedIssues`.
- Update del test `TestNoHardcodedLabelsOutsideThisPackage` para que prohíba los strings v1 nuevos.

PR6d es trivial post-merge de éste — todos los archivos a tocar están marcados `REMOVE IN PR6d` en sus comentarios.

## Notas del agente

Ver `EXEC_NOTES.md` adjunto para decisiones de diseño detalladas (helper rejectV1Labels por-flow, stateref dual-family, dash mapping vs cascade, validating caveat, etc).
