### PR TITLE
feat(#60): [#50 PR7] Lock + heartbeat + auto-creación de labels

### DIFF
--- a/EXEC_NOTES.md
+++ b/EXEC_NOTES.md
@@ -125,6 +125,34 @@ target — el comment va al issue raíz cuando está disponible.
 
 ## Lo que no se hizo (pendiente para PRs siguientes)
 
+0. **PR7-followup-X: Deprecar `labels.Lock` (mutex `che:locked`) y unificar
+   en `internal/lock`.** Hoy cada flow aplica AMBOS al arrancar (mutex
+   viejo + heartbeat lock nuevo) — ver el patrón `labels.Lock(...)
+   defer labels.Unlock(...)` arriba del `runguard.AcquireLock(...)
+   defer runguard.ReleaseLock(...)` en cada flow. Eso duplica
+   round-trips a `gh` y deja al usuario final con DOS labels de "estoy
+   ocupado" cuando se activa `CHE_LOCK_HEARTBEAT=1`. Trigger para hacer
+   el follow-up: cuando `CHE_LOCK_HEARTBEAT=1` haya corrido en N runs
+   reales sin incidentes (propuesta: **50 runs en 2 semanas**, contando
+   manualmente en repos donde se active la flag por env).
+
+   Plan:
+   1. Migrar los gates pre-existentes que leen `che:locked`
+      (`internal/labels.IsLocked`, `internal/dash` filterCandidates,
+      cualquier otro consumidor) para que también acepten el formato
+      `che:lock:<ts>:<pid>-<host>` via `pipelinelabels.Parse`. Conocer
+      el dueño/edad del lock es estrictamente más útil que el binario.
+   2. Borrar `labels.Lock` / `labels.Unlock` y todos los call-sites
+      (`internal/flow/{explore,execute,iterate,validate,close}`).
+   3. Cleanup one-shot: subcomando opcional para borrar el label
+      `che:locked` huerfano de repos en uso. No es bloqueante — el
+      label simplemente queda inerte si nadie lo aplica.
+   4. Repos con `che:locked` huérfano por un crash pre-migración: el
+      cleanup script borra el label si la edad supera `<TTL>` desde el
+      commit de migración (heuristic; el binario `che:locked` no lleva
+      timestamp así que no hay forma determinística — la heurística es
+      "si nadie lo refrescó en 5 minutos, asumir muerto").
+
 1. **Default-on**: ambos features arrancan default-off. Cuando estén
    validados en repos reales, un follow-up corto (~10 LoC) puede
    invertir los defaults o borrar las funciones `Enabled()`/
@@ -161,6 +189,38 @@ target — el comment va al issue raíz cuando está disponible.
    nada. Si alguien quiere colores específicos por estado/verdict,
    sumar `--color` y `--description` per-label en EnsureForPipeline
    (tabla en `internal/labels`).
+
+7. **PR7-followup-Y: Matriz e2e con `flag=on` para los 5 flows
+   restantes.** Este PR cubre el happy-path solo para `explore` (ver
+   `e2e/heartbeat_lock_happy_path_test.go` con `TestHeartbeatLock_HappyPath_Explore`,
+   `TestHeartbeatLock_HappyPath_Explore_RunVariant`,
+   `TestHeartbeatLock_StaleEvicted_Explore`). Falta replicar para
+   `execute`, `iterate-pr`, `iterate-plan`, `validate-pr`, `validate-plan`,
+   y `close`. Cada uno requiere:
+
+   - Subtest `t.Run("flag=on", ...)` con `env.SetEnv("CHE_LOCK_HEARTBEAT",
+     "1")` y, en paralelo, un caso similar con `CHE_AUDIT_LOG=1` si se
+     quiere ejercer el audit log también.
+   - Matchers nuevos en el harness para `gh api .../labels` (POST/DELETE
+     de `che:lock:*`) por cada Acquire/Release.
+   - Matchers nuevos para `gh api PATCH .../comments/<id>` si tambien
+     se activa `CHE_AUDIT_LOG=1`.
+   - Estimación: ~30 LoC por flow × 6 flows = ~180 LoC. Bloqueador
+     realista: el harness exige consume-once por matcher (ver
+     `project_e2e_design.md`), así que cada call nuevo necesita su
+     propio matcher en cada test que ejercita ese flow — los catch-alls
+     existentes (`scriptCheLockDefault`, etc.) son non-consumable y
+     pueden absorber muchos pero no todos los casos.
+
+8. **PR7-followup-Z: Post-create re-list en audit log para neutralizar
+   comments fantasma**. `internal/auditlog.Append` hoy hace
+   List → Create-if-missing. Dos runs paralelos sin marker pueden caer
+   en "ambos crean" y queda un comment fantasma. Fix barato: post-create,
+   re-list los comments del issue, filtrar por marker, mantener el más
+   viejo y borrar los demás. Cuesta 1 list + N deletes adicionales pero
+   es una sola vez en la vida del issue (post-create). Es el mismo
+   patrón del post-check de race del lock — vale aplicarlo
+   consistentemente.
 
 ## Compatibilidad con PR6c
 

--- a/EXEC_NOTES.md
+++ b/EXEC_NOTES.md
@@ -1,133 +1,182 @@
-# PR6c — Terminar migración a labels v2: notas de ejecución
+# PR7 — Lock + heartbeat + auto-creación de labels: notas de ejecución
 
 ## Scope cubierto
 
-Migración completa de los flows restantes (validate / iterate / close +
-stateref + dash) a los strings v2 (`che:state:*`), guards v1-rejection
-wirecados en los 3 flows + `ValidateNoMixedLabels` enganchado, subcomando
-`migrate-labels-v2` listo para repos vivos. Tests + fixtures e2e migrados;
-`go test ./...` 100% verde, `go vet` clean, regresión `grep` solo deja los
-hits intencionales (guards + stateref legacy lookup + dash closed filter).
+Cuatro features cohesivas pero independientes (PRD §6.a, §6.b, §6.d, §8):
+
+1. **Lock con heartbeat + TTL** (`internal/lock`): label
+   `che:lock:<unix-nano>:<pid>-<host>` con TTL=5min, heartbeat=60s,
+   detección de stale + race-loss best-effort. Reusa el formato y el
+   parser ya definidos en `internal/pipelinelabels` (PR6a).
+2. **Auto-creación de labels** (`internal/labels.ExpectedForPipeline`,
+   `EnsureForPipeline`): set completo (estados, applying, verdicts, marker)
+   computado desde un pipeline declarativo.
+3. **Subcomando `che init-labels`** (`cmd/init_labels.go`): opt-in para
+   CI / repos nuevos. Soporta `--pipeline <name>` y `--dry-run`.
+4. **Audit log** (`internal/auditlog`): comment dedicado en el issue raíz
+   con marker `<!-- claude-cli: skill=audit-log -->`. Idempotente: edita
+   vía `gh api PATCH .../comments/<id>` en vez de crear duplicados.
+
+Resolución del issue raíz vía `closingIssuesReferences` (PRD §6.a) ya
+existía en `internal/flow/stateref` desde PR6b — reutilizada, no
+duplicada.
 
 ## Decisiones de diseño
 
-### 1. Helper `rejectV1Labels` por-flow, no centralizado
+### 1. Feature flags vs. wireup duro
 
-Cada uno de los 3 flows (validate, iterate, close) define su propio
-`v1StateLabels` slice + helper `rejectV1Labels` con mensaje accionable
-contextualizado al flow ("antes de validar", "antes de iterar", "antes
-de cerrar"). Evaluamos centralizar en `internal/labels` pero cada
-mensaje incluye el verbo del flow — extraer pierde la pista textual.
-Patrón consistente con `gateBasic` de explore (PR6b). El helper wirea
-`labels.ValidateNoMixedLabels` adentro: cualquier mezcla v1+v2 fall por
-ahí antes que el loop sobre v1StateLabels, así no pisamos labels mezclados
-con un v2 nuevo.
+Las dos primitivas runtime (heartbeat lock + audit log) están detrás de
+**env vars opt-in**:
 
-### 2. `stateref.stateLabelSet` mantiene AMBAS familias
+- `CHE_LOCK_HEARTBEAT=1` activa el lock con heartbeat en los 5 flows
+  (explore / execute / iterate-pr / iterate-plan / validate-pr /
+  validate-plan / close).
+- `CHE_AUDIT_LOG=1` activa la escritura del audit log en cada
+  transición exitosa (y en rollbacks).
 
-`internal/flow/stateref/stateref.go:stateLabelSet` reconoce tanto los 9
-labels v1 como los 9 v2 durante PR6c. Esto es necesario para que un PR v2
-con `closingIssuesReferences` apuntando a un issue legacy v1 (típico de
-repos a medio migrar) siga resolviendo al issue. Los gates de los flows
-migrados rechazan los v1 con mensaje accionable, así que reconocer el
-label v1 en stateref no afloja la validación — solo evita falsos negativos
-en la resolución (caer al PR cuando el issue ESTÁ trackeado, solo que en
-v1).
+Razón: cualquier flow con un `gh api ...` nuevo en runtime rompe
+inmediatamente los e2e tests existentes (el harness exige matchers
+explícitos para cada llamada). Wirear duro implicaría tocar 50+ tests
+con expectativas de gh y aumentar el área de superficie de PR7 más
+allá de su scope. Con env-flag:
 
-REMOVE IN PR6d: cuando ya no haya repos sin migrar, el set se reduce a
-solo v2.
+- Default off → 100% retro-compatible. Cero cambios a tests existentes.
+- Activable en prod / CI cuando esté validado el formato del label y la
+  carga de la API (1 PATCH por transición).
+- El día que sea estable, un follow-up invierte el default (o borra
+  el flag) sin tocar la lógica.
 
-### 3. Dash `applyLabels`: prefix-aware con `v2StatusByLabel` map
+### 2. `internal/lock` no depende de `internal/labels`
 
-El parser ramifica por:
-1. `che:state:applying:*` o `che:state:*` (v2) → mapeo via
-   `v2StatusByLabel` a uno de los 9 strings canónicos del kanban
-   (idea/planning/plan/.../closed). El orden de chequeo es
-   `PrefixState` (que cubre ambos casos) primero; el TrimPrefix correcto
-   se elige por presencia de `PrefixApplying`.
-2. `che:*` (v1 legacy) → fallback que preserva el comportamiento
-   pre-PR6c (TrimPrefix → idea/planning/etc).
-3. `che:locked` se intercepta arriba con prioridad (es marker).
+`internal/labels` ya importa `internal/pipelinelabels`. Si `lock`
+importara `labels` y los flows usaran `labels.AcquireHeartbeat(...)`
+estaríamos a un paso del ciclo `labels → lock → labels`. La separación:
 
-El mapping es necesario porque los strings de columna del kanban del dash
-(`idea`, `planning`, etc) no se cambian en PR6c — preflight.go, loop.go,
-model.go esperan esos strings literales y ramifican por ellos. El
-modelo v2 los preserva via mapping en vez de cascadear el cambio a 8
-archivos del dash que están bien.
+- `pipelinelabels`: fuente de verdad del FORMATO del label (LockLabelAt,
+  Parse). Sin estado, sin gh.
+- `lock`: adquisición/liberación + heartbeat con `gh api` propio. Hooks
+  REST inyectables para tests.
+- `labels`: `Lock`/`Unlock` para el binario `che:locked` (legacy mutex).
+  Sin tocar.
 
-Decisión sobre `validate_pr` v2 → `validating`/`validated` v1:
-preservamos las columnas legacy del kanban porque el modelo v1 colapsaba
-plan-validate y PR-validate en ese mismo bucket también — semánticamente
-no perdemos información.
+Tests del lock hacen 100% mocking via `Options.AddLabel/DelLabel/
+ListLabels/EnsureLabel/Now`. Cero shell-out a `gh`, cero `time.Sleep`.
 
-### 4. Dash `fetchClosedIssues` consulta AMBAS familias
+### 3. `internal/auditlog` también es opt-in y stub-friendly
 
-Antes filtraba por `che:closed` (v1) único. Ahora hace dos `gh issue
-list --state closed --label X`, una por v1 y otra por v2, y deduplica
-por número. Así repos a medio migrar (algunos issues cerrados con v1,
-otros con v2) muestran el set completo en la columna `closed`.
+Mismo patrón: un struct `Options` con hooks para tests y `Enabled()`
+gate. Marker `<!-- claude-cli: skill=audit-log -->` reutiliza la
+convención del paquete `internal/comments` pero con namespace propio
+(skill=audit-log vs. flow=...) para no confundirlo con un comment de
+un flow.
 
-REMOVE IN PR6d: dejar solo la query v2 cuando el v1 deje de existir.
+Idempotencia por marker (no por timestamp): si dos runs paralelos
+creyeran que no hay comment y crearan dos, el segundo Append los va a
+ver y editar el primero — pero como no resolvemos race en el create,
+queda el comment fantasma. Caso patológico (>2 humanos lanzando che
+contra el mismo issue al mismo segundo); no se vio en producción.
 
-### 5. `migrate-labels-v2` aplica por-issue, no a nivel repo
+### 4. `runguard` package centraliza el wireup
 
-A diferencia de `migrate-labels` (renombra labels via `gh label edit`),
-v2 hace remove + add por cada issue. Razón: los strings v1 → v2 son
-totalmente distintos (`che:plan` vs `che:state:explore`), así que un
-rename a nivel repo no funciona — son dos labels distintos. Además
-preservamos los labels v1 en el repo (pueden referenciarse desde
-issues cerrados o ramas viejas) hasta el cleanup de PR6d.
+Para no duplicar 20+ líneas idénticas en cada uno de los 5 flows,
+`internal/flow/runguard` expone `AcquireLock`, `ReleaseLock`,
+`AuditAppend`. Cada función chequea su feature flag y devuelve no-op si
+está off. Los flows cambian solo 4 líneas en cada Run().
 
-Implementación: ensure label v2 en el repo (idempotente) → DELETE v1
-(tolerante a 404, idempotente) → POST v2 (idempotente en GitHub). Si
-todo falla, paramos para no dejar labels parciales.
+Razón: este es el patrón que SI los features pasan a default-on, se
+borra el if-flag de adentro de runguard y los flows quedan ya wireados.
+Si se borra, los flows ya están conectados.
 
-### 6. Caveat de `che:validating` documentado pero no resuelto
+### 5. Race window de Acquire es post-check, no CAS
 
-v1 colapsaba validate-de-plan y validate-de-PR en `che:validating`. v2
-solo tiene `applying:validate_pr`. El subcomando mapea
-`che:validating` → `che:state:applying:validate_pr` y emite un warning
-en stdout para que el operador sepa que puede ser semánticamente
-impreciso si el run en curso era plan-validate. En la práctica
-`validating` es transitorio (solo aparece durante un run) así que
-encontrarlo en migración bulk es raro. La alternativa "saltarlo y
-dejarlo manual" pierde info; la alternativa "no migrarlo" deja el repo
-con `che:validating` huérfano que ningún flow v2 entiende. El warn +
-mapping aproximado es el menos malo.
+GitHub no expone CAS sobre labels. El protocolo es:
+
+1. List labels → no hay lock vivo.
+2. POST nuestro label.
+3. Re-list → ¿hay otro lock vivo distinto al nuestro?
+4. Si sí: DELETE el nuestro y devolver ErrAlreadyLocked.
+
+Esto reduce la ventana de carrera pero no la elimina (dos procesos
+pueden re-listar en paralelo y ambos ver el label del otro). En
+escenarios reales (humano lanzando manualmente, dash auto-loop con
+concurrency=1) la window es irrelevante. Documentado en docstring.
+
+### 6. Resolución del issue raíz NO se duplicó
+
+PR6b dejó `internal/flow/stateref/Resolve(prRef, prLabels, closingIssues)`
+funcionando. Los flows que arrancan sobre PR (validate-pr, iterate-pr,
+close) ya pasan por `pr.ResolveStateRef()`. Para el lock con heartbeat,
+el caller le pasa `stateRes.Ref` (el issue raíz si está linkeado, el PR
+si no) — alineado con donde van las transiciones. Para el audit log,
+le pasa `stateRes.IssueNumber` (o `pr.Number` si no linkeado) como
+target — el comment va al issue raíz cuando está disponible.
+
+## Cobertura de tests
+
+| Paquete | Cobertura |
+|---------|-----------|
+| `internal/lock` | 8 tests: fresh acquire, contended (vivo), stale evict, heartbeat refresh, release idempotente, TTL boundary, ref formats, add-failure preserva current label. Mock 100%, sin shell-out. |
+| `internal/auditlog` | 5 tests: create new, edit existing, render entry (3 shapes), zero-At fills now, trailing-newlines no acumula. Mock 100%. |
+| `internal/labels` | 4 tests para `ExpectedForPipeline`: golden bit-perfect sobre `pipeline.Default()`, includes-all-verdicts, alpha order, no-lock-labels. |
+| `internal/flow/runguard` | 4 tests: acquire/release/audit son no-op silencioso con feature off; nil-safe. |
+| `cmd/init-labels` | 2 tests: dry-run output, pipeline-not-found error. |
+| `e2e/init_labels_test.go` | 3 tests: command-exists, dry-run output, real-run con `gh label create` matchers. |
+| `e2e/heartbeat_lock_test.go` | 1 test: con `CHE_LOCK_HEARTBEAT=1` y un lock vivo en el issue, `che explore` aborta con exit 3 y mensaje accionable. |
 
 ## Lo que no se hizo (pendiente para PRs siguientes)
 
-- Borrar las constantes v1 viejas en `internal/labels/labels.go` y las
-  21 keys viejas en `validTransitions`. Eso es **PR6d**, después de
-  mergear este. Borrar también el shim `internal/labels/v2_transitions.go`
-  entero, las 4 listas `v1StateLabels` por flow, las ramas legacy de
-  `applyLabels` en dash y el segundo query de `fetchClosedIssues`. La
-  guía de cuáles archivos tienen `REMOVE IN PR6d:` está embebida en los
-  comentarios de los archivos respectivos.
-- Update del test `TestNoHardcodedLabelsOutsideThisPackage` para que
-  prohíba los strings v1 nuevos (post-cleanup). Hoy permite ambos
-  durante la transición.
+1. **Default-on**: ambos features arrancan default-off. Cuando estén
+   validados en repos reales, un follow-up corto (~10 LoC) puede
+   invertir los defaults o borrar las funciones `Enabled()`/
+   `HeartbeatEnabled()` directamente.
 
-## Tests verdes
+2. **Audit en rollbacks de execute**: el `cleanupLocal` de
+   `internal/flow/execute` es una closure compleja con 3 ramas de label
+   handling (executedApplied / prCreated / default rollback). No fue
+   instrumentado con `runguard.AuditAppend`; los happy-paths sí.
+   Refactor a callbacks inyectables ya estaba pendiente desde PR6b
+   (TODO en docstring de cleanupLocal). Cuando se haga ese refactor,
+   sumar audit ahí.
+
+3. **Comment del audit log: cap en paginación**: `gh api .../comments`
+   pagina. Default per_page=30; subimos a 100 para que `Append` lo
+   encuentre con un solo hit. >100 comments en un issue → el siguiente
+   Append crea un comment fantasma. Caso patológico; queda como TODO
+   con comentario en el código.
+
+4. **Subcomando `che init-labels` con `--repo <path>`**: hoy el
+   subcomando depende del cwd para detectar el repo root. Para CI puede
+   ser útil un flag explícito. Trivial: `--repo <path>` que sustituye
+   `repoRootForPipeline()`.
+
+5. **Heartbeat con context.Context**: el goroutine del heartbeat usa
+   un `chan struct{}` como stop signal. Cambiar a `context.Context` lo
+   alinearía con el resto del codebase (execute, validate). Refactor
+   sin impacto funcional.
+
+6. **EnsureForPipeline NO es idempotente respecto al color/descripción
+   del label**: `gh label create --force` actualiza color/descripción
+   solo si los pasamos. Hoy no pasamos ninguno — el label se crea con
+   default color (gris) la primera vez, y subsiguientes runs no tocan
+   nada. Si alguien quiere colores específicos por estado/verdict,
+   sumar `--color` y `--description` per-label en EnsureForPipeline
+   (tabla en `internal/labels`).
+
+## Compatibilidad con PR6c
+
+`labels.V1LegacyStates()` y los guards `rejectV1Labels` siguen
+existiendo y se ejecutan ANTES del lock con heartbeat. Si un repo todavía
+tiene labels v1, el guard falla con mensaje accionable antes de tocar la
+máquina nueva — exactamente como en PR6b/6c.
+
+`stateref` reconoce v1+v2 (PR6c). El lock con heartbeat se aplica al
+mismo `stateRef` que la transición — si stateref cae al PR (no había
+issue linkeado o todos los issues fallaron al fetch), el lock va al PR.
+
+## Checklist verde
 
 ```
-internal/flow/validate    ok (incluye TestPullRequest_PRLabelNames migrado)
-internal/flow/iterate     ok (incluye TestRunPRGate_StateFromIssue migrado)
-internal/flow/close       ok (incluye TestCloseFromStateRes migrado)
-internal/flow/stateref    ok
-internal/dash             ok (los tests existentes pasan; no se agregan nuevos
-                              porque applyLabels seguía funcionando con v1
-                              y ahora también con v2)
-cmd                       ok (TestMigrateV2_*, 8 casos cubriendo los 9
-                              labels, idempotencia, dry-run, mixed,
-                              short-circuit-resilient, output)
-e2e                       ok (incluye 3 nuevos tests v1-rejection: validate,
-                              iterate, close — paralelo al de explore)
+go build ./...        clean
+go vet ./...          clean
+go test ./...         100% pass (cmd, e2e, internal/*)
 ```
-
-`go build ./...` clean, `go vet ./...` clean, `go test ./...` 100% verde.
-
-`grep -rn 'labels\\.\\(CheIdea\\|...\\)' internal/flow internal/dash` solo
-muestra los hits intencionales (guards + stateref legacy lookup + dash
-closed filter); todos comentados con `REMOVE IN PR6d` para señalizar el
-cleanup.

--- a/cmd/init_labels.go
+++ b/cmd/init_labels.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/chichex/che/internal/labels"
+	"github.com/chichex/che/internal/pipeline"
+	"github.com/spf13/cobra"
+)
+
+// Flags de `che init-labels`. Globales al package por consistencia con
+// el resto de subcomandos (cobra los lee del flag set y `runInitLabels`
+// los recibe explícitos para tests).
+var (
+	initLabelsPipelineFlag string
+	initLabelsDryRun       bool
+)
+
+var initLabelsCmd = &cobra.Command{
+	Use:   "init-labels",
+	Short: "crea en el repo todos los labels que el pipeline necesita (idempotente)",
+	Long: `init-labels resuelve el pipeline activo (jerarquía: --pipeline > config.default >
+built-in) y para cada label que el pipeline requiere (estados terminales,
+estados aplicantes, verdicts del validador, marker ct:plan, lock binario
+che:locked) corre 'gh label create --force' — idempotente.
+
+Pensado para CI: en repos nuevos, este subcomando hace que la primera
+corrida del pipeline no pise un 404 al crear el primer label. Los flows
+ya hacen Ensure por su cuenta cuando aplican un label, así que esto NO
+es estrictamente necesario en runtime — pero es útil como pre-vuelo
+explícito para detectar problemas de auth/permisos antes de gastar tiempo
+ejecutando un agente.
+
+NO crea los labels dinámicos 'che:lock:<ts>:...' (uno por run, con
+timestamp único — no tiene sentido pre-crear).
+
+Flags:
+  --pipeline <name>  pipeline a usar (default: el del config o built-in)
+  --dry-run          solo lista los labels esperados, no los crea`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		root, err := repoRootForPipeline()
+		if err != nil {
+			return err
+		}
+		mgr, err := pipeline.NewManager(root)
+		if err != nil {
+			return fmt.Errorf("init pipeline manager: %s", formatLoadError(err))
+		}
+		return runInitLabels(cmd.OutOrStdout(), cmd.ErrOrStderr(), mgr, initLabelsPipelineFlag, initLabelsDryRun)
+	},
+}
+
+func init() {
+	initLabelsCmd.Flags().StringVar(&initLabelsPipelineFlag, "pipeline", "",
+		"nombre del pipeline a usar (default: el del config o built-in)")
+	initLabelsCmd.Flags().BoolVar(&initLabelsDryRun, "dry-run", false,
+		"solo lista los labels esperados, no los crea")
+	rootCmd.AddCommand(initLabelsCmd)
+}
+
+// runInitLabels es la función testeable: resuelve el pipeline, computa el
+// set esperado y, si no es dry-run, los crea uno por uno con
+// labels.EnsureForPipeline. Devuelve el primer error.
+//
+// El parámetro `out` recibe el output humano (lista de labels y resumen).
+// `errOut` se usa para warnings (en este subcomando, ninguno por ahora —
+// el wiring queda listo por simetría con run/explore).
+func runInitLabels(out, errOut io.Writer, mgr *pipeline.Manager, pipelineFlag string, dryRun bool) error {
+	r, err := mgr.Resolve(pipelineFlag)
+	if err != nil {
+		return fmt.Errorf("%s", formatLoadError(err))
+	}
+	src := r.Path
+	if src == "" {
+		src = "<built-in>"
+	}
+	fmt.Fprintf(out, "pipeline: %s\n", r.Name)
+	fmt.Fprintf(out, "source:   %s (%s)\n", r.Source, src)
+
+	expected := labels.ExpectedForPipeline(r.Pipeline)
+	fmt.Fprintf(out, "labels esperados (%d):\n", len(expected))
+	for _, l := range expected {
+		fmt.Fprintf(out, "  %s\n", l)
+	}
+
+	if dryRun {
+		fmt.Fprintln(out, "\n[dry-run] no se crearon labels")
+		return nil
+	}
+
+	if err := labels.EnsureForPipeline(r.Pipeline); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "\nok: %d label(s) asegurado(s) en el repo\n", len(expected))
+	_ = errOut // reservado para warnings futuros (drift, deprecaciones)
+	return nil
+}

--- a/cmd/init_labels_test.go
+++ b/cmd/init_labels_test.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestRunInitLabels_DryRun: el dry-run lista los labels esperados y NO
+// invoca shell-out. Como Default() es lo que se resuelve sin config, el
+// fixture es vacío.
+func TestRunInitLabels_DryRun(t *testing.T) {
+	mgr, _ := pipelineFixture(t, nil, "")
+	var out, errOut bytes.Buffer
+	if err := runInitLabels(&out, &errOut, mgr, "", true); err != nil {
+		t.Fatalf("runInitLabels: %v", err)
+	}
+	got := out.String()
+	wantSubstr := []string{
+		"pipeline:",
+		"source:",
+		"labels esperados",
+		"che:state:idea",
+		"validated:approve",
+		"plan-validated:approve",
+		"ct:plan",
+		"[dry-run]",
+	}
+	for _, s := range wantSubstr {
+		if !strings.Contains(got, s) {
+			t.Errorf("output sin %q:\n%s", s, got)
+		}
+	}
+}
+
+// TestRunInitLabels_DryRun_PipelineNotFound: pasar --pipeline a un nombre
+// que no existe devuelve error humano.
+func TestRunInitLabels_DryRun_PipelineNotFound(t *testing.T) {
+	mgr, _ := pipelineFixture(t, nil, "")
+	var out, errOut bytes.Buffer
+	err := runInitLabels(&out, &errOut, mgr, "no-existe", true)
+	if err == nil {
+		t.Fatal("runInitLabels con --pipeline inválido debería errar")
+	}
+	if !strings.Contains(err.Error(), "no-existe") {
+		t.Errorf("error sin nombre del pipeline: %v", err)
+	}
+}

--- a/e2e/heartbeat_lock_happy_path_test.go
+++ b/e2e/heartbeat_lock_happy_path_test.go
@@ -1,0 +1,191 @@
+package e2e_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/chichex/che/e2e/harness"
+)
+
+// TestHeartbeatLock_HappyPath_Explore: con CHE_LOCK_HEARTBEAT=1 y un
+// issue sin lock vivo, `che explore` debe completar el flujo end-to-end:
+// acquire OK → flow completo → release OK.
+//
+// Es la contraparte simétrica de TestHeartbeatLock_ContendedAbortsExplore
+// (lock vivo → abort). Sin esta cobertura, el wireup de
+// runguard.AcquireLock se mergea sin que CI vea ningún path donde la
+// feature está activa Y el flow completa OK — punto ciego del feature
+// flag default-off.
+//
+// Importante: este test cubre SOLO el flow `explore`. La matriz completa
+// para los otros 5 flows (execute, iterate-pr, iterate-plan, validate-pr,
+// validate-plan, close) queda como follow-up — ver EXEC_NOTES.md
+// "PR7-followup-Y".
+//
+// Stub strategy:
+//   - El primer `gh api repos/.../issues/42` que internal/lock.Acquire
+//     hace para listar locks, devuelve un payload SIN labels che:lock:*
+//     → fresh acquire.
+//   - El POST del lock va al catch-all de scriptCheLockDefault (que ya
+//     responde "{}" a cualquier POST de labels al issue).
+//   - El segundo `gh api .../issues/42` (post-check de race) también
+//     devuelve sin lock vivo nuestro → ganamos.
+//   - El DELETE del lock al final (Release) cae en el catch-all de
+//     scriptCheLockDefault (que matchea cualquier DELETE de label
+//     che:*).
+func TestHeartbeatLock_HappyPath_Explore(t *testing.T) {
+	t.Parallel()
+	env := harness.New(t)
+	env.SetEnv("CHE_LOCK_HEARTBEAT", "1")
+
+	// Primer + segundo list (initial check + post-check race detection):
+	// devuelven payload SIN locks vivos. Importante: este matcher es
+	// non-consumable (matchea las dos veces que internal/lock.Acquire
+	// llama al endpoint).
+	env.ExpectGh(`^api repos/\{owner\}/\{repo\}/issues/42$`).
+		RespondStdout(`{"labels":[]}`, 0)
+
+	scriptExplorePrechecks(env)
+	env.ExpectGh(`^issue view 42`).RespondStdoutFromFixture("explore/gh_issue_view_with_ctplan.json", 0)
+	env.ExpectAgent("claude").
+		WhenArgsMatch(`ingeniero senior`).
+		RespondStdoutFromFixture("explore/sonnet_explore_ok.json", 0)
+	env.ExpectGh(`^issue comment 42`).RespondStdout("https://github.com/acme/demo/issues/42#issuecomment-999\n", 0)
+	env.ExpectGh(`^issue edit 42 --body-file`).RespondStdout("ok\n", 0)
+	env.ExpectGh(`^label create `).RespondStdout("ok\n", 0)
+	env.ExpectGh(`^issue edit 42 `).RespondStdout("ok\n", 0)
+
+	out := env.MustRun("explore", "42")
+	harness.AssertContains(t, out, "Explored")
+
+	inv := env.Invocations()
+
+	// Verificación 1: hubo al menos 1 POST de un che:lock:* label (el
+	// acquire del heartbeat). El log del Step "lock con heartbeat
+	// aplicado" se asserta en TestHeartbeatLock_HappyPath_Explore_RunVariant
+	// porque MustRun no expone stderr de manera estructurada.
+	posts := inv.FindCalls("gh", "api", "-X", "POST", "issues/42/labels")
+	foundLockPost := false
+	for _, p := range posts {
+		joined := strings.Join(p.Args, " ")
+		if strings.Contains(joined, "labels[]=che:lock:") {
+			foundLockPost = true
+			break
+		}
+	}
+	if !foundLockPost {
+		t.Errorf("expected al menos 1 POST de un che:lock:* label (heartbeat acquire); posts=%v", posts)
+	}
+
+	// Verificación 2: hubo al menos 1 DELETE de un che:lock:* label (el
+	// release al final del flow).
+	deletes := inv.FindCalls("gh", "api", "-X", "DELETE")
+	foundLockDelete := false
+	for _, d := range deletes {
+		joined := strings.Join(d.Args, " ")
+		if strings.Contains(joined, "/labels/che:lock:") {
+			foundLockDelete = true
+			break
+		}
+	}
+	if !foundLockDelete {
+		t.Errorf("expected al menos 1 DELETE de un che:lock:* label (heartbeat release); deletes=%v", deletes)
+	}
+}
+
+// TestHeartbeatLock_HappyPath_Explore_RunVariant: variante que usa Run()
+// en vez de MustRun() para poder asertar sobre stderr (el logger de
+// runguard imprime "lock con heartbeat aplicado" allí). Útil para
+// verificar que la feature está realmente activa y no silenciosamente
+// disabled.
+func TestHeartbeatLock_HappyPath_Explore_RunVariant(t *testing.T) {
+	t.Parallel()
+	env := harness.New(t)
+	env.SetEnv("CHE_LOCK_HEARTBEAT", "1")
+
+	env.ExpectGh(`^api repos/\{owner\}/\{repo\}/issues/42$`).
+		RespondStdout(`{"labels":[]}`, 0)
+	scriptExplorePrechecks(env)
+	env.ExpectGh(`^issue view 42`).RespondStdoutFromFixture("explore/gh_issue_view_with_ctplan.json", 0)
+	env.ExpectAgent("claude").
+		WhenArgsMatch(`ingeniero senior`).
+		RespondStdoutFromFixture("explore/sonnet_explore_ok.json", 0)
+	env.ExpectGh(`^issue comment 42`).RespondStdout("https://github.com/acme/demo/issues/42#issuecomment-999\n", 0)
+	env.ExpectGh(`^issue edit 42 --body-file`).RespondStdout("ok\n", 0)
+	env.ExpectGh(`^label create `).RespondStdout("ok\n", 0)
+	env.ExpectGh(`^issue edit 42 `).RespondStdout("ok\n", 0)
+
+	r := env.Run("explore", "42")
+	if r.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d\nstderr:\n%s", r.ExitCode, r.Stderr)
+	}
+	combined := r.Stdout + r.Stderr
+	if !strings.Contains(combined, "lock con heartbeat aplicado") {
+		t.Errorf("salida no menciona 'lock con heartbeat aplicado' — feature flag puede no estar activo:\nstdout:\n%s\nstderr:\n%s",
+			r.Stdout, r.Stderr)
+	}
+}
+
+// TestHeartbeatLock_StaleEvicted_Explore: simétrico al test contended,
+// pero el lock pre-existente está STALE (timestamp viejo, > TTL=5min) →
+// internal/lock.Acquire debe evictarlo y proceder con el flow normal,
+// devolviendo exit 0.
+//
+// Este caso ejercita el path donde un proceso anterior crasheó dejando
+// un lock huérfano: el siguiente run no debe quedar bloqueado para
+// siempre. Es exactamente el path donde el TTL boundary check (`< TTL`
+// vs `<= TTL`) podría romper en producción si alguien lo refactorea.
+func TestHeartbeatLock_StaleEvicted_Explore(t *testing.T) {
+	t.Parallel()
+	env := harness.New(t)
+	env.SetEnv("CHE_LOCK_HEARTBEAT", "1")
+
+	// Timestamp claramente vencido (1970 + 1ns) → bien por encima del TTL
+	// default (5min). El TTL boundary check de internal/lock se asegura
+	// de evictar.
+	staleNanos := int64(1_000_000_000)
+	staleLockLabel := fmt.Sprintf("che:lock:%d:777-other-host", staleNanos)
+
+	// Initial list: devuelve el stale lock.
+	env.ExpectGh(`^api repos/\{owner\}/\{repo\}/issues/42$`).
+		Consumable().
+		RespondStdout(`{"labels":[{"name":"`+staleLockLabel+`"}]}`, 0)
+	// Post-check list: ya sin locks (el stale fue evicted por
+	// internal/lock antes del POST nuestro, y nuestro lock todavía no
+	// está en la respuesta porque el fake no mantiene estado).
+	env.ExpectGh(`^api repos/\{owner\}/\{repo\}/issues/42$`).
+		RespondStdout(`{"labels":[]}`, 0)
+
+	scriptExplorePrechecks(env)
+	env.ExpectGh(`^issue view 42`).RespondStdoutFromFixture("explore/gh_issue_view_with_ctplan.json", 0)
+	env.ExpectAgent("claude").
+		WhenArgsMatch(`ingeniero senior`).
+		RespondStdoutFromFixture("explore/sonnet_explore_ok.json", 0)
+	env.ExpectGh(`^issue comment 42`).RespondStdout("https://github.com/acme/demo/issues/42#issuecomment-999\n", 0)
+	env.ExpectGh(`^issue edit 42 --body-file`).RespondStdout("ok\n", 0)
+	env.ExpectGh(`^label create `).RespondStdout("ok\n", 0)
+	env.ExpectGh(`^issue edit 42 `).RespondStdout("ok\n", 0)
+
+	r := env.Run("explore", "42")
+	if r.ExitCode != 0 {
+		t.Fatalf("expected exit 0 (stale evicted, flow procede), got %d\nstderr:\n%s", r.ExitCode, r.Stderr)
+	}
+
+	inv := env.Invocations()
+	// Debió haber un DELETE del lock stale (eviction) ANTES del POST
+	// nuestro.
+	deletes := inv.FindCalls("gh", "api", "-X", "DELETE")
+	foundStaleDelete := false
+	for _, d := range deletes {
+		joined := strings.Join(d.Args, " ")
+		if strings.Contains(joined, staleLockLabel) {
+			foundStaleDelete = true
+			break
+		}
+	}
+	if !foundStaleDelete {
+		t.Errorf("expected DELETE del lock stale %q; deletes=%v", staleLockLabel, deletes)
+	}
+}
+

--- a/e2e/heartbeat_lock_test.go
+++ b/e2e/heartbeat_lock_test.go
@@ -1,0 +1,47 @@
+package e2e_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chichex/che/e2e/harness"
+)
+
+// TestHeartbeatLock_ContendedAbortsExplore: con CHE_LOCK_HEARTBEAT=1, el
+// flow `che explore` debe detectar un `che:lock:*` vivo presente en el
+// issue y abortar con ExitSemantic (3) — sin tocar la transición de
+// estado.
+//
+// Stubeamos `gh api .../issues/<n>` (que internal/lock.Acquire usa para
+// listar labels) devolviendo un payload con un lock vivo (timestamp
+// reciente). El flow después llama a `gh issue view ...` que devuelve la
+// fixture sin lock — los dos endpoints son distintos.
+func TestHeartbeatLock_ContendedAbortsExplore(t *testing.T) {
+	t.Parallel()
+	env := harness.New(t)
+	env.SetEnv("CHE_LOCK_HEARTBEAT", "1")
+	// Importante: registramos los matchers ESPECÍFICOS antes que los
+	// catch-all de scriptExplorePrechecks/scriptCheLockDefault, ya que el
+	// harness matchea en orden de registro.
+	// Timestamp reciente (30s atrás) → lock VIVO según TTL=5min default.
+	liveLockNanos := time.Now().Add(-30 * time.Second).UnixNano()
+	env.ExpectGh(`^api repos/\{owner\}/\{repo\}/issues/42$`).
+		RespondStdout(fmt.Sprintf(`{"labels":[{"name":"che:lock:%d:777-other-host"}]}`, liveLockNanos), 0)
+	scriptExplorePrechecks(env)
+	env.ExpectGh(`^issue view 42`).RespondStdoutFromFixture("explore/gh_issue_view_with_ctplan.json", 0)
+
+	r := env.Run("explore", "42")
+	if r.ExitCode != 3 {
+		t.Errorf("want exit 3 (ExitSemantic) por lock vivo, got %d\nstdout:\n%s\nstderr:\n%s",
+			r.ExitCode, r.Stdout, r.Stderr)
+	}
+	combined := r.Stdout + r.Stderr
+	// El error puede aparecer en stderr (output.Logger) — sentinel en
+	// español.
+	if !strings.Contains(combined, "bloqueado") &&
+		!strings.Contains(combined, "already locked") {
+		t.Errorf("salida no menciona el lock vivo:\n%s", combined)
+	}
+}

--- a/e2e/init_labels_test.go
+++ b/e2e/init_labels_test.go
@@ -1,0 +1,83 @@
+package e2e_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chichex/che/e2e/harness"
+)
+
+// TestInitLabels_CommandExists fuerza la existencia del subcomando
+// `init-labels` y de su help.
+func TestInitLabels_CommandExists(t *testing.T) {
+	t.Parallel()
+	env := harness.New(t)
+	out := env.MustRun("init-labels", "--help")
+	harness.AssertContains(t, out, "init-labels")
+	harness.AssertContains(t, out, "labels")
+}
+
+// TestInitLabels_DryRun lista los labels esperados sin tocar gh. Como el
+// repo no tiene `.che/pipelines/`, resuelve al built-in.
+func TestInitLabels_DryRun(t *testing.T) {
+	t.Parallel()
+	env := harness.New(t)
+	// init-labels llama a `git rev-parse --show-toplevel` para detectar
+	// el repo root. Stubeamos con un path arbitrario — la lógica que sigue
+	// (NewManager + Resolve) tolera que no haya `.che/` ahí.
+	env.ExpectGit(`^rev-parse --show-toplevel`).RespondStdout("/tmp/fake-repo\n", 0)
+	out := env.MustRun("init-labels", "--dry-run")
+	for _, want := range []string{
+		"pipeline:",
+		"labels esperados",
+		"che:state:idea",
+		"validated:approve",
+		"plan-validated:approve",
+		"ct:plan",
+		"[dry-run]",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output sin %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestInitLabels_RealRun corre la creación real con gh stubeado: cada
+// `gh label create` debe matchear y responder OK; el output final debe
+// indicar éxito.
+func TestInitLabels_RealRun(t *testing.T) {
+	t.Parallel()
+	env := harness.New(t)
+	env.ExpectGit(`^rev-parse --show-toplevel`).RespondStdout("/tmp/fake-repo\n", 0)
+	// `gh label create <name> --force` se llama una vez por label.
+	env.ExpectGh(`^label create `).RespondStdout("", 0)
+
+	out := env.MustRun("init-labels")
+	harness.AssertContains(t, out, "ok:")
+	harness.AssertContains(t, out, "asegurado(s)")
+
+	// Verificamos que se intentó crear los 9 estados v2 + 6 verdicts +
+	// ct:plan + che:locked = 17 (estado y aplicante por step × 6 steps de
+	// Default + 6 verdicts + ct:plan + che:locked = 19).
+	inv := env.Invocations()
+	calls := inv.FindCalls("gh", "label", "create")
+	// El número exacto depende de Default(); chequeamos al menos una
+	// muestra representativa de las 4 familias.
+	mustHave := []string{
+		"che:state:idea",
+		"che:state:applying:execute",
+		"validated:approve",
+		"plan-validated:approve",
+		"ct:plan",
+		"che:locked",
+	}
+	joined := ""
+	for _, c := range calls {
+		joined += " " + strings.Join(c.Args, " ")
+	}
+	for _, expected := range mustHave {
+		if !strings.Contains(joined, expected) {
+			t.Errorf("expected gh label create %s; calls=%v", expected, calls)
+		}
+	}
+}

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -1,0 +1,298 @@
+// Package auditlog mantiene un comment dedicado en el issue raíz que
+// registra cada transición de estado del pipeline (PRD §8). El comment
+// es editable: cada nueva entrada se appendea al body existente vía
+// `gh api PATCH .../comments/<id>` en vez de crear comments duplicados,
+// para que el timeline quede compacto y filtrable como un solo bloque.
+//
+// Marker:
+//
+//	<!-- claude-cli: skill=audit-log -->
+//
+// Es un HTML comment (invisible al render) en la primera línea del body.
+// Usamos el mismo formato que los headers de comments del paquete
+// internal/comments pero con un namespace distinto (skill=audit-log) para
+// que no se confunda con un comment de un flow concreto.
+//
+// Idempotencia:
+//   - El comment se identifica buscando el marker en los comments del
+//     issue. Si lo encuentra, edita; si no, crea uno nuevo.
+//   - Append no detecta duplicados de líneas: si el caller llama dos veces
+//     con el mismo from→to, se appendean dos entradas. La unicidad la
+//     garantiza el caller (un solo Append por transición exitosa).
+//
+// El paquete NO sabe nada de la máquina de estados — recibe strings
+// libres ("from", "to", "flow") y los serializa como una línea Markdown.
+// Es deliberado: si mañana el modelo de labels cambia, este paquete no
+// necesita actualizarse.
+package auditlog
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Marker es el HTML comment que identifica al comment del audit log
+// dentro del thread del issue. Mantener exportado para que tests fuera
+// del paquete (e2e) puedan grep contra el body.
+const Marker = "<!-- claude-cli: skill=audit-log -->"
+
+// Title es el header Markdown que prefija el comment para que un humano
+// que abra el issue entienda qué es ese bloque sin leer el HTML.
+const Title = "## Audit log (che pipelines)"
+
+// Entry es una transición concreta a registrar en el log.
+type Entry struct {
+	// At es el timestamp del evento. Si zero al pasarse a Append, se usa
+	// time.Now() automáticamente.
+	At time.Time
+
+	// Flow es el nombre del flow que generó la transición ("explore",
+	// "execute", "validate-pr", etc.). Texto libre — el paquete no
+	// valida.
+	Flow string
+
+	// From es el estado de origen (label crudo, ej. `che:state:idea`).
+	From string
+
+	// To es el estado destino. Vacío si la entrada describe una acción
+	// que no transiciona (ej. lock acquired); el renderer omite la
+	// flecha en ese caso.
+	To string
+
+	// Note es texto opcional que se agrega entre paréntesis al final de
+	// la línea — usado para discriminar rollback vs success ("rollback",
+	// "stale-evicted", etc.).
+	Note string
+}
+
+// Options ajusta el comportamiento de Append. Cero-valor es válido (usa
+// gh REST). Tests stubean los hooks para evitar shell-out.
+type Options struct {
+	// Now devuelve el "ahora" para entradas con At zero. Default time.Now.
+	Now func() time.Time
+
+	// ListComments devuelve los comments del issue/PR identificado por
+	// number. Default `gh api /repos/.../issues/<n>/comments`. Tests
+	// stubean. Cada Comment tiene ID y Body.
+	ListComments func(number int) ([]Comment, error)
+
+	// CreateComment postea un comment nuevo y devuelve su ID. Default
+	// `gh issue comment <n> --body-file ...`.
+	CreateComment func(number int, body string) (int64, error)
+
+	// EditComment reemplaza el body de un comment existente. Default
+	// `gh api PATCH /repos/.../issues/comments/<id>`.
+	EditComment func(commentID int64, body string) error
+}
+
+// Comment es la vista mínima que necesitamos del comment. ID identifica
+// al comment (no al issue) — necesario para PATCH.
+type Comment struct {
+	ID   int64
+	Body string
+}
+
+// Append añade `entry` al comment de audit log del issue/PR identificado
+// por `number`. Si no hay comment con el marker, lo crea; si sí, edita.
+//
+// El body resultante tiene este shape:
+//
+//	<!-- claude-cli: skill=audit-log -->
+//	## Audit log (che pipelines)
+//
+//	- 2024-12-01T10:23:45Z · explore · che:state:idea → che:state:applying:explore
+//	- 2024-12-01T10:24:15Z · explore · che:state:applying:explore → che:state:explore
+//	- 2024-12-01T10:30:00Z · execute · che:state:explore → che:state:applying:execute (rollback)
+//
+// Devuelve el ID del comment (creado o editado) para que el caller pueda
+// loguearlo.
+func Append(number int, entry Entry, opts Options) (int64, error) {
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	if entry.At.IsZero() {
+		entry.At = now()
+	}
+	listComments := opts.ListComments
+	if listComments == nil {
+		listComments = ghListComments
+	}
+	createComment := opts.CreateComment
+	if createComment == nil {
+		createComment = ghCreateComment
+	}
+	editComment := opts.EditComment
+	if editComment == nil {
+		editComment = ghEditComment
+	}
+
+	line := renderEntry(entry)
+
+	comments, err := listComments(number)
+	if err != nil {
+		return 0, fmt.Errorf("auditlog: list comments for #%d: %w", number, err)
+	}
+	for _, c := range comments {
+		if !strings.Contains(c.Body, Marker) {
+			continue
+		}
+		// Comment existente: appendear la línea al final.
+		newBody := strings.TrimRight(c.Body, "\n") + "\n" + line
+		if err := editComment(c.ID, newBody); err != nil {
+			return 0, fmt.Errorf("auditlog: edit comment %d: %w", c.ID, err)
+		}
+		return c.ID, nil
+	}
+	// Sin comment previo: creamos uno con el marker + título + primera entrada.
+	body := Marker + "\n" + Title + "\n\n" + line
+	id, err := createComment(number, body)
+	if err != nil {
+		return 0, fmt.Errorf("auditlog: create comment on #%d: %w", number, err)
+	}
+	return id, nil
+}
+
+// renderEntry serializa un Entry como una línea Markdown bullet. Mantenida
+// pública (lowercase pero testeada en archivo del paquete) para que tests
+// puedan validar el formato sin pasar por Append.
+//
+// Formato:
+//
+//	- <RFC3339> · <flow> · <from> → <to> [(<note>)]
+//
+// Si To está vacío, se omite la flecha. Si Note está vacío, se omite el
+// paréntesis.
+func renderEntry(e Entry) string {
+	var sb strings.Builder
+	sb.WriteString("- ")
+	sb.WriteString(e.At.UTC().Format(time.RFC3339))
+	if e.Flow != "" {
+		sb.WriteString(" · ")
+		sb.WriteString(e.Flow)
+	}
+	if e.From != "" || e.To != "" {
+		sb.WriteString(" · ")
+		sb.WriteString(e.From)
+		if e.To != "" {
+			sb.WriteString(" → ")
+			sb.WriteString(e.To)
+		}
+	}
+	if e.Note != "" {
+		sb.WriteString(" (")
+		sb.WriteString(e.Note)
+		sb.WriteString(")")
+	}
+	return sb.String()
+}
+
+// ghListComments corre `gh api /repos/{owner}/{repo}/issues/<n>/comments`.
+// El endpoint devuelve issues Y PRs uniformemente (un PR es un issue en
+// REST, mismo patrón que internal/labels.Lock).
+//
+// Default per_page es 30; subimos a 100 para minimizar paginación. Si
+// alguien tiene >100 comments y el del audit log no está en los primeros
+// 100, este paquete no lo encuentra y crea otro — caso patológico (un
+// thread con 100+ comments es raro en repos manejados por che). Si pasa,
+// el operador puede borrar el comment fantasma a mano.
+func ghListComments(number int) ([]Comment, error) {
+	cmd := exec.Command("gh", "api",
+		fmt.Sprintf("repos/{owner}/{repo}/issues/%d/comments?per_page=100", number),
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("gh api comments: %s", strings.TrimSpace(string(ee.Stderr)))
+		}
+		return nil, err
+	}
+	var raw []struct {
+		ID   int64  `json:"id"`
+		Body string `json:"body"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("parse comments: %w", err)
+	}
+	out2 := make([]Comment, 0, len(raw))
+	for _, r := range raw {
+		out2 = append(out2, Comment{ID: r.ID, Body: r.Body})
+	}
+	return out2, nil
+}
+
+// ghCreateComment postea un comment vía `gh issue comment <n> --body-file`
+// (mismo patrón que el resto del codebase) y devuelve el ID del comment
+// creado. La URL la imprime gh por stdout — para extraer el ID hacemos
+// una llamada extra a la API (la URL contiene el number del issue, no el
+// del comment). Es un costo aceptable: 1 comment de auditoría por flow,
+// post-creación, una sola vez.
+//
+// Si no podemos extraer el ID (gh emite un formato inesperado), devolvemos
+// 0 sin error: el comment quedó creado, el siguiente Append lo va a
+// encontrar por el marker (no por el ID que el caller usa solo para log).
+func ghCreateComment(number int, body string) (int64, error) {
+	tmpDir, err := os.MkdirTemp("", "che-auditlog-*")
+	if err != nil {
+		return 0, err
+	}
+	defer os.RemoveAll(tmpDir)
+	bodyFile := filepath.Join(tmpDir, "audit.md")
+	if err := os.WriteFile(bodyFile, []byte(body), 0o644); err != nil {
+		return 0, err
+	}
+	cmd := exec.Command("gh", "issue", "comment", fmt.Sprintf("%d", number), "--body-file", bodyFile)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return 0, fmt.Errorf("gh issue comment: %s", strings.TrimSpace(string(out)))
+	}
+	// gh imprime la URL del comment, ej:
+	// https://github.com/owner/repo/issues/42#issuecomment-1234567890
+	url := strings.TrimSpace(string(out))
+	if i := strings.LastIndex(url, "issuecomment-"); i >= 0 {
+		idStr := url[i+len("issuecomment-"):]
+		// Cortar por cualquier carácter no numérico que aparezca después.
+		end := 0
+		for end < len(idStr) && idStr[end] >= '0' && idStr[end] <= '9' {
+			end++
+		}
+		if end > 0 {
+			var id int64
+			_, _ = fmt.Sscanf(idStr[:end], "%d", &id)
+			return id, nil
+		}
+	}
+	return 0, nil
+}
+
+// ghEditComment reemplaza el body de un comment existente vía REST. La
+// API es PATCH /repos/{owner}/{repo}/issues/comments/{id} con `body` como
+// field. Importante: NO usamos `gh issue comment --edit-last` porque ese
+// no permite identificar el comment por marker — solo "el último". Si el
+// humano agregó un comment después, --edit-last apunta al equivocado.
+func ghEditComment(commentID int64, body string) error {
+	tmpDir, err := os.MkdirTemp("", "che-auditlog-edit-*")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+	bodyFile := filepath.Join(tmpDir, "body.md")
+	if err := os.WriteFile(bodyFile, []byte(body), 0o644); err != nil {
+		return err
+	}
+	cmd := exec.Command("gh", "api",
+		"-X", "PATCH",
+		fmt.Sprintf("repos/{owner}/{repo}/issues/comments/%d", commentID),
+		"-F", "body=@"+bodyFile,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh api PATCH comment %d: %s", commentID, strings.TrimSpace(string(out)))
+	}
+	return nil
+}

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -1,6 +1,7 @@
 package auditlog
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -158,6 +159,88 @@ func TestAppend_AtZeroFillsNow(t *testing.T) {
 	}
 	if !strings.Contains(captured, "2025-05-03T12:00:00Z") {
 		t.Errorf("body sin timestamp inyectado:\n%s", captured)
+	}
+}
+
+// TestParseCommentURL_CanonicalFormats: ghCreateComment extrae el ID del
+// comment a partir de la URL que imprime `gh issue comment` por stdout.
+// Verificamos que el parser acepta los formatos canónicos que gh emite,
+// incluyendo URLs con trailing newline / whitespace y con paths que
+// usan /pull/ en vez de /issues/.
+//
+// Si gh cambia el formato, este test rompe ANTES de descubrir el bug en
+// producción (donde silenciosamente quedaríamos con id=0 y el siguiente
+// Append sobreviviría por marker, pero perderíamos la observabilidad
+// del log).
+func TestParseCommentURL_CanonicalFormats(t *testing.T) {
+	// Reproduce in-line la lógica que vive en ghCreateComment para que
+	// podamos testearla sin shell-out. Mantener sincronizado con
+	// auditlog.go: si cambia, este test rompe.
+	parse := func(stdout string) int64 {
+		url := strings.TrimSpace(stdout)
+		if i := strings.LastIndex(url, "issuecomment-"); i >= 0 {
+			idStr := url[i+len("issuecomment-"):]
+			end := 0
+			for end < len(idStr) && idStr[end] >= '0' && idStr[end] <= '9' {
+				end++
+			}
+			if end > 0 {
+				var id int64
+				_, _ = fmt.Sscanf(idStr[:end], "%d", &id)
+				return id
+			}
+		}
+		return 0
+	}
+
+	cases := []struct {
+		name string
+		in   string
+		want int64
+	}{
+		{
+			name: "issue url plain",
+			in:   "https://github.com/acme/demo/issues/42#issuecomment-12345\n",
+			want: 12345,
+		},
+		{
+			name: "pr url plain",
+			in:   "https://github.com/acme/demo/pull/7#issuecomment-99887766\n",
+			want: 99887766,
+		},
+		{
+			name: "no trailing newline",
+			in:   "https://github.com/acme/demo/issues/42#issuecomment-1",
+			want: 1,
+		},
+		{
+			name: "extra whitespace",
+			in:   "  https://github.com/o/r/issues/N#issuecomment-987654321  \n",
+			want: 987654321,
+		},
+		{
+			name: "github enterprise host",
+			in:   "https://github.acme.corp/o/r/issues/1#issuecomment-555\n",
+			want: 555,
+		},
+		{
+			name: "no issuecomment fragment → 0",
+			in:   "https://github.com/o/r/issues/1\n",
+			want: 0,
+		},
+		{
+			name: "empty stdout → 0",
+			in:   "",
+			want: 0,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := parse(c.in)
+			if got != c.want {
+				t.Errorf("parse(%q) = %d, want %d", c.in, got, c.want)
+			}
+		})
 	}
 }
 

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -1,0 +1,185 @@
+package auditlog
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestAppend_CreatesNewComment: el issue no tiene un comment con el marker
+// → Append llama a CreateComment con el body completo (marker + título +
+// primera entrada). EditComment no se invoca.
+func TestAppend_CreatesNewComment(t *testing.T) {
+	var createdBody string
+	editCalls := 0
+
+	id, err := Append(42, Entry{
+		At:   time.Date(2024, 12, 1, 10, 23, 45, 0, time.UTC),
+		Flow: "explore",
+		From: "che:state:idea",
+		To:   "che:state:applying:explore",
+	}, Options{
+		ListComments: func(int) ([]Comment, error) { return nil, nil },
+		CreateComment: func(_ int, body string) (int64, error) {
+			createdBody = body
+			return 999, nil
+		},
+		EditComment: func(int64, string) error {
+			editCalls++
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if id != 999 {
+		t.Errorf("id = %d, want 999", id)
+	}
+	if editCalls != 0 {
+		t.Errorf("editCalls = %d, want 0 (no había comment previo)", editCalls)
+	}
+	if !strings.Contains(createdBody, Marker) {
+		t.Errorf("body sin marker:\n%s", createdBody)
+	}
+	if !strings.Contains(createdBody, Title) {
+		t.Errorf("body sin título:\n%s", createdBody)
+	}
+	if !strings.Contains(createdBody, "explore") || !strings.Contains(createdBody, "che:state:idea") {
+		t.Errorf("body sin línea de evento:\n%s", createdBody)
+	}
+}
+
+// TestAppend_EditsExistingComment: ya existe un comment con el marker →
+// Append edita el body, no crea un comment nuevo. El body resultante
+// preserva el contenido viejo + appendea la nueva línea.
+func TestAppend_EditsExistingComment(t *testing.T) {
+	existingBody := Marker + "\n" + Title + "\n\n- 2024-12-01T10:00:00Z · idea · - → che:state:idea"
+	createCalls := 0
+	var editID int64
+	var editBody string
+
+	id, err := Append(42, Entry{
+		At:   time.Date(2024, 12, 1, 10, 23, 45, 0, time.UTC),
+		Flow: "explore",
+		From: "che:state:idea",
+		To:   "che:state:applying:explore",
+	}, Options{
+		ListComments: func(int) ([]Comment, error) {
+			return []Comment{
+				{ID: 11, Body: "comment de un humano sin marker"},
+				{ID: 22, Body: existingBody},
+				{ID: 33, Body: "otro comment sin marker"},
+			}, nil
+		},
+		CreateComment: func(int, string) (int64, error) {
+			createCalls++
+			return 0, nil
+		},
+		EditComment: func(cid int64, body string) error {
+			editID = cid
+			editBody = body
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if id != 22 {
+		t.Errorf("id devuelto = %d, want 22 (comment con marker)", id)
+	}
+	if createCalls != 0 {
+		t.Errorf("createCalls = %d, want 0 (debe editar, no crear)", createCalls)
+	}
+	if editID != 22 {
+		t.Errorf("editID = %d, want 22", editID)
+	}
+	if !strings.Contains(editBody, "che:state:idea → che:state:applying:explore") {
+		t.Errorf("editBody no contiene la nueva entrada:\n%s", editBody)
+	}
+	// Preserva la entrada vieja.
+	if !strings.Contains(editBody, "10:00:00Z") {
+		t.Errorf("editBody no preserva la entrada vieja:\n%s", editBody)
+	}
+}
+
+// TestRenderEntry_FormatVariations cubre los tres shapes principales:
+// transición completa, sin To, sin From ni To pero con flow + note.
+func TestRenderEntry_FormatVariations(t *testing.T) {
+	at := time.Date(2024, 12, 1, 10, 23, 45, 0, time.UTC)
+	cases := []struct {
+		name string
+		in   Entry
+		want string
+	}{
+		{
+			name: "transition",
+			in:   Entry{At: at, Flow: "explore", From: "che:state:idea", To: "che:state:applying:explore"},
+			want: "- 2024-12-01T10:23:45Z · explore · che:state:idea → che:state:applying:explore",
+		},
+		{
+			name: "rollback note",
+			in:   Entry{At: at, Flow: "explore", From: "che:state:applying:explore", To: "che:state:idea", Note: "rollback"},
+			want: "- 2024-12-01T10:23:45Z · explore · che:state:applying:explore → che:state:idea (rollback)",
+		},
+		{
+			name: "no destination",
+			in:   Entry{At: at, Flow: "lock", From: "acquired", Note: "pid=12345"},
+			want: "- 2024-12-01T10:23:45Z · lock · acquired (pid=12345)",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := renderEntry(c.in)
+			if got != c.want {
+				t.Errorf("\ngot:  %q\nwant: %q", got, c.want)
+			}
+		})
+	}
+}
+
+// TestAppend_AtZeroFillsNow: si entry.At es zero, Append usa Now(). Tests
+// inyectan un Now fijo para verificar que la línea generada lleva ese
+// timestamp.
+func TestAppend_AtZeroFillsNow(t *testing.T) {
+	fixedNow := time.Date(2025, 5, 3, 12, 0, 0, 0, time.UTC)
+	var captured string
+	_, err := Append(42, Entry{
+		Flow: "execute",
+		From: "che:state:explore",
+		To:   "che:state:applying:execute",
+	}, Options{
+		Now:           func() time.Time { return fixedNow },
+		ListComments:  func(int) ([]Comment, error) { return nil, nil },
+		CreateComment: func(_ int, body string) (int64, error) { captured = body; return 1, nil },
+		EditComment:   func(int64, string) error { return nil },
+	})
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if !strings.Contains(captured, "2025-05-03T12:00:00Z") {
+		t.Errorf("body sin timestamp inyectado:\n%s", captured)
+	}
+}
+
+// TestAppend_PreservesTrailingNewlinesGracefully: si el body existente
+// tiene trailing newlines, Append no acumula líneas vacías al editar.
+func TestAppend_PreservesTrailingNewlinesGracefully(t *testing.T) {
+	existing := Marker + "\n" + Title + "\n\n- 2024-12-01T10:00:00Z · idea\n\n\n"
+	var got string
+	_, err := Append(42, Entry{
+		At: time.Date(2024, 12, 1, 10, 23, 45, 0, time.UTC), Flow: "x", From: "a", To: "b",
+	}, Options{
+		ListComments: func(int) ([]Comment, error) {
+			return []Comment{{ID: 22, Body: existing}}, nil
+		},
+		CreateComment: func(int, string) (int64, error) { return 0, nil },
+		EditComment:   func(_ int64, b string) error { got = b; return nil },
+	})
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	// No debe haber 3+ newlines consecutivas justo antes de la nueva entrada.
+	if strings.Contains(got, "\n\n\n-") {
+		t.Errorf("trailing newlines acumuladas:\n%q", got)
+	}
+}

--- a/internal/auditlog/feature.go
+++ b/internal/auditlog/feature.go
@@ -1,0 +1,23 @@
+// Feature-flag para roll-out gradual del audit log (PRD §8).
+//
+// El audit log agrega un comment al issue raíz con la timeline de
+// transiciones — útil pero no crítico. Mientras se valida el formato y
+// el rendimiento (1 PATCH por transición), se gatea con env var. Cuando
+// sea estable se invierte el default en un PR follow-up.
+package auditlog
+
+import (
+	"os"
+	"strings"
+)
+
+// Enabled devuelve true si CHE_AUDIT_LOG=1|true|on. Cualquier otro valor
+// (incluyendo unset) → false.
+func Enabled() bool {
+	v := strings.TrimSpace(strings.ToLower(os.Getenv("CHE_AUDIT_LOG")))
+	switch v {
+	case "1", "true", "on", "yes":
+		return true
+	}
+	return false
+}

--- a/internal/flow/close/closing.go
+++ b/internal/flow/close/closing.go
@@ -28,9 +28,11 @@ import (
 	"time"
 
 	"github.com/chichex/che/internal/flow/execute"
+	"github.com/chichex/che/internal/flow/runguard"
 	"github.com/chichex/che/internal/flow/stateref"
 	"github.com/chichex/che/internal/flow/validate"
 	"github.com/chichex/che/internal/labels"
+	"github.com/chichex/che/internal/lock"
 	"github.com/chichex/che/internal/output"
 	"github.com/chichex/che/internal/pipelinelabels"
 )
@@ -490,6 +492,17 @@ func Run(prRef string, opts Opts) ExitCode {
 		}
 	}()
 
+	// Lock con heartbeat + TTL (PRD §6.d) — opt-in.
+	heartbeat := runguard.AcquireLock(stateRef, "close", log)
+	defer runguard.ReleaseLock(heartbeat, log)
+	if heartbeat == nil && lock.HeartbeatEnabled() {
+		return ExitSemantic
+	}
+	auditTarget := pr.Number
+	if stateRes.ResolvedToIssue {
+		auditTarget = stateRes.IssueNumber
+	}
+
 	// Transición <prFrom> → che:state:applying:close. Rollback en defer LIFO si
 	// stateClosed queda en false. Target: issue si hay linkeado con che:*,
 	// PR si no.
@@ -502,6 +515,7 @@ func Run(prRef string, opts Opts) ExitCode {
 		log.Error("no pude transicionar a "+pipelinelabels.StateApplyingClose, output.F{Cause: err})
 		return ExitRetry
 	}
+	runguard.AuditAppend(auditTarget, "close", prFrom, pipelinelabels.StateApplyingClose, "", log)
 	var stateClosed bool
 	defer func() {
 		if stateClosed {
@@ -509,7 +523,9 @@ func Run(prRef string, opts Opts) ExitCode {
 		}
 		if err := labels.Apply(stateRef, pipelinelabels.StateApplyingClose, prFrom); err != nil {
 			log.Warn(fmt.Sprintf("rollback %s → %s fallo: %v — revisá labels a mano", pipelinelabels.StateApplyingClose, prFrom, err))
+			return
 		}
+		runguard.AuditAppend(auditTarget, "close", pipelinelabels.StateApplyingClose, prFrom, "rollback", log)
 	}()
 
 	if blocking := BlockingVerdict(pr); blocking != "" {
@@ -673,6 +689,7 @@ func Run(prRef string, opts Opts) ExitCode {
 		log.Warn(fmt.Sprintf("no pude transicionar a %s: %v — revisá labels a mano", pipelinelabels.StateClose, err))
 	} else {
 		stateClosed = true
+		runguard.AuditAppend(auditTarget, "close", pipelinelabels.StateApplyingClose, pipelinelabels.StateClose, "", log)
 	}
 
 	// Cerrar issues asociados. Después del merge, los que tenían "closes #N"

--- a/internal/flow/close/closing.go
+++ b/internal/flow/close/closing.go
@@ -32,7 +32,6 @@ import (
 	"github.com/chichex/che/internal/flow/stateref"
 	"github.com/chichex/che/internal/flow/validate"
 	"github.com/chichex/che/internal/labels"
-	"github.com/chichex/che/internal/lock"
 	"github.com/chichex/che/internal/output"
 	"github.com/chichex/che/internal/pipelinelabels"
 )
@@ -493,9 +492,9 @@ func Run(prRef string, opts Opts) ExitCode {
 	}()
 
 	// Lock con heartbeat + TTL (PRD §6.d) — opt-in.
-	heartbeat := runguard.AcquireLock(stateRef, "close", log)
+	heartbeat, lockResult := runguard.AcquireLock(stateRef, "close", log)
 	defer runguard.ReleaseLock(heartbeat, log)
-	if heartbeat == nil && lock.HeartbeatEnabled() {
+	if lockResult == runguard.AcquireContended {
 		return ExitSemantic
 	}
 	auditTarget := pr.Number

--- a/internal/flow/execute/execute.go
+++ b/internal/flow/execute/execute.go
@@ -31,7 +31,6 @@ import (
 	"github.com/chichex/che/internal/agent"
 	"github.com/chichex/che/internal/flow/runguard"
 	"github.com/chichex/che/internal/labels"
-	"github.com/chichex/che/internal/lock"
 	"github.com/chichex/che/internal/output"
 	"github.com/chichex/che/internal/pipelinelabels"
 	planpkg "github.com/chichex/che/internal/plan"
@@ -339,9 +338,9 @@ func Run(issueRef string, opts Opts) ExitCode {
 	}()
 
 	// Lock con heartbeat + TTL (PRD §6.d) — opt-in vía CHE_LOCK_HEARTBEAT.
-	heartbeat := runguard.AcquireLock(issueRef, "execute", log)
+	heartbeat, lockResult := runguard.AcquireLock(issueRef, "execute", log)
 	defer runguard.ReleaseLock(heartbeat, log)
-	if heartbeat == nil && lock.HeartbeatEnabled() {
+	if lockResult == runguard.AcquireContended {
 		return ExitSemantic
 	}
 

--- a/internal/flow/execute/execute.go
+++ b/internal/flow/execute/execute.go
@@ -29,7 +29,9 @@ import (
 	"time"
 
 	"github.com/chichex/che/internal/agent"
+	"github.com/chichex/che/internal/flow/runguard"
 	"github.com/chichex/che/internal/labels"
+	"github.com/chichex/che/internal/lock"
 	"github.com/chichex/che/internal/output"
 	"github.com/chichex/che/internal/pipelinelabels"
 	planpkg "github.com/chichex/che/internal/plan"
@@ -336,6 +338,13 @@ func Run(issueRef string, opts Opts) ExitCode {
 		}
 	}()
 
+	// Lock con heartbeat + TTL (PRD §6.d) — opt-in vía CHE_LOCK_HEARTBEAT.
+	heartbeat := runguard.AcquireLock(issueRef, "execute", log)
+	defer runguard.ReleaseLock(heartbeat, log)
+	if heartbeat == nil && lock.HeartbeatEnabled() {
+		return ExitSemantic
+	}
+
 	// Transition <from> → applying:execute. Desde acá se lockea el issue
 	// (también vía che:* — redundante con che:locked pero preservado porque
 	// el listado de candidatos y el gate ya dependen de la máquina de
@@ -345,6 +354,7 @@ func Run(issueRef string, opts Opts) ExitCode {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return ExitRetry
 	}
+	runguard.AuditAppend(issue.Number, "execute", from, pipelinelabels.StateApplyingExecute, "", log)
 
 	var (
 		succeeded       bool
@@ -564,6 +574,7 @@ func Run(issueRef string, opts Opts) ExitCode {
 		return ExitRetry
 	}
 	executedApplied = true
+	runguard.AuditAppend(issue.Number, "execute", pipelinelabels.StateApplyingExecute, pipelinelabels.StateExecute, "", log)
 
 	progress("posteando comment en el issue con link al PR…")
 	if err := commentIssue(ctx, issueRef, renderIssueComment(prURL)); err != nil {

--- a/internal/flow/explore/explore.go
+++ b/internal/flow/explore/explore.go
@@ -20,7 +20,9 @@ import (
 	"github.com/chichex/che/internal/agent"
 	"github.com/chichex/che/internal/comments"
 	"github.com/chichex/che/internal/flow/idea"
+	"github.com/chichex/che/internal/flow/runguard"
 	"github.com/chichex/che/internal/labels"
+	"github.com/chichex/che/internal/lock"
 	"github.com/chichex/che/internal/output"
 	"github.com/chichex/che/internal/pipelinelabels"
 	"github.com/chichex/che/internal/plan"
@@ -355,6 +357,16 @@ func Run(issueRef string, opts Opts) ExitCode {
 		}
 	}()
 
+	// Lock con heartbeat + TTL (PRD §6.d) — opt-in vía CHE_LOCK_HEARTBEAT.
+	// Convive con `labels.Lock` arriba: el binario `che:locked` queda como
+	// mutex simple para flows v1 y este lock agrega identidad + staleness.
+	heartbeat := runguard.AcquireLock(issueRef, "explore", log)
+	defer runguard.ReleaseLock(heartbeat, log)
+	if heartbeat == nil && lock.HeartbeatEnabled() {
+		// Lock vivo de otro proceso — abortamos sin tocar nada.
+		return ExitSemantic
+	}
+
 	// Transición idea → applying:explore (lock de máquina de estados). El
 	// rollback (applying:explore → idea) lo hace el defer si succeeded queda
 	// en false.
@@ -363,6 +375,7 @@ func Run(issueRef string, opts Opts) ExitCode {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return ExitRetry
 	}
+	runguard.AuditAppend(issue.Number, "explore", pipelinelabels.StateIdea, pipelinelabels.StateApplyingExplore, "", log)
 	var succeeded bool
 	defer func() {
 		if succeeded {
@@ -371,7 +384,9 @@ func Run(issueRef string, opts Opts) ExitCode {
 		if err := labels.Apply(issueRef, pipelinelabels.StateApplyingExplore, pipelinelabels.StateIdea); err != nil {
 			fmt.Fprintf(stderr, "warning: rollback %s → %s fallo: %v — revisá labels a mano\n",
 				pipelinelabels.StateApplyingExplore, pipelinelabels.StateIdea, err)
+			return
 		}
+		runguard.AuditAppend(issue.Number, "explore", pipelinelabels.StateApplyingExplore, pipelinelabels.StateIdea, "rollback", log)
 	}()
 
 	a := opts.Agent
@@ -416,6 +431,7 @@ func Run(issueRef string, opts Opts) ExitCode {
 		fmt.Fprintf(stderr, "warning: comentario posteado (%s) pero label no cambió; corré de nuevo o editá a mano\n", commentURL)
 		return ExitRetry
 	}
+	runguard.AuditAppend(issue.Number, "explore", pipelinelabels.StateApplyingExplore, pipelinelabels.StateExplore, "", log)
 	succeeded = true
 
 	fmt.Fprintf(stdout, "Explored %s\n", issue.URL)

--- a/internal/flow/explore/explore.go
+++ b/internal/flow/explore/explore.go
@@ -22,7 +22,6 @@ import (
 	"github.com/chichex/che/internal/flow/idea"
 	"github.com/chichex/che/internal/flow/runguard"
 	"github.com/chichex/che/internal/labels"
-	"github.com/chichex/che/internal/lock"
 	"github.com/chichex/che/internal/output"
 	"github.com/chichex/che/internal/pipelinelabels"
 	"github.com/chichex/che/internal/plan"
@@ -360,9 +359,9 @@ func Run(issueRef string, opts Opts) ExitCode {
 	// Lock con heartbeat + TTL (PRD §6.d) — opt-in vía CHE_LOCK_HEARTBEAT.
 	// Convive con `labels.Lock` arriba: el binario `che:locked` queda como
 	// mutex simple para flows v1 y este lock agrega identidad + staleness.
-	heartbeat := runguard.AcquireLock(issueRef, "explore", log)
+	heartbeat, lockResult := runguard.AcquireLock(issueRef, "explore", log)
 	defer runguard.ReleaseLock(heartbeat, log)
-	if heartbeat == nil && lock.HeartbeatEnabled() {
+	if lockResult == runguard.AcquireContended {
 		// Lock vivo de otro proceso — abortamos sin tocar nada.
 		return ExitSemantic
 	}

--- a/internal/flow/iterate/iterate.go
+++ b/internal/flow/iterate/iterate.go
@@ -39,7 +39,6 @@ import (
 	"github.com/chichex/che/internal/flow/runguard"
 	"github.com/chichex/che/internal/flow/validate"
 	"github.com/chichex/che/internal/labels"
-	"github.com/chichex/che/internal/lock"
 	"github.com/chichex/che/internal/output"
 	"github.com/chichex/che/internal/pipelinelabels"
 	planpkg "github.com/chichex/che/internal/plan"
@@ -287,9 +286,9 @@ func runPR(prRef string, opts Opts, stdout io.Writer, log *output.Logger) ExitCo
 	// el mismo `stateRef` que las transiciones (issue raíz si está
 	// linkeado, PR si no) para no aplicar el lock en un lugar y las
 	// transiciones en otro.
-	heartbeat := runguard.AcquireLock(stateRef, "iterate-pr", log)
+	heartbeat, lockResult := runguard.AcquireLock(stateRef, "iterate-pr", log)
 	defer runguard.ReleaseLock(heartbeat, log)
-	if heartbeat == nil && lock.HeartbeatEnabled() {
+	if lockResult == runguard.AcquireContended {
 		return ExitSemantic
 	}
 	auditTarget := pr.Number
@@ -482,9 +481,9 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 	}()
 
 	// Lock con heartbeat + TTL (PRD §6.d) — opt-in.
-	heartbeat := runguard.AcquireLock(issueRef, "iterate-plan", log)
+	heartbeat, lockResult := runguard.AcquireLock(issueRef, "iterate-plan", log)
 	defer runguard.ReleaseLock(heartbeat, log)
-	if heartbeat == nil && lock.HeartbeatEnabled() {
+	if lockResult == runguard.AcquireContended {
 		return ExitSemantic
 	}
 

--- a/internal/flow/iterate/iterate.go
+++ b/internal/flow/iterate/iterate.go
@@ -36,8 +36,10 @@ import (
 
 	"github.com/chichex/che/internal/agent"
 	"github.com/chichex/che/internal/flow/execute"
+	"github.com/chichex/che/internal/flow/runguard"
 	"github.com/chichex/che/internal/flow/validate"
 	"github.com/chichex/che/internal/labels"
+	"github.com/chichex/che/internal/lock"
 	"github.com/chichex/che/internal/output"
 	"github.com/chichex/che/internal/pipelinelabels"
 	planpkg "github.com/chichex/che/internal/plan"
@@ -281,6 +283,20 @@ func runPR(prRef string, opts Opts, stdout io.Writer, log *output.Logger) ExitCo
 		}
 	}()
 
+	// Lock con heartbeat + TTL (PRD §6.d) — opt-in. El target del lock es
+	// el mismo `stateRef` que las transiciones (issue raíz si está
+	// linkeado, PR si no) para no aplicar el lock en un lugar y las
+	// transiciones en otro.
+	heartbeat := runguard.AcquireLock(stateRef, "iterate-pr", log)
+	defer runguard.ReleaseLock(heartbeat, log)
+	if heartbeat == nil && lock.HeartbeatEnabled() {
+		return ExitSemantic
+	}
+	auditTarget := pr.Number
+	if stateRes.ResolvedToIssue {
+		auditTarget = stateRes.IssueNumber
+	}
+
 	// Transición che:state:validate_pr → che:state:applying:execute. Rollback en defer LIFO.
 	// Target: issue si hay linkeado con che:*, PR si no.
 	if stateRes.ResolvedToIssue {
@@ -292,6 +308,7 @@ func runPR(prRef string, opts Opts, stdout io.Writer, log *output.Logger) ExitCo
 		log.Error("no pude transicionar a "+pipelinelabels.StateApplyingExecute, output.F{Cause: err})
 		return ExitRetry
 	}
+	runguard.AuditAppend(auditTarget, "iterate-pr", pipelinelabels.StateValidatePR, pipelinelabels.StateApplyingExecute, "", log)
 	var stateExecuted bool
 	defer func() {
 		if stateExecuted {
@@ -299,7 +316,9 @@ func runPR(prRef string, opts Opts, stdout io.Writer, log *output.Logger) ExitCo
 		}
 		if err := labels.Apply(stateRef, pipelinelabels.StateApplyingExecute, pipelinelabels.StateValidatePR); err != nil {
 			log.Warn(fmt.Sprintf("rollback %s → %s fallo: %v — revisá labels a mano", pipelinelabels.StateApplyingExecute, pipelinelabels.StateValidatePR, err))
+			return
 		}
+		runguard.AuditAppend(auditTarget, "iterate-pr", pipelinelabels.StateApplyingExecute, pipelinelabels.StateValidatePR, "rollback", log)
 	}()
 
 	log.Step("leyendo comments previos para buscar findings")
@@ -390,6 +409,7 @@ func runPR(prRef string, opts Opts, stdout io.Writer, log *output.Logger) ExitCo
 		log.Warn(fmt.Sprintf("no pude transicionar a %s: %v — revisá labels a mano", pipelinelabels.StateExecute, err))
 	} else {
 		stateExecuted = true
+		runguard.AuditAppend(auditTarget, "iterate-pr", pipelinelabels.StateApplyingExecute, pipelinelabels.StateExecute, "", log)
 	}
 
 	log.Success("iterated PR", output.F{PR: pr.Number, URL: pr.URL, Detail: fmt.Sprintf("%d nuevos commits", len(newCommits))})
@@ -461,12 +481,20 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 		}
 	}()
 
+	// Lock con heartbeat + TTL (PRD §6.d) — opt-in.
+	heartbeat := runguard.AcquireLock(issueRef, "iterate-plan", log)
+	defer runguard.ReleaseLock(heartbeat, log)
+	if heartbeat == nil && lock.HeartbeatEnabled() {
+		return ExitSemantic
+	}
+
 	// Transición che:state:validate_pr → che:state:applying:explore. Rollback en defer LIFO.
 	log.Step("transicionando a "+pipelinelabels.StateApplyingExplore, output.F{Issue: issue.Number})
 	if err := labels.Apply(issueRef, pipelinelabels.StateValidatePR, pipelinelabels.StateApplyingExplore); err != nil {
 		log.Error("no pude transicionar a "+pipelinelabels.StateApplyingExplore, output.F{Cause: err})
 		return ExitRetry
 	}
+	runguard.AuditAppend(issue.Number, "iterate-plan", pipelinelabels.StateValidatePR, pipelinelabels.StateApplyingExplore, "", log)
 	var statePlan bool
 	defer func() {
 		if statePlan {
@@ -474,7 +502,9 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 		}
 		if err := labels.Apply(issueRef, pipelinelabels.StateApplyingExplore, pipelinelabels.StateValidatePR); err != nil {
 			log.Warn(fmt.Sprintf("rollback %s → %s fallo: %v — revisá labels a mano", pipelinelabels.StateApplyingExplore, pipelinelabels.StateValidatePR, err))
+			return
 		}
+		runguard.AuditAppend(issue.Number, "iterate-plan", pipelinelabels.StateApplyingExplore, pipelinelabels.StateValidatePR, "rollback", log)
 	}()
 
 	currentPlan, parseErr := planpkg.Parse(issue.Body)
@@ -551,6 +581,7 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 		log.Warn(fmt.Sprintf("no pude transicionar a %s: %v — revisá labels a mano", pipelinelabels.StateExplore, err))
 	} else {
 		statePlan = true
+		runguard.AuditAppend(issue.Number, "iterate-plan", pipelinelabels.StateApplyingExplore, pipelinelabels.StateExplore, "", log)
 	}
 
 	log.Success("iterated plan", output.F{Issue: issue.Number, URL: issue.URL})

--- a/internal/flow/runguard/runguard.go
+++ b/internal/flow/runguard/runguard.go
@@ -1,0 +1,111 @@
+// Package runguard centraliza la adquisición/liberación del lock con
+// heartbeat (PRD §6.d) y la escritura del audit log (PRD §8) para que los
+// 5 flows (explore, execute, iterate, validate, close) no dupliquen 20+
+// líneas idénticas cada uno.
+//
+// Patrón de uso desde un flow:
+//
+//	hb := runguard.AcquireLock(issueRef, "explore", log)
+//	defer runguard.ReleaseLock(hb, log)
+//	if hb == nil && lock.HeartbeatEnabled() {
+//	    // Lock vivo de otro proceso — abort.
+//	    return ExitSemantic
+//	}
+//	...
+//	runguard.AuditAppend(issueNumber, "explore", from, to, "")
+//
+// Los dos features están gateados por env vars (CHE_LOCK_HEARTBEAT,
+// CHE_AUDIT_LOG): si no están on, las funciones son no-op silencioso.
+// Eso permite roll-out gradual sin tocar tests existentes.
+package runguard
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/chichex/che/internal/auditlog"
+	"github.com/chichex/che/internal/lock"
+	"github.com/chichex/che/internal/output"
+)
+
+// AcquireLock toma el lock con heartbeat sobre `ref`. Si la feature está
+// off (env CHE_LOCK_HEARTBEAT no=1), devuelve nil sin tocar nada (caller
+// debe interpretar nil como "feature off, seguir adelante").
+//
+// Si la feature está on:
+//   - Acquire OK → devuelve un Handle vivo (el caller hace defer Release).
+//   - Lock previo vivo (ErrAlreadyLocked) → loggea error y devuelve nil.
+//     El caller debe abortar con ExitSemantic. La forma de distinguir
+//     "feature off" de "lock contended" es chequear lock.HeartbeatEnabled()
+//     después de un nil return.
+//   - Cualquier otro error (red, gh) → loggea warn y devuelve nil. El
+//     caller puede decidir continuar (el flow no tiene heartbeat pero el
+//     binario `che:locked` legacy ya cubrió la sección crítica) o abortar.
+//     Conservamos "continuar" como default para no degradar runs por red
+//     intermitente.
+func AcquireLock(ref, flow string, log *output.Logger) *lock.Handle {
+	if !lock.HeartbeatEnabled() {
+		return nil
+	}
+	h, err := lock.Acquire(ref, lock.Options{
+		LogErrf: func(format string, args ...any) {
+			if log != nil {
+				log.Warn("heartbeat: " + fmt.Sprintf(format, args...))
+			}
+		},
+	})
+	if err == nil {
+		if log != nil {
+			log.Step("lock con heartbeat aplicado", output.F{Labels: []string{h.CurrentLabel()}})
+		}
+		return h
+	}
+	if errors.Is(err, lock.ErrAlreadyLocked) {
+		if log != nil {
+			log.Error("ref bloqueado por otro proceso (heartbeat lock)", output.F{Cause: err})
+		}
+		return nil
+	}
+	if log != nil {
+		log.Warn("no se pudo aplicar heartbeat lock — sigo con che:locked legacy", output.F{Cause: err})
+	}
+	return nil
+}
+
+// ReleaseLock libera el handle si no es nil. Idempotente. Loggea warn si
+// la liberación falla (el flow ya terminó, no podemos abortar).
+func ReleaseLock(h *lock.Handle, log *output.Logger) {
+	if h == nil {
+		return
+	}
+	if err := h.Release(); err != nil {
+		if log != nil {
+			log.Warn("no se pudo liberar heartbeat lock", output.F{Cause: err})
+		}
+	}
+}
+
+// AuditAppend agrega una entrada al audit log del issue/PR. No-op si
+// CHE_AUDIT_LOG no está on. Errores se loggean como warn pero no abortan
+// el flow (el audit log es valor agregado, no crítico).
+//
+// `note` es opcional — pasalo como "rollback", "stale-evicted", etc. para
+// distinguir transiciones de éxito de las correctivas.
+func AuditAppend(number int, flow, from, to, note string, log *output.Logger) {
+	if !auditlog.Enabled() {
+		return
+	}
+	if number <= 0 {
+		return
+	}
+	_, err := auditlog.Append(number, auditlog.Entry{
+		Flow: flow,
+		From: from,
+		To:   to,
+		Note: note,
+	}, auditlog.Options{})
+	if err != nil && log != nil {
+		log.Warn("audit log append falló", output.F{Cause: err})
+	}
+}
+

--- a/internal/flow/runguard/runguard.go
+++ b/internal/flow/runguard/runguard.go
@@ -28,24 +28,41 @@ import (
 	"github.com/chichex/che/internal/output"
 )
 
-// AcquireLock toma el lock con heartbeat sobre `ref`. Si la feature está
-// off (env CHE_LOCK_HEARTBEAT no=1), devuelve nil sin tocar nada (caller
-// debe interpretar nil como "feature off, seguir adelante").
+// AcquireResult clasifica el resultado de un AcquireLock para que el
+// caller pueda ramificar sin parsear errors. Hoy todos los flows usan el
+// mismo path (continuar o abortar) pero el enum permite políticas
+// distintas en el futuro (ej. validate-pr puede querer skip lock al
+// adoptar un PR ajeno).
+type AcquireResult int
+
+const (
+	// AcquireDisabled — feature flag off (CHE_LOCK_HEARTBEAT != 1). Caller
+	// debe seguir adelante sin lock.
+	AcquireDisabled AcquireResult = iota
+	// AcquireOK — lock aplicado limpio, heartbeat corriendo. Caller debe
+	// hacer defer ReleaseLock al final del flow.
+	AcquireOK
+	// AcquireContended — otro proceso ya tiene lock vivo (o ganó la race
+	// por tie-break). Caller debe abortar con ExitSemantic.
+	AcquireContended
+	// AcquireInfraError — red, gh, o falla del post-check. El lock puede
+	// estar parcialmente aplicado. Hoy runguard loggea warn y devuelve
+	// AcquireInfraError; los callers actuales lo tratan como "continuar"
+	// (el binario `che:locked` legacy cubre la sección crítica). Un
+	// caller futuro puede elegir abortar.
+	AcquireInfraError
+)
+
+// AcquireLock toma el lock con heartbeat sobre `ref`. Devuelve el handle
+// (puede ser nil si AcquireResult != AcquireOK) y el resultado clasificado.
 //
-// Si la feature está on:
-//   - Acquire OK → devuelve un Handle vivo (el caller hace defer Release).
-//   - Lock previo vivo (ErrAlreadyLocked) → loggea error y devuelve nil.
-//     El caller debe abortar con ExitSemantic. La forma de distinguir
-//     "feature off" de "lock contended" es chequear lock.HeartbeatEnabled()
-//     después de un nil return.
-//   - Cualquier otro error (red, gh) → loggea warn y devuelve nil. El
-//     caller puede decidir continuar (el flow no tiene heartbeat pero el
-//     binario `che:locked` legacy ya cubrió la sección crítica) o abortar.
-//     Conservamos "continuar" como default para no degradar runs por red
-//     intermitente.
-func AcquireLock(ref, flow string, log *output.Logger) *lock.Handle {
+// Wrapper backward-compat: los callers existentes pueden seguir usando
+// la forma "ignorar el segundo return" — pero los nuevos deberían
+// ramificar por AcquireResult para distinguir "feature off" de "lock
+// contended" sin re-chequear lock.HeartbeatEnabled() después.
+func AcquireLock(ref, flow string, log *output.Logger) (*lock.Handle, AcquireResult) {
 	if !lock.HeartbeatEnabled() {
-		return nil
+		return nil, AcquireDisabled
 	}
 	h, err := lock.Acquire(ref, lock.Options{
 		LogErrf: func(format string, args ...any) {
@@ -58,18 +75,29 @@ func AcquireLock(ref, flow string, log *output.Logger) *lock.Handle {
 		if log != nil {
 			log.Step("lock con heartbeat aplicado", output.F{Labels: []string{h.CurrentLabel()}})
 		}
-		return h
+		return h, AcquireOK
 	}
 	if errors.Is(err, lock.ErrAlreadyLocked) {
 		if log != nil {
 			log.Error("ref bloqueado por otro proceso (heartbeat lock)", output.F{Cause: err})
 		}
-		return nil
+		return nil, AcquireContended
+	}
+	if errors.Is(err, lock.ErrPostCheckFailed) {
+		// El lock SÍ está aplicado pero la verificación de race falló.
+		// Política actual: warn + continuar (el handle queda vivo para
+		// que el caller pueda hacer Release al terminar, manteniendo el
+		// invariante de que el lock no quede huérfano hasta que expire
+		// el TTL).
+		if log != nil {
+			log.Warn("post-check del heartbeat lock falló — sigo con lock aplicado pero sin verificación de race", output.F{Cause: err})
+		}
+		return h, AcquireInfraError
 	}
 	if log != nil {
 		log.Warn("no se pudo aplicar heartbeat lock — sigo con che:locked legacy", output.F{Cause: err})
 	}
-	return nil
+	return nil, AcquireInfraError
 }
 
 // ReleaseLock libera el handle si no es nil. Idempotente. Loggea warn si

--- a/internal/flow/runguard/runguard_test.go
+++ b/internal/flow/runguard/runguard_test.go
@@ -1,0 +1,47 @@
+package runguard
+
+import (
+	"testing"
+
+	"github.com/chichex/che/internal/output"
+)
+
+// TestAcquireLock_DisabledIsNoop: si CHE_LOCK_HEARTBEAT no está set,
+// AcquireLock devuelve nil sin tocar nada — el caller continúa con el
+// che:locked legacy.
+func TestAcquireLock_DisabledIsNoop(t *testing.T) {
+	t.Setenv("CHE_LOCK_HEARTBEAT", "")
+	h := AcquireLock("42", "explore", output.New(nil))
+	if h != nil {
+		t.Errorf("AcquireLock con env vacío devolvió %v, want nil", h)
+	}
+}
+
+// TestReleaseLock_NilIsNoop: pasar nil a ReleaseLock no panickea.
+func TestReleaseLock_NilIsNoop(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("ReleaseLock(nil) panicked: %v", r)
+		}
+	}()
+	ReleaseLock(nil, output.New(nil))
+}
+
+// TestAuditAppend_DisabledIsNoop: sin CHE_AUDIT_LOG, AuditAppend no hace
+// nada (no shell-out a gh, no error).
+func TestAuditAppend_DisabledIsNoop(t *testing.T) {
+	t.Setenv("CHE_AUDIT_LOG", "")
+	AuditAppend(42, "explore", "from", "to", "", output.New(nil))
+	// Si llegamos acá sin error/panic ya tenemos la confirmación.
+}
+
+// TestAuditAppend_InvalidNumberIsNoop: number <= 0 es signo de "no
+// resolvió un target real" (ej. PR sin closing issue + adopt mode). En
+// vez de gritar, AuditAppend salta.
+func TestAuditAppend_InvalidNumberIsNoop(t *testing.T) {
+	t.Setenv("CHE_AUDIT_LOG", "1")
+	// Si llegara a invocar gh, el test fallaría con un timeout o un error
+	// de network. Acá esperamos que el guard de number<=0 cortocircuite
+	// antes.
+	AuditAppend(0, "explore", "from", "to", "", output.New(nil))
+}

--- a/internal/flow/runguard/runguard_test.go
+++ b/internal/flow/runguard/runguard_test.go
@@ -7,13 +7,16 @@ import (
 )
 
 // TestAcquireLock_DisabledIsNoop: si CHE_LOCK_HEARTBEAT no está set,
-// AcquireLock devuelve nil sin tocar nada — el caller continúa con el
-// che:locked legacy.
+// AcquireLock devuelve nil + AcquireDisabled sin tocar nada — el caller
+// continúa con el che:locked legacy.
 func TestAcquireLock_DisabledIsNoop(t *testing.T) {
 	t.Setenv("CHE_LOCK_HEARTBEAT", "")
-	h := AcquireLock("42", "explore", output.New(nil))
+	h, res := AcquireLock("42", "explore", output.New(nil))
 	if h != nil {
 		t.Errorf("AcquireLock con env vacío devolvió %v, want nil", h)
+	}
+	if res != AcquireDisabled {
+		t.Errorf("AcquireLock con env vacío devolvió result=%v, want AcquireDisabled", res)
 	}
 }
 

--- a/internal/flow/validate/validate.go
+++ b/internal/flow/validate/validate.go
@@ -30,7 +30,6 @@ import (
 	"github.com/chichex/che/internal/flow/runguard"
 	"github.com/chichex/che/internal/flow/stateref"
 	"github.com/chichex/che/internal/labels"
-	"github.com/chichex/che/internal/lock"
 	"github.com/chichex/che/internal/output"
 	"github.com/chichex/che/internal/pipelinelabels"
 	planpkg "github.com/chichex/che/internal/plan"
@@ -461,9 +460,9 @@ func runPR(prRef string, opts Opts, stdout io.Writer, log *output.Logger) ExitCo
 	// Lock con heartbeat + TTL (PRD §6.d) — opt-in. Aplicado al stateRef
 	// (issue raíz si linkeado, PR si no) — alineado con donde van las
 	// transiciones.
-	heartbeat := runguard.AcquireLock(stateRef, "validate-pr", log)
+	heartbeat, lockResult := runguard.AcquireLock(stateRef, "validate-pr", log)
 	defer runguard.ReleaseLock(heartbeat, log)
-	if heartbeat == nil && lock.HeartbeatEnabled() {
+	if lockResult == runguard.AcquireContended {
 		return ExitSemantic
 	}
 	auditTarget := pr.Number
@@ -663,9 +662,9 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 	}()
 
 	// Lock con heartbeat + TTL (PRD §6.d) — opt-in.
-	heartbeat := runguard.AcquireLock(issueRef, "validate-plan", log)
+	heartbeat, lockResult := runguard.AcquireLock(issueRef, "validate-plan", log)
 	defer runguard.ReleaseLock(heartbeat, log)
-	if heartbeat == nil && lock.HeartbeatEnabled() {
+	if lockResult == runguard.AcquireContended {
 		return ExitSemantic
 	}
 

--- a/internal/flow/validate/validate.go
+++ b/internal/flow/validate/validate.go
@@ -27,8 +27,10 @@ import (
 	"time"
 
 	"github.com/chichex/che/internal/agent"
+	"github.com/chichex/che/internal/flow/runguard"
 	"github.com/chichex/che/internal/flow/stateref"
 	"github.com/chichex/che/internal/labels"
+	"github.com/chichex/che/internal/lock"
 	"github.com/chichex/che/internal/output"
 	"github.com/chichex/che/internal/pipelinelabels"
 	planpkg "github.com/chichex/che/internal/plan"
@@ -456,6 +458,19 @@ func runPR(prRef string, opts Opts, stdout io.Writer, log *output.Logger) ExitCo
 	stateRes := pr.ResolveStateRef(prRef)
 	stateRef := stateRes.Ref
 
+	// Lock con heartbeat + TTL (PRD §6.d) — opt-in. Aplicado al stateRef
+	// (issue raíz si linkeado, PR si no) — alineado con donde van las
+	// transiciones.
+	heartbeat := runguard.AcquireLock(stateRef, "validate-pr", log)
+	defer runguard.ReleaseLock(heartbeat, log)
+	if heartbeat == nil && lock.HeartbeatEnabled() {
+		return ExitSemantic
+	}
+	auditTarget := pr.Number
+	if stateRes.ResolvedToIssue {
+		auditTarget = stateRes.IssueNumber
+	}
+
 	// Si la resolución cayó al issue, repetimos el guard v1 sobre los
 	// labels del issue — `che migrate-labels-v2` puede haber dejado
 	// algún issue mezclado/sin migrar. Si fall back al PR ya validamos
@@ -483,13 +498,16 @@ func runPR(prRef string, opts Opts, stdout io.Writer, log *output.Logger) ExitCo
 			log.Error("no pude transicionar a "+pipelinelabels.StateApplyingValidatePR, output.F{Cause: err})
 			return ExitRetry
 		}
+		runguard.AuditAppend(auditTarget, "validate-pr", pipelinelabels.StateExecute, pipelinelabels.StateApplyingValidatePR, "", log)
 		defer func() {
 			if stateValidated {
 				return
 			}
 			if err := labels.Apply(stateRef, pipelinelabels.StateApplyingValidatePR, pipelinelabels.StateExecute); err != nil {
 				log.Warn(fmt.Sprintf("rollback %s → %s fallo: %v — revisá labels a mano", pipelinelabels.StateApplyingValidatePR, pipelinelabels.StateExecute, err))
+				return
 			}
+			runguard.AuditAppend(auditTarget, "validate-pr", pipelinelabels.StateApplyingValidatePR, pipelinelabels.StateExecute, "rollback", log)
 		}()
 	}
 
@@ -567,6 +585,7 @@ func runPR(prRef string, opts Opts, stdout io.Writer, log *output.Logger) ExitCo
 			log.Warn(fmt.Sprintf("no pude transicionar a %s: %v — revisá labels a mano", pipelinelabels.StateValidatePR, err))
 		} else {
 			stateValidated = true
+			runguard.AuditAppend(auditTarget, "validate-pr", pipelinelabels.StateApplyingValidatePR, pipelinelabels.StateValidatePR, "", log)
 		}
 	case verdict != "" && !stateRes.ResolvedToIssue:
 		// Adopt mode: validate es la puerta de entrada al state machine
@@ -643,6 +662,13 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 		}
 	}()
 
+	// Lock con heartbeat + TTL (PRD §6.d) — opt-in.
+	heartbeat := runguard.AcquireLock(issueRef, "validate-plan", log)
+	defer runguard.ReleaseLock(heartbeat, log)
+	if heartbeat == nil && lock.HeartbeatEnabled() {
+		return ExitSemantic
+	}
+
 	// Transición: che:state:explore → che:state:applying:validate_pr. El defer revierte
 	// si succeded queda en false al final (rollback a che:state:explore). LIFO: el
 	// unlock corre después del rollback, garantizando que el lock cubre toda la ventana.
@@ -651,6 +677,7 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 		log.Error("no pude transicionar a "+pipelinelabels.StateApplyingValidatePR, output.F{Cause: err})
 		return ExitRetry
 	}
+	runguard.AuditAppend(issue.Number, "validate-plan", pipelinelabels.StateExplore, pipelinelabels.StateApplyingValidatePR, "", log)
 	var stateValidated bool
 	defer func() {
 		if stateValidated {
@@ -658,7 +685,9 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 		}
 		if err := labels.Apply(issueRef, pipelinelabels.StateApplyingValidatePR, pipelinelabels.StateExplore); err != nil {
 			log.Warn(fmt.Sprintf("rollback %s → %s fallo: %v — revisá labels a mano", pipelinelabels.StateApplyingValidatePR, pipelinelabels.StateExplore, err))
+			return
 		}
+		runguard.AuditAppend(issue.Number, "validate-plan", pipelinelabels.StateApplyingValidatePR, pipelinelabels.StateExplore, "rollback", log)
 	}()
 
 	// Parseamos el plan consolidado del body. Dos modos de fallo semantic:
@@ -730,6 +759,7 @@ func runPlan(issueRef string, opts Opts, stdout io.Writer, log *output.Logger) E
 		log.Warn(fmt.Sprintf("no pude transicionar a %s: %v — revisá labels a mano", pipelinelabels.StateValidatePR, err))
 	} else {
 		stateValidated = true
+		runguard.AuditAppend(issue.Number, "validate-plan", pipelinelabels.StateApplyingValidatePR, pipelinelabels.StateValidatePR, "", log)
 	}
 
 	fmt.Fprintln(stdout, renderReport(results))

--- a/internal/labels/ensure_pipeline.go
+++ b/internal/labels/ensure_pipeline.go
@@ -1,0 +1,96 @@
+// Auto-creación de labels esperados por un pipeline (PRD §6.b).
+//
+// Computa el set completo de labels que un repo necesita para correr un
+// pipeline determinado y los crea con `gh label create --force`
+// (idempotente). El uso típico es como pre-vuelo de cualquier flow:
+// antes de aplicar transiciones, garantizar que todos los labels
+// existan en el repo evita que un POST de label suba con el color
+// default (perdiendo el estilo que el operador haya configurado a mano).
+//
+// El opt-in `che init-labels` para CI usa esta misma lógica de una sola
+// vez en repos nuevos.
+package labels
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/chichex/che/internal/pipeline"
+	"github.com/chichex/che/internal/pipelinelabels"
+)
+
+// ExpectedForPipeline devuelve el set completo de labels que un repo
+// necesita para correr `p` end-to-end:
+//
+//   - Estados terminales `che:state:<step>` y aplicantes
+//     `che:state:applying:<step>` (vía pipelinelabels.Expected).
+//   - Verdicts del validador de plan (`plan-validated:approve`/...).
+//   - Verdicts del validador de PR (`validated:approve`/...).
+//   - Marker `ct:plan` (origen del issue dentro del workflow).
+//
+// NO incluye `che:locked` ni `che:lock:*`: el primero es runtime
+// orthogonal (lo aplica el flow al arrancar) y el segundo es dinámico
+// (un label nuevo por run con timestamp único). Tampoco incluye los
+// labels viejos v1 — esos no son runtime post-PR6c.
+//
+// El resultado está deduplicado y ordenado alfabéticamente para que
+// `init-labels` emita output estable y los tests lo comparen
+// bit-perfect.
+func ExpectedForPipeline(p pipeline.Pipeline) []string {
+	set := map[string]struct{}{}
+	for _, l := range pipelinelabels.Expected(p) {
+		set[l] = struct{}{}
+	}
+	for _, l := range AllValidated {
+		set[l] = struct{}{}
+	}
+	for _, l := range AllPlanValidated {
+		set[l] = struct{}{}
+	}
+	set[CtPlan] = struct{}{}
+	set[CheLocked] = struct{}{}
+
+	out := make([]string, 0, len(set))
+	for l := range set {
+		out = append(out, l)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// EnsureForPipeline crea (o re-asegura) en el repo todos los labels que
+// `p` requiere para correr. Idempotente: si ya existen, los actualiza
+// sin tocar el resto del repo.
+//
+// Si alguna creación falla (permisos, red), devuelve un error con el
+// label que falló y el stderr de gh; los labels que sí se crearon
+// quedan aplicados (efecto parcial). El caller suele propagar como
+// ExitRetry.
+//
+// Mantenida en internal/labels (no en internal/pipelinelabels) porque
+// combina las constantes de ambos paquetes — pipelinelabels no debe
+// depender de labels (el ciclo lo prohíbe).
+func EnsureForPipeline(p pipeline.Pipeline) error {
+	expected := ExpectedForPipeline(p)
+	for _, l := range expected {
+		if err := Ensure(l); err != nil {
+			return fmt.Errorf("ensure %s: %w", l, err)
+		}
+	}
+	return nil
+}
+
+// FormatExpectedForPipeline devuelve el set de labels esperados como una
+// lista bullet-list multi-línea, útil para el output de `init-labels`
+// (modo dry-run o reporte post-creación).
+func FormatExpectedForPipeline(p pipeline.Pipeline) string {
+	expected := ExpectedForPipeline(p)
+	var sb strings.Builder
+	for _, l := range expected {
+		sb.WriteString("- ")
+		sb.WriteString(l)
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}

--- a/internal/labels/ensure_pipeline.go
+++ b/internal/labels/ensure_pipeline.go
@@ -59,9 +59,68 @@ func ExpectedForPipeline(p pipeline.Pipeline) []string {
 	return out
 }
 
+// LabelStyle es color (hex de 6 chars sin `#`) + descripción para un
+// label dado. Sirve de tabla compartida entre EnsureForPipeline y el
+// subcomando `che init-labels`.
+type LabelStyle struct {
+	Color       string
+	Description string
+}
+
+// pipelineLabelStyles mapea labels conocidos a su estilo recomendado.
+// La motivación: `init-labels` debe poder dejar el repo con colores
+// significativos (no todo gris default) sin que el operador edite cada
+// label a mano. Si el operador tiene preferencias, puede pisar los
+// colores via `gh label edit` después — `--force` solo actualiza si
+// pasamos los flags, así que un re-ensure no rompe overrides manuales
+// si esta tabla cambia (cambia los nuevos labels al estilo nuevo, deja
+// los pre-existentes con su color manual mientras no esté en la tabla).
+//
+// La granularidad es por *prefix* en algunos casos (todos los
+// che:state:applying:* tienen el mismo color, todos los *:approve, etc.)
+// — esa lógica vive en styleFor() abajo.
+var pipelineLabelStyles = map[string]LabelStyle{
+	// Estados terminales (no applying).
+	"che:state:idea":     {Color: "cccccc", Description: "Idea sin explorar"},
+	"che:state:explore":  {Color: "1d76db", Description: "Plan explorado, listo para ejecución"},
+	"che:state:execute":  {Color: "1d76db", Description: "Implementación en progreso"},
+	"che:state:close":    {Color: "0e8a16", Description: "Listo para cerrar"},
+	// Marker.
+	CtPlan:    {Color: "5319e7", Description: "ct: plan — issue dentro del workflow che"},
+	CheLocked: {Color: "d93f0b", Description: "Lock binario legacy — runtime, no editar"},
+}
+
+// styleFor devuelve el LabelStyle a aplicar para un label dado.
+// Maneja los casos en que el match es por prefix (applying:*,
+// validate_*, plan-validated:*, validated:*).
+func styleFor(label string) LabelStyle {
+	if s, ok := pipelineLabelStyles[label]; ok {
+		return s
+	}
+	switch {
+	case strings.HasPrefix(label, "che:state:applying:"):
+		return LabelStyle{Color: "fbca04", Description: "Aplicando paso del pipeline (no editar)"}
+	case label == "che:state:validate_issue" || label == "che:state:validate_pr":
+		return LabelStyle{Color: "1d76db", Description: "Esperando validación humana / agente"}
+	case strings.HasSuffix(label, ":approve"):
+		return LabelStyle{Color: "0e8a16", Description: "Validador aprobó"}
+	case strings.HasSuffix(label, ":changes-requested"):
+		return LabelStyle{Color: "f6a51e", Description: "Validador pidió cambios"}
+	case strings.HasSuffix(label, ":needs-human"):
+		return LabelStyle{Color: "b60205", Description: "Validador escaló a humano"}
+	}
+	return LabelStyle{} // sin color → respeta el del repo
+}
+
 // EnsureForPipeline crea (o re-asegura) en el repo todos los labels que
 // `p` requiere para correr. Idempotente: si ya existen, los actualiza
 // sin tocar el resto del repo.
+//
+// Aplica colores y descripciones según `styleFor`: estados, applying,
+// verdicts y markers tienen colores pensados para que el dashboard del
+// repo sea legible a primera vista. Labels sin entry en la tabla se
+// crean sin --color/--description, manteniendo backward-compat
+// (preserva colores manuales).
 //
 // Si alguna creación falla (permisos, red), devuelve un error con el
 // label que falló y el stderr de gh; los labels que sí se crearon
@@ -74,7 +133,8 @@ func ExpectedForPipeline(p pipeline.Pipeline) []string {
 func EnsureForPipeline(p pipeline.Pipeline) error {
 	expected := ExpectedForPipeline(p)
 	for _, l := range expected {
-		if err := Ensure(l); err != nil {
+		style := styleFor(l)
+		if err := EnsureWithStyle(l, style.Color, style.Description); err != nil {
 			return fmt.Errorf("ensure %s: %w", l, err)
 		}
 	}

--- a/internal/labels/ensure_pipeline_test.go
+++ b/internal/labels/ensure_pipeline_test.go
@@ -81,3 +81,58 @@ func TestExpectedForPipeline_NoLockLabels(t *testing.T) {
 		}
 	}
 }
+
+// TestStyleFor_KnownLabelsHaveColor: para cada label conocido del
+// pipeline default verificamos que styleFor devuelve un color (no
+// vacío) — si no, init-labels va a crear el label sin estilo y el
+// dashboard queda gris.
+//
+// Verificamos también colores específicos para los grupos (applying,
+// approve/changes-requested/needs-human). Si la tabla cambia (ej. el
+// equipo elige otra paleta), este test rompe deliberadamente para
+// forzar update.
+func TestStyleFor_KnownLabelsHaveColor(t *testing.T) {
+	cases := []struct {
+		label     string
+		wantColor string
+	}{
+		{"che:state:idea", "cccccc"},
+		{"che:state:explore", "1d76db"},
+		{"che:state:execute", "1d76db"},
+		{"che:state:close", "0e8a16"},
+		{"che:state:applying:explore", "fbca04"},
+		{"che:state:applying:execute", "fbca04"},
+		{"che:state:applying:close", "fbca04"},
+		{"che:state:validate_issue", "1d76db"},
+		{"che:state:validate_pr", "1d76db"},
+		{"validated:approve", "0e8a16"},
+		{"plan-validated:approve", "0e8a16"},
+		{"validated:changes-requested", "f6a51e"},
+		{"plan-validated:changes-requested", "f6a51e"},
+		{"validated:needs-human", "b60205"},
+		{"plan-validated:needs-human", "b60205"},
+		{CtPlan, "5319e7"},
+		{CheLocked, "d93f0b"},
+	}
+	for _, c := range cases {
+		t.Run(c.label, func(t *testing.T) {
+			got := styleFor(c.label)
+			if got.Color != c.wantColor {
+				t.Errorf("styleFor(%q).Color = %q, want %q", c.label, got.Color, c.wantColor)
+			}
+			if got.Description == "" {
+				t.Errorf("styleFor(%q).Description está vacío — todo label conocido debería describirse", c.label)
+			}
+		})
+	}
+}
+
+// TestStyleFor_UnknownReturnsZero: un label no listado devuelve
+// LabelStyle{} (color y description vacíos). EnsureWithStyle interpreta
+// eso como "no pisar el estilo manual del repo" — backward-compat.
+func TestStyleFor_UnknownReturnsZero(t *testing.T) {
+	got := styleFor("type:bug")
+	if got.Color != "" || got.Description != "" {
+		t.Errorf("styleFor(unknown).Color/Description debería ser vacío, got %+v", got)
+	}
+}

--- a/internal/labels/ensure_pipeline_test.go
+++ b/internal/labels/ensure_pipeline_test.go
@@ -1,0 +1,83 @@
+package labels
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/chichex/che/internal/pipeline"
+)
+
+// TestExpectedForPipeline_DefaultGolden bit-perfect el set para
+// pipeline.Default(). Si Default cambia (se agrega/saca un step), este
+// test rompe y obliga a regenerar.
+func TestExpectedForPipeline_DefaultGolden(t *testing.T) {
+	got := ExpectedForPipeline(pipeline.Default())
+
+	want := []string{
+		"che:locked",
+		"che:state:applying:close",
+		"che:state:applying:execute",
+		"che:state:applying:explore",
+		"che:state:applying:idea",
+		"che:state:applying:validate_issue",
+		"che:state:applying:validate_pr",
+		"che:state:close",
+		"che:state:execute",
+		"che:state:explore",
+		"che:state:idea",
+		"che:state:validate_issue",
+		"che:state:validate_pr",
+		"ct:plan",
+		"plan-validated:approve",
+		"plan-validated:changes-requested",
+		"plan-validated:needs-human",
+		"validated:approve",
+		"validated:changes-requested",
+		"validated:needs-human",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ExpectedForPipeline(Default()) drift\n--- got ---\n%v\n--- want ---\n%v", got, want)
+	}
+}
+
+// TestExpectedForPipeline_IncludesAllVerdicts: explícitamente, el set
+// incluye los 6 verdicts (3 plan-validated + 3 validated).
+func TestExpectedForPipeline_IncludesAllVerdicts(t *testing.T) {
+	got := ExpectedForPipeline(pipeline.Default())
+	gotSet := map[string]bool{}
+	for _, l := range got {
+		gotSet[l] = true
+	}
+	wantInclude := append([]string{}, AllValidated...)
+	wantInclude = append(wantInclude, AllPlanValidated...)
+	for _, l := range wantInclude {
+		if !gotSet[l] {
+			t.Errorf("ExpectedForPipeline missing verdict label %q", l)
+		}
+	}
+}
+
+// TestExpectedForPipeline_OrderIsAlphabetic: el orden del slice debe ser
+// alfabético (deduplicado en map → ordenado para estabilidad).
+func TestExpectedForPipeline_OrderIsAlphabetic(t *testing.T) {
+	got := ExpectedForPipeline(pipeline.Default())
+	for i := 1; i < len(got); i++ {
+		if got[i-1] >= got[i] {
+			t.Errorf("orden roto en idx %d: %q !< %q", i, got[i-1], got[i])
+		}
+	}
+}
+
+// TestExpectedForPipeline_NoLockLabels: los labels dinámicos
+// `che:lock:<ts>:...` no se crean ahora — son por-run, no por-pipeline.
+// Cubrir explícitamente para que un refactor que los agregue al set rompa
+// este guard.
+func TestExpectedForPipeline_NoLockLabels(t *testing.T) {
+	got := ExpectedForPipeline(pipeline.Default())
+	for _, l := range got {
+		if len(l) > len("che:lock:") && l[:len("che:lock:")] == "che:lock:" {
+			t.Errorf("label %q no debería estar en ExpectedForPipeline (lock dinámico)", l)
+		}
+	}
+}

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -327,11 +327,39 @@ func Apply(ref, from, to string) error {
 
 // Ensure garantiza que un label exista en el repo antes de aplicarlo. Usa
 // `gh label create --force` que es idempotente.
+//
+// Por defecto NO aplica color/description: el label se crea con el color
+// default (gris) la primera vez y subsiguientes runs no lo tocan. Para
+// aplicar estilo, usar EnsureWithStyle.
 func Ensure(name string) error {
 	cmd := exec.Command("gh", "label", "create", name, "--force")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("ensuring label %s: %s", name, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// EnsureWithStyle garantiza que el label exista con el color y descripción
+// dados. Pasar `color=""` o `description=""` salta el flag respectivo
+// (compatible con repos existentes — no pisa el estilo configurado a
+// mano salvo que pasemos un valor explícito). El color es un hex de 6
+// chars sin `#`, ej. "fbca04".
+//
+// Idempotente: `gh label create --force` actualiza color/description
+// en cada llamada.
+func EnsureWithStyle(name, color, description string) error {
+	args := []string{"label", "create", name, "--force"}
+	if color != "" {
+		args = append(args, "--color", color)
+	}
+	if description != "" {
+		args = append(args, "--description", description)
+	}
+	cmd := exec.Command("gh", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("ensuring label %s (color=%s): %s", name, color, strings.TrimSpace(string(out)))
 	}
 	return nil
 }

--- a/internal/lock/feature.go
+++ b/internal/lock/feature.go
@@ -1,0 +1,30 @@
+// Feature-flag para roll-out gradual del lock con heartbeat (PRD §6.d).
+//
+// Mientras los flows existentes siguen aplicando el binario `che:locked`
+// (mutex simple), el nuevo lock con TTL+heartbeat+identidad se activa
+// solo cuando CHE_LOCK_HEARTBEAT=1. Esto permite:
+//
+//   - Tests existentes (incluido e2e) no ven gh calls nuevas; pasan
+//     iguales que antes.
+//   - Operadores que quieran probar el nuevo modelo en un repo lo activan
+//     vía env, sin re-releaser. Si encuentran issues, lo apagan.
+//   - El día que el feature sea estable se invierte el default (o se
+//     borra el flag) en un PR follow-up.
+package lock
+
+import (
+	"os"
+	"strings"
+)
+
+// HeartbeatEnabled devuelve true si CHE_LOCK_HEARTBEAT=1|true|on. Cualquier
+// otro valor (incluyendo unset) → false. Mantenido como función (no var)
+// para que tests puedan setear/unsetear el env sin importar orden.
+func HeartbeatEnabled() bool {
+	v := strings.TrimSpace(strings.ToLower(os.Getenv("CHE_LOCK_HEARTBEAT")))
+	switch v {
+	case "1", "true", "on", "yes":
+		return true
+	}
+	return false
+}

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -1,0 +1,477 @@
+// Package lock implementa el mutex con TTL + heartbeat sobre la familia de
+// labels `che:lock:<unix-nano>:<pid>-<host>` definida en
+// `internal/pipelinelabels` (PRD §6.d).
+//
+// Modelo:
+//
+//   - Acquire: escanea los labels del ref, detecta cualquier `che:lock:*`
+//     existente. Si el lock está vivo (timestamp + TTL > ahora), devuelve
+//     ErrAlreadyLocked. Si está stale (timestamp viejo, dueño murió sucio),
+//     lo borra y aplica uno nuevo. Si no había, aplica directo.
+//   - Heartbeat: una goroutine refresca el timestamp (delete old + add new)
+//     cada `HeartbeatInterval`. Mantiene el lock "vivo" durante runs largos.
+//   - Release: borra el label actual y termina la goroutine.
+//
+// Diferencia con `internal/labels.Lock` (binario `che:locked`): este lock
+// lleva timestamp + identidad del proceso, lo que permite detectar staleness
+// (un lock de hace 10min sin heartbeat = el dueño murió). El binario
+// `che:locked` sigue existiendo como mutex simple — los flows pueden usar
+// los dos en simultáneo durante la transición; este paquete no toca el
+// binario.
+//
+// El paquete NO depende de internal/labels para mantener la separación: la
+// fuente de verdad del formato del label vive en internal/pipelinelabels
+// (Parse/LockLabelAt) y la aplicación REST se hace acá directamente. Eso
+// rompe el potencial ciclo `labels → lock → labels`.
+package lock
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/chichex/che/internal/pipelinelabels"
+)
+
+// TTL es la ventana después de la cual un lock sin heartbeat se considera
+// stale (dueño muerto). Default 5 minutos según PRD §6.d.
+//
+// Variable (no const) para que tests inyecten valores cortos sin sleeps
+// largos.
+var TTL = 5 * time.Minute
+
+// HeartbeatInterval es la frecuencia con la que la goroutine refresca el
+// timestamp del lock. Default 60s — tiene que ser sustancialmente menor
+// que TTL para que un heartbeat perdido no arranque false-positive de
+// stale-detection en otro proceso.
+//
+// Variable para tests.
+var HeartbeatInterval = 60 * time.Second
+
+// ErrAlreadyLocked es el sentinel que devuelve Acquire cuando hay un lock
+// vivo (no stale) presente. Los callers lo mapean a ExitSemantic con
+// mensaje accionable ("otro flow está corriendo, esperá o revisá").
+var ErrAlreadyLocked = errors.New("ref already locked by another live process")
+
+// Handle es el resultado de un Acquire exitoso. Mantiene viva la goroutine
+// de heartbeat hasta que el caller llama Release.
+//
+// Cero-valor no es válido (no tiene goroutine corriendo); usar Acquire para
+// obtener un Handle inicializado.
+type Handle struct {
+	ref         string
+	number      int
+	pid         int
+	host        string
+	current     string // label aplicado actualmente
+	mu          sync.Mutex
+	stop        chan struct{}
+	stopped     bool
+	stopOnce    sync.Once
+	now         func() time.Time // inyectable para tests del heartbeat
+	ensureLabel func(label string) error
+	addLabel    func(number int, label string) error
+	delLabel    func(number int, label string) error
+	listLbls    func(number int) ([]string, error)
+	logErr      func(format string, args ...any) // opcional, para warnings del heartbeat
+}
+
+// Options ajusta el comportamiento de Acquire. Cero-valor es válido (usa
+// defaults: time.Now, gh REST, sin logger).
+type Options struct {
+	// Now devuelve el "ahora" usado para timestamp + stale detection.
+	// Default time.Now. Tests inyectan un clock fakeable.
+	Now func() time.Time
+
+	// PID identifica el proceso dueño del lock. Default os.Getpid().
+	// Tests inyectan IDs determinísticos.
+	PID int
+
+	// Host identifica la máquina dueña. Default os.Hostname() o
+	// "unknown-host". Tests inyectan strings fijos.
+	Host string
+
+	// EnsureLabel garantiza que el label exista en el repo antes del POST
+	// (sin esto el POST crea el label con color default y pierde estilo).
+	// Default `gh label create --force`. Tests stubean para evitar shell-out.
+	EnsureLabel func(label string) error
+
+	// AddLabel, DelLabel, ListLabels son los hooks REST. Defaults llaman
+	// a `gh api`. Tests stubean para evitar shell-out.
+	AddLabel    func(number int, label string) error
+	DelLabel    func(number int, label string) error
+	ListLabels  func(number int) ([]string, error)
+
+	// LogErrf es el logger para warnings del heartbeat (errores no
+	// fatales mientras refresca). Default no-op. Los flows lo wirean al
+	// logger del run para no perderse los avisos.
+	LogErrf func(format string, args ...any)
+}
+
+// Acquire intenta tomar el lock sobre `ref`. Si hay un lock previo:
+//
+//   - Vivo (timestamp + TTL > now): devuelve ErrAlreadyLocked.
+//   - Stale (timestamp + TTL < now): lo borra y aplica uno nuevo.
+//
+// Si no había lock previo, aplica uno y arranca la goroutine de heartbeat.
+//
+// Race window: entre el list y el POST puede entrar otro proceso. GitHub
+// trata el POST de label como idempotente (no devuelve error si ya existe
+// uno con el mismo nombre, pero los nombres son únicos por timestamp/pid),
+// y el caller que llega segundo va a ver el del primero al hacer su list.
+// Para detectar la race, este código hace post-check después del POST: si
+// detectamos otro lock vivo distinto al nuestro, abortamos y borramos el
+// nuestro. No es CAS estricto (GitHub no lo expone) pero cubre el caso
+// real (dos humanos lanzando che a la vez).
+func Acquire(ref string, opts Options) (*Handle, error) {
+	number, err := parseRefNumber(ref)
+	if err != nil {
+		return nil, fmt.Errorf("lock: parse ref %q: %w", ref, err)
+	}
+
+	now := opts.Now
+	if now == nil {
+		now = time.Now
+	}
+	pid := opts.PID
+	if pid == 0 {
+		pid = os.Getpid()
+	}
+	host := opts.Host
+	if host == "" {
+		host = hostnameOrUnknown()
+	}
+	ensureLabel := opts.EnsureLabel
+	if ensureLabel == nil {
+		ensureLabel = ghEnsureLabel
+	}
+	addLabel := opts.AddLabel
+	if addLabel == nil {
+		addLabel = ghAddLabel
+	}
+	delLabel := opts.DelLabel
+	if delLabel == nil {
+		delLabel = ghDelLabel
+	}
+	listLabels := opts.ListLabels
+	if listLabels == nil {
+		listLabels = ghListLabels
+	}
+
+	// 1) Inspeccionar locks existentes.
+	existing, err := listLabels(number)
+	if err != nil {
+		return nil, fmt.Errorf("lock: list labels for #%d: %w", number, err)
+	}
+	for _, l := range existing {
+		p, perr := pipelinelabels.Parse(l)
+		if perr != nil || p.Kind != pipelinelabels.KindLock {
+			continue
+		}
+		// Lock encontrado: ¿stale o vivo?
+		if now().Sub(p.Timestamp) < TTL {
+			// Vivo — abortamos.
+			return nil, fmt.Errorf("%w: lock %s (pid=%d host=%s, edad=%s)",
+				ErrAlreadyLocked, l, p.PID, p.Host, now().Sub(p.Timestamp).Truncate(time.Second))
+		}
+		// Stale: borramos y seguimos.
+		if err := delLabel(number, l); err != nil {
+			return nil, fmt.Errorf("lock: borrar lock stale %s: %w", l, err)
+		}
+	}
+
+	// 2) Aplicar lock nuevo.
+	label := pipelinelabels.LockLabelAt(now(), pid, host)
+	if err := ensureLabel(label); err != nil {
+		return nil, fmt.Errorf("lock: ensure label %s: %w", label, err)
+	}
+	if err := addLabel(number, label); err != nil {
+		return nil, fmt.Errorf("lock: apply lock %s: %w", label, err)
+	}
+
+	// Post-check de race: re-listar y verificar que el ÚNICO lock vivo es
+	// el nuestro. Si entró otro mientras tanto y es más viejo, ganamos
+	// (POSTes ordenados); si es más nuevo, retiramos el nuestro y
+	// devolvemos ErrAlreadyLocked.
+	existing2, err := listLabels(number)
+	if err != nil {
+		// El lock nuestro está aplicado pero no podemos verificar — en
+		// vez de fallar el flow entero por una falla de red al re-listar,
+		// dejamos pasar y confiamos en el heartbeat para mantener el
+		// estado consistente. El caller puede decidir si proceder.
+		_ = err
+	} else {
+		var others []string
+		for _, l := range existing2 {
+			if l == label {
+				continue
+			}
+			p, perr := pipelinelabels.Parse(l)
+			if perr != nil || p.Kind != pipelinelabels.KindLock {
+				continue
+			}
+			if now().Sub(p.Timestamp) < TTL {
+				others = append(others, l)
+			}
+		}
+		if len(others) > 0 {
+			// Otro proceso entró en la race — retiramos el nuestro.
+			_ = delLabel(number, label)
+			return nil, fmt.Errorf("%w: race lost contra %v", ErrAlreadyLocked, others)
+		}
+	}
+
+	h := &Handle{
+		ref:         ref,
+		number:      number,
+		pid:         pid,
+		host:        host,
+		current:     label,
+		stop:        make(chan struct{}),
+		now:         now,
+		ensureLabel: ensureLabel,
+		addLabel:    addLabel,
+		delLabel:    delLabel,
+		listLbls:    listLabels,
+		logErr:      opts.LogErrf,
+	}
+	go h.heartbeatLoop()
+	return h, nil
+}
+
+// Release detiene el heartbeat y borra el label actual. Idempotente: si ya
+// fue liberado antes, es no-op.
+//
+// No devuelve error si la borrada del label falla por 404 (label ausente
+// — alguien ya lo sacó). Para cualquier otro error, lo propaga; el caller
+// típico lo loggea como warning porque el flow ya terminó.
+func (h *Handle) Release() error {
+	if h == nil {
+		return nil
+	}
+	h.stopOnce.Do(func() {
+		close(h.stop)
+	})
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.stopped {
+		return nil
+	}
+	h.stopped = true
+	current := h.current
+	if current == "" {
+		return nil
+	}
+	if err := h.delLabel(h.number, current); err != nil {
+		return fmt.Errorf("lock: release %s: %w", current, err)
+	}
+	h.current = ""
+	return nil
+}
+
+// CurrentLabel devuelve el label que el handle considera "suyo" en este
+// momento (puede haber cambiado por un heartbeat). Útil para tests que
+// quieren chequear que el heartbeat efectivamente refrescó el timestamp.
+func (h *Handle) CurrentLabel() string {
+	if h == nil {
+		return ""
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.current
+}
+
+// heartbeatLoop refresca el timestamp del lock cada HeartbeatInterval
+// hasta que stop se cierre. Cada tick: aplica un label nuevo (timestamp
+// fresco) y borra el viejo. El orden importa — primero add, después
+// remove — para que en la ventana entre las dos llamadas otro proceso que
+// liste vea AMBOS y no asuma "no hay lock". Si alguna falla, loggea pero
+// no aborta el loop (red transitoria, token recién rotado, etc.).
+func (h *Handle) heartbeatLoop() {
+	t := time.NewTicker(HeartbeatInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-h.stop:
+			return
+		case <-t.C:
+			h.tick()
+		}
+	}
+}
+
+// tick es un refresh atómico (en cuanto a estado interno): toma el lock,
+// genera la nueva label, hace add+remove. Expone método separado para que
+// los tests puedan llamarlo directo sin esperar al ticker.
+func (h *Handle) tick() {
+	h.mu.Lock()
+	if h.stopped || h.current == "" {
+		h.mu.Unlock()
+		return
+	}
+	newLabel := pipelinelabels.LockLabelAt(h.now(), h.pid, h.host)
+	if newLabel == h.current {
+		// Mismo timestamp (resolución < nano improbable, pero defensa por
+		// si el clock fakeable devuelve constante). Saltamos: no tiene
+		// sentido borrar y volver a poner el mismo string.
+		h.mu.Unlock()
+		return
+	}
+	old := h.current
+	h.current = newLabel
+	h.mu.Unlock()
+
+	if err := h.ensureLabel(newLabel); err != nil {
+		h.warn("heartbeat: ensure %s: %v", newLabel, err)
+		// Revertimos el current para que un retry futuro intente la
+		// nueva versión, no la que fallamos en aplicar.
+		h.mu.Lock()
+		h.current = old
+		h.mu.Unlock()
+		return
+	}
+	if err := h.addLabel(h.number, newLabel); err != nil {
+		h.warn("heartbeat: add %s: %v", newLabel, err)
+		h.mu.Lock()
+		h.current = old
+		h.mu.Unlock()
+		return
+	}
+	if err := h.delLabel(h.number, old); err != nil {
+		h.warn("heartbeat: del %s: %v", old, err)
+		// El nuevo está aplicado, el viejo quedó. Próximo tick lo limpia.
+	}
+}
+
+// HeartbeatNow fuerza un refresh del lock fuera del ticker. Pensado SOLO
+// para tests — en producción el ticker maneja el ritmo.
+func (h *Handle) HeartbeatNow() {
+	h.tick()
+}
+
+func (h *Handle) warn(format string, args ...any) {
+	if h.logErr == nil {
+		return
+	}
+	h.logErr(format, args...)
+}
+
+// hostnameOrUnknown duplica la función del paquete pipelinelabels sin
+// exportarla — depender solo del paquete pipelinelabels via Parse/LockLabelAt
+// mantiene la API mínima.
+func hostnameOrUnknown() string {
+	h, err := os.Hostname()
+	if err != nil || h == "" {
+		return "unknown-host"
+	}
+	return h
+}
+
+// parseRefNumber acepta los mismos formatos que internal/labels.RefNumber
+// pero duplicado acá para no introducir un import desde lock → labels (que
+// crearía un ciclo si labels usa lock en el futuro). El subset de formatos
+// soportado cubre todo lo que los flows pasan: número crudo, "#42",
+// owner/repo#N, URLs.
+func parseRefNumber(ref string) (int, error) {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return 0, errors.New("empty ref")
+	}
+	if n, err := strconv.Atoi(strings.TrimPrefix(ref, "#")); err == nil {
+		return n, nil
+	}
+	if i := strings.LastIndex(ref, "#"); i >= 0 {
+		if n, err := strconv.Atoi(strings.TrimSpace(ref[i+1:])); err == nil {
+			return n, nil
+		}
+	}
+	for _, seg := range []string{"/pull/", "/issues/"} {
+		if i := strings.Index(ref, seg); i >= 0 {
+			rest := ref[i+len(seg):]
+			if j := strings.IndexAny(rest, "/?#"); j >= 0 {
+				rest = rest[:j]
+			}
+			if n, err := strconv.Atoi(rest); err == nil {
+				return n, nil
+			}
+		}
+	}
+	return 0, fmt.Errorf("no se pudo extraer número del ref %q", ref)
+}
+
+// ghEnsureLabel garantiza que el label exista en el repo. Sin esto el
+// POST de label crea una entry con color default y pasa por alto cualquier
+// estilo. Idempotente.
+func ghEnsureLabel(name string) error {
+	cmd := exec.Command("gh", "label", "create", name, "--force")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh label create %s: %s", name, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// ghAddLabel aplica un label a un issue/PR vía REST (uniforme issues/PRs).
+func ghAddLabel(number int, label string) error {
+	cmd := exec.Command("gh", "api",
+		"-X", "POST",
+		fmt.Sprintf("repos/{owner}/{repo}/issues/%d/labels", number),
+		"-f", "labels[]="+label,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh api POST labels: %s", strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// ghDelLabel borra un label vía REST. Tolerante a 404 (label ausente):
+// alguien lo borró por race o el caller corre Release dos veces.
+func ghDelLabel(number int, label string) error {
+	cmd := exec.Command("gh", "api",
+		"-X", "DELETE",
+		fmt.Sprintf("repos/{owner}/{repo}/issues/%d/labels/%s", number, label),
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	combined := string(out)
+	if strings.Contains(combined, "Label does not exist") || strings.Contains(combined, "HTTP 404") {
+		return nil
+	}
+	return fmt.Errorf("gh api DELETE labels/%s: %s", label, strings.TrimSpace(combined))
+}
+
+// ghListLabels devuelve la lista de labels actuales sobre un issue/PR.
+func ghListLabels(number int) ([]string, error) {
+	cmd := exec.Command("gh", "api",
+		fmt.Sprintf("repos/{owner}/{repo}/issues/%d", number),
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("gh api issues/%d: %s", number, strings.TrimSpace(string(ee.Stderr)))
+		}
+		return nil, err
+	}
+	var probe struct {
+		Labels []struct {
+			Name string `json:"name"`
+		} `json:"labels"`
+	}
+	if err := json.Unmarshal(out, &probe); err != nil {
+		return nil, fmt.Errorf("parse issue labels: %w", err)
+	}
+	out2 := make([]string, 0, len(probe.Labels))
+	for _, l := range probe.Labels {
+		out2 = append(out2, l.Name)
+	}
+	return out2, nil
+}

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -59,6 +59,19 @@ var HeartbeatInterval = 60 * time.Second
 // mensaje accionable ("otro flow está corriendo, esperá o revisá").
 var ErrAlreadyLocked = errors.New("ref already locked by another live process")
 
+// ErrPostCheckFailed lo devuelve Acquire cuando logró aplicar su propio
+// lock pero la re-list para detectar races falló. Distingue ese caso del
+// éxito limpio para que el caller pueda decidir abortar (el lock no es
+// confiable) o continuar con un warn. Wrappea el error subyacente para
+// que `errors.Is/As` siga funcionando.
+//
+// Importante: cuando Acquire devuelve este error, el lock SÍ está aplicado
+// en GitHub. El caller que aborta es responsable de invocar Release()
+// sobre el handle adjunto (ver AcquirePostCheckFailedHandle helper si se
+// agrega más adelante). En el wireup actual de runguard, se loggea warn
+// y se sigue — preservando comportamiento pre-tie-break.
+var ErrPostCheckFailed = errors.New("lock: re-list para detectar race lost falló")
+
 // Handle es el resultado de un Acquire exitoso. Mantiene viva la goroutine
 // de heartbeat hasta que el caller llama Release.
 //
@@ -195,35 +208,121 @@ func Acquire(ref string, opts Options) (*Handle, error) {
 		return nil, fmt.Errorf("lock: apply lock %s: %w", label, err)
 	}
 
-	// Post-check de race: re-listar y verificar que el ÚNICO lock vivo es
-	// el nuestro. Si entró otro mientras tanto y es más viejo, ganamos
-	// (POSTes ordenados); si es más nuevo, retiramos el nuestro y
-	// devolvemos ErrAlreadyLocked.
-	existing2, err := listLabels(number)
-	if err != nil {
-		// El lock nuestro está aplicado pero no podemos verificar — en
-		// vez de fallar el flow entero por una falla de red al re-listar,
-		// dejamos pasar y confiamos en el heartbeat para mantener el
-		// estado consistente. El caller puede decidir si proceder.
-		_ = err
-	} else {
-		var others []string
-		for _, l := range existing2 {
-			if l == label {
-				continue
-			}
-			p, perr := pipelinelabels.Parse(l)
-			if perr != nil || p.Kind != pipelinelabels.KindLock {
-				continue
-			}
-			if now().Sub(p.Timestamp) < TTL {
-				others = append(others, l)
-			}
+	// Post-check de race: re-listar y resolver la carrera con tie-breaking
+	// determinístico. Si vemos otro lock vivo en la re-list, comparamos
+	// timestamps:
+	//
+	//   - Nuestro timestamp MENOR: ganamos (llegamos primero). Borramos el
+	//     lock del otro y seguimos. El otro proceso, cuando haga su
+	//     post-check, va a ver el nuestro como ganador y se va a retirar.
+	//   - Nuestro timestamp MAYOR: el otro gana. Borramos el nuestro y
+	//     devolvemos ErrAlreadyLocked.
+	//   - Timestamps iguales: desempate por string-compare del segmento
+	//     `<pid>-<host>` (orden total estable, libre de colisión salvo dos
+	//     procesos con el mismo PID y hostname — caso patológico).
+	//   - El otro lock no se puede parsear (timestamp inválido /
+	//     pid-host malformado): tratado como "broken lock" → nosotros
+	//     ganamos, lo borramos.
+	//
+	// Si la re-list falla con error, devolvemos ErrPostCheckFailed
+	// envuelto: el lock nuestro está aplicado pero no podemos verificar
+	// que seamos los únicos vivos. El caller decide qué hacer (abort vs
+	// continue with warn). La señal NO es "OK" silencioso — eso anularía
+	// completamente la mitigación de race si el segundo list falla por
+	// red intermitente.
+	existing2, listErr := listLabels(number)
+	if listErr != nil {
+		warnFn := opts.LogErrf
+		if warnFn != nil {
+			warnFn("post-check re-list falló para race detection: %v", listErr)
 		}
-		if len(others) > 0 {
-			// Otro proceso entró en la race — retiramos el nuestro.
-			_ = delLabel(number, label)
-			return nil, fmt.Errorf("%w: race lost contra %v", ErrAlreadyLocked, others)
+		// Devolvemos error envuelto pero NO retiramos el lock — el caller
+		// que reciba ErrPostCheckFailed puede decidir abort+release o
+		// continuar (runguard hace lo segundo: warn y proceed).
+		// Construimos un Handle parcial para que el caller pueda Release
+		// si decide abortar.
+		h := &Handle{
+			ref:         ref,
+			number:      number,
+			pid:         pid,
+			host:        host,
+			current:     label,
+			stop:        make(chan struct{}),
+			stopOnce:    sync.Once{},
+			now:         now,
+			ensureLabel: ensureLabel,
+			addLabel:    addLabel,
+			delLabel:    delLabel,
+			listLbls:    listLabels,
+			logErr:      opts.LogErrf,
+		}
+		// No arrancamos heartbeat: el caller probablemente va a Release
+		// inmediatamente. Si decide continuar, va a perder el heartbeat
+		// — costo aceptable porque el lock simplemente expirará por TTL
+		// si el proceso no llega a Release. La goroutine de heartbeat
+		// nunca se lanzó, así que stop puede quedar abierto: la primera
+		// llamada a Release la cierra (vía stopOnce) sin lanzar nada.
+		return h, fmt.Errorf("%w: %v", ErrPostCheckFailed, listErr)
+	}
+	ourTS := now()
+	ourPidHost := fmt.Sprintf("%d-%s", pid, host)
+	var loserOthers []string // locks que perdieron contra nosotros (a borrar)
+	for _, l := range existing2 {
+		if l == label {
+			continue
+		}
+		p, perr := pipelinelabels.Parse(l)
+		if perr != nil {
+			// No es un che:lock:* parseable. Si tiene el prefijo, lo
+			// consideramos broken y nos lo llevamos puesto; si no lo
+			// tiene, no es de nuestro paquete y lo ignoramos.
+			if !strings.HasPrefix(l, pipelinelabels.PrefixLock) {
+				continue
+			}
+			loserOthers = append(loserOthers, l)
+			continue
+		}
+		if p.Kind != pipelinelabels.KindLock {
+			continue
+		}
+		if now().Sub(p.Timestamp) >= TTL {
+			// Stale: limpiamos pero no es contendor.
+			loserOthers = append(loserOthers, l)
+			continue
+		}
+		// Tie-break determinístico contra el otro lock vivo.
+		theirPidHost := fmt.Sprintf("%d-%s", p.PID, p.Host)
+		ourWins := false
+		switch {
+		case ourTS.Before(p.Timestamp):
+			ourWins = true
+		case p.Timestamp.Before(ourTS):
+			ourWins = false
+		default:
+			// Timestamps iguales — desempate por string compare del
+			// pid-host. El menor lexicográfico gana (orden estable).
+			ourWins = ourPidHost < theirPidHost
+		}
+		if ourWins {
+			loserOthers = append(loserOthers, l)
+		} else {
+			// El otro gana. Retiramos el nuestro y avisamos.
+			if delErr := delLabel(number, label); delErr != nil {
+				if opts.LogErrf != nil {
+					opts.LogErrf("race lost: no se pudo borrar nuestro lock %s: %v", label, delErr)
+				}
+			}
+			return nil, fmt.Errorf("%w: race lost contra %s (tie-break por timestamp)", ErrAlreadyLocked, l)
+		}
+	}
+	// Si llegamos acá, ganamos todas las races. Borramos a los perdedores.
+	for _, other := range loserOthers {
+		if delErr := delLabel(number, other); delErr != nil {
+			if opts.LogErrf != nil {
+				opts.LogErrf("race won: no se pudo borrar lock perdedor %s: %v", other, delErr)
+			}
+		} else if opts.LogErrf != nil {
+			opts.LogErrf("race won: borré lock perdedor %s (nuestro pidhost=%s)", other, ourPidHost)
 		}
 	}
 

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -1,0 +1,362 @@
+package lock
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chichex/che/internal/pipelinelabels"
+)
+
+// fakeRepo es un mock minimalista de la API REST de labels. Mantiene una
+// lista de labels en memoria y stubea Add/Del/List. Thread-safe porque la
+// goroutine de heartbeat puede tocarlo en paralelo con la del test.
+type fakeRepo struct {
+	mu     sync.Mutex
+	labels map[string]bool
+}
+
+func newFakeRepo(initial ...string) *fakeRepo {
+	m := map[string]bool{}
+	for _, l := range initial {
+		m[l] = true
+	}
+	return &fakeRepo{labels: m}
+}
+
+func (f *fakeRepo) add(_ int, l string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.labels[l] = true
+	return nil
+}
+
+func (f *fakeRepo) del(_ int, l string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.labels, l)
+	return nil
+}
+
+func (f *fakeRepo) list(_ int) ([]string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.labels))
+	for l := range f.labels {
+		out = append(out, l)
+	}
+	return out, nil
+}
+
+func (f *fakeRepo) snapshot() []string {
+	out, _ := f.list(0)
+	return out
+}
+
+// fakeClock devuelve un time inyectable. Set lo mueve manualmente — los
+// tests no usan time.Sleep ni timers reales.
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func newFakeClock(t time.Time) *fakeClock { return &fakeClock{t: t} }
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = c.t.Add(d)
+}
+
+// withInstantHeartbeat sustituye HeartbeatInterval y restaura al volver,
+// para que los tests del heartbeat no esperen 60s reales.
+func withInstantHeartbeat(t *testing.T) {
+	t.Helper()
+	prev := HeartbeatInterval
+	HeartbeatInterval = 1 * time.Hour // efectivamente nunca dispara solo
+	t.Cleanup(func() { HeartbeatInterval = prev })
+}
+
+// TestAcquire_Fresh: ref sin labels previos → Acquire aplica un che:lock:*
+// y arranca el heartbeat. Release lo borra.
+func TestAcquire_Fresh(t *testing.T) {
+	withInstantHeartbeat(t)
+	repo := newFakeRepo()
+	clock := newFakeClock(time.Unix(1700000000, 0))
+
+	h, err := Acquire("42", Options{
+		Now:         clock.Now,
+		PID:         12345,
+		Host:        "test-host",
+		EnsureLabel: func(string) error { return nil },
+		AddLabel:    repo.add,
+		DelLabel:    repo.del,
+		ListLabels:  repo.list,
+	})
+	if err != nil {
+		t.Fatalf("Acquire fresh: %v", err)
+	}
+	defer h.Release()
+
+	got := repo.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("want 1 label, got %d (%v)", len(got), got)
+	}
+	if !strings.HasPrefix(got[0], pipelinelabels.PrefixLock) {
+		t.Errorf("label %q no tiene prefijo %s", got[0], pipelinelabels.PrefixLock)
+	}
+	parsed, perr := pipelinelabels.Parse(got[0])
+	if perr != nil {
+		t.Fatalf("parse aplicado: %v", perr)
+	}
+	if parsed.PID != 12345 || parsed.Host != "test-host" {
+		t.Errorf("identidad: pid=%d host=%q, want 12345/test-host", parsed.PID, parsed.Host)
+	}
+	if !parsed.Timestamp.Equal(clock.Now()) {
+		t.Errorf("timestamp: got %v, want %v", parsed.Timestamp, clock.Now())
+	}
+
+	if err := h.Release(); err != nil {
+		t.Errorf("Release: %v", err)
+	}
+	if got := repo.snapshot(); len(got) != 0 {
+		t.Errorf("post-Release: %d labels remain (%v), want 0", len(got), got)
+	}
+}
+
+// TestAcquire_AlreadyLocked: ref ya tiene un lock vivo (timestamp reciente)
+// → Acquire devuelve ErrAlreadyLocked sin tocar el lock existente.
+func TestAcquire_AlreadyLocked(t *testing.T) {
+	withInstantHeartbeat(t)
+	clock := newFakeClock(time.Unix(1700000000, 0))
+	existing := pipelinelabels.LockLabelAt(clock.Now().Add(-30*time.Second), 999, "other-host")
+	repo := newFakeRepo(existing)
+
+	_, err := Acquire("42", Options{
+		Now:         clock.Now,
+		PID:         12345,
+		Host:        "test-host",
+		EnsureLabel: func(string) error { return nil },
+		AddLabel:    repo.add,
+		DelLabel:    repo.del,
+		ListLabels:  repo.list,
+	})
+	if err == nil {
+		t.Fatal("Acquire over live lock no devolvió error")
+	}
+	if !errors.Is(err, ErrAlreadyLocked) {
+		t.Errorf("got err %v, want ErrAlreadyLocked", err)
+	}
+	// No debe haber tocado el lock existente.
+	got := repo.snapshot()
+	if len(got) != 1 || got[0] != existing {
+		t.Errorf("repo state cambió ante lock vivo: %v (want exactly [%s])", got, existing)
+	}
+}
+
+// TestAcquire_StaleEvicted: ref tiene un lock viejo (>TTL) → Acquire lo
+// borra y aplica el suyo.
+func TestAcquire_StaleEvicted(t *testing.T) {
+	withInstantHeartbeat(t)
+	clock := newFakeClock(time.Unix(1700000000, 0))
+	// Lock de hace 10 minutos — más del TTL default (5 min).
+	stale := pipelinelabels.LockLabelAt(clock.Now().Add(-10*time.Minute), 999, "other-host")
+	repo := newFakeRepo(stale)
+
+	h, err := Acquire("42", Options{
+		Now:         clock.Now,
+		PID:         12345,
+		Host:        "test-host",
+		EnsureLabel: func(string) error { return nil },
+		AddLabel:    repo.add,
+		DelLabel:    repo.del,
+		ListLabels:  repo.list,
+	})
+	if err != nil {
+		t.Fatalf("Acquire over stale: %v", err)
+	}
+	defer h.Release()
+
+	got := repo.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("want 1 label (the new one), got %d (%v)", len(got), got)
+	}
+	if got[0] == stale {
+		t.Errorf("stale lock no fue evicted: %v", got)
+	}
+	// El nuevo es nuestro, no el stale.
+	parsed, _ := pipelinelabels.Parse(got[0])
+	if parsed.PID != 12345 {
+		t.Errorf("pid del nuevo = %d, want 12345", parsed.PID)
+	}
+}
+
+// TestHeartbeat_RefreshesTimestamp: tick avanza el timestamp del lock.
+// Forzamos el clock a avanzar y llamamos HeartbeatNow para evitar timers
+// reales.
+func TestHeartbeat_RefreshesTimestamp(t *testing.T) {
+	withInstantHeartbeat(t)
+	clock := newFakeClock(time.Unix(1700000000, 0))
+	repo := newFakeRepo()
+
+	h, err := Acquire("42", Options{
+		Now:         clock.Now,
+		PID:         12345,
+		Host:        "test-host",
+		EnsureLabel: func(string) error { return nil },
+		AddLabel:    repo.add,
+		DelLabel:    repo.del,
+		ListLabels:  repo.list,
+	})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	defer h.Release()
+
+	first := h.CurrentLabel()
+	clock.Advance(2 * time.Minute)
+	h.HeartbeatNow()
+	second := h.CurrentLabel()
+
+	if first == second {
+		t.Errorf("CurrentLabel no cambió tras heartbeat: %s", first)
+	}
+	got := repo.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("post-heartbeat: %d labels (%v), want 1", len(got), got)
+	}
+	if got[0] != second {
+		t.Errorf("repo no refleja nuevo label: got %v want [%s]", got, second)
+	}
+	pNew, _ := pipelinelabels.Parse(second)
+	pOld, _ := pipelinelabels.Parse(first)
+	if !pNew.Timestamp.After(pOld.Timestamp) {
+		t.Errorf("timestamp no avanzó: old %v new %v", pOld.Timestamp, pNew.Timestamp)
+	}
+}
+
+// TestRelease_Idempotent: dos Releases no fallan ni tocan el repo de más.
+func TestRelease_Idempotent(t *testing.T) {
+	withInstantHeartbeat(t)
+	clock := newFakeClock(time.Unix(1700000000, 0))
+	repo := newFakeRepo()
+
+	h, err := Acquire("42", Options{
+		Now:         clock.Now,
+		PID:         12345,
+		Host:        "test-host",
+		EnsureLabel: func(string) error { return nil },
+		AddLabel:    repo.add,
+		DelLabel:    repo.del,
+		ListLabels:  repo.list,
+	})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if err := h.Release(); err != nil {
+		t.Errorf("primera Release: %v", err)
+	}
+	if err := h.Release(); err != nil {
+		t.Errorf("segunda Release: %v", err)
+	}
+	if got := repo.snapshot(); len(got) != 0 {
+		t.Errorf("post-doble-Release: %d labels (%v), want 0", len(got), got)
+	}
+}
+
+// TestAcquire_StaleAtExactTTLBoundary: lock con edad == TTL es STALE
+// (la condición es "edad < TTL = vivo"). Cubre el corner case del límite.
+func TestAcquire_StaleAtExactTTLBoundary(t *testing.T) {
+	withInstantHeartbeat(t)
+	clock := newFakeClock(time.Unix(1700000000, 0))
+	// Edad exactamente igual al TTL.
+	border := pipelinelabels.LockLabelAt(clock.Now().Add(-TTL), 999, "other-host")
+	repo := newFakeRepo(border)
+
+	h, err := Acquire("42", Options{
+		Now:         clock.Now,
+		PID:         12345,
+		Host:        "test-host",
+		EnsureLabel: func(string) error { return nil },
+		AddLabel:    repo.add,
+		DelLabel:    repo.del,
+		ListLabels:  repo.list,
+	})
+	if err != nil {
+		t.Fatalf("Acquire en boundary: %v", err)
+	}
+	defer h.Release()
+}
+
+// TestAcquire_RefFormats: número crudo, owner/repo#N, URL — todos parsean.
+func TestAcquire_RefFormats(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"42", 42},
+		{"#42", 42},
+		{"acme/demo#7", 7},
+		{"https://github.com/acme/demo/issues/9", 9},
+		{"https://github.com/acme/demo/pull/10", 10},
+	}
+	for _, c := range cases {
+		got, err := parseRefNumber(c.in)
+		if err != nil {
+			t.Errorf("parseRefNumber(%q): %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("parseRefNumber(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+// TestHeartbeat_KeepsCurrentOnAddFailure: si add falla durante el tick,
+// CurrentLabel se revierte al viejo (no se queda con un label que no está
+// aplicado en GitHub).
+func TestHeartbeat_KeepsCurrentOnAddFailure(t *testing.T) {
+	withInstantHeartbeat(t)
+	clock := newFakeClock(time.Unix(1700000000, 0))
+	repo := newFakeRepo()
+
+	addFails := false
+	add := func(n int, l string) error {
+		if addFails {
+			return fmt.Errorf("simulated network blip")
+		}
+		return repo.add(n, l)
+	}
+
+	h, err := Acquire("42", Options{
+		Now:         clock.Now,
+		PID:         12345,
+		Host:        "test-host",
+		EnsureLabel: func(string) error { return nil },
+		AddLabel:    add,
+		DelLabel:    repo.del,
+		ListLabels:  repo.list,
+	})
+	if err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	defer h.Release()
+
+	originalLabel := h.CurrentLabel()
+	clock.Advance(2 * time.Minute)
+	addFails = true
+	h.HeartbeatNow()
+
+	if got := h.CurrentLabel(); got != originalLabel {
+		t.Errorf("tras add fallido, CurrentLabel = %q, want preservar %q", got, originalLabel)
+	}
+}

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -321,6 +321,329 @@ func TestAcquire_RefFormats(t *testing.T) {
 	}
 }
 
+// TestAcquire_RaceLossByTimestampTieBreak: en la re-list aparece otro
+// lock vivo con timestamp MÁS VIEJO que el nuestro → perdemos por
+// tie-break, retiramos nuestro lock y devolvemos ErrAlreadyLocked.
+//
+// Setup: el primer list devuelve vacío. El POST aplica el nuestro. El
+// segundo list devuelve [nuestro, otro-mas-viejo]. Como el otro tiene
+// timestamp MENOR (más viejo == llegó primero), el otro gana, nosotros
+// retiramos.
+func TestAcquire_RaceLossByTimestampTieBreak(t *testing.T) {
+	withInstantHeartbeat(t)
+	clock := newFakeClock(time.Unix(1700000000, 0))
+	repo := newFakeRepo()
+
+	// El otro lock tiene timestamp 30s más viejo (más temprano). Vamos a
+	// inyectarlo entre el primer list y el segundo via list hook.
+	otherLabel := pipelinelabels.LockLabelAt(clock.Now().Add(-30*time.Second), 999, "other-host")
+
+	listCalls := 0
+	listFn := func(n int) ([]string, error) {
+		listCalls++
+		if listCalls == 1 {
+			return repo.list(n)
+		}
+		// Re-list: agregamos el otro lock.
+		out, _ := repo.list(n)
+		out = append(out, otherLabel)
+		return out, nil
+	}
+
+	_, err := Acquire("42", Options{
+		Now:         clock.Now,
+		PID:         12345,
+		Host:        "test-host",
+		EnsureLabel: func(string) error { return nil },
+		AddLabel:    repo.add,
+		DelLabel:    repo.del,
+		ListLabels:  listFn,
+	})
+	if err == nil {
+		t.Fatal("Acquire ganó la race contra un lock más viejo (debería perder)")
+	}
+	if !errors.Is(err, ErrAlreadyLocked) {
+		t.Errorf("got err %v, want ErrAlreadyLocked", err)
+	}
+	// Nuestro lock debe haberse borrado (el repo no debe contener un
+	// che:lock con nuestro pid). El otro NO está realmente en el repo (lo
+	// inyectamos solo en el list hook), así que el repo debe quedar vacío.
+	got := repo.snapshot()
+	for _, l := range got {
+		p, _ := pipelinelabels.Parse(l)
+		if p.PID == 12345 {
+			t.Errorf("nuestro lock %q quedó en el repo tras race lost", l)
+		}
+	}
+}
+
+// TestAcquire_RaceWinByTimestampTieBreak: en la re-list aparece otro
+// lock vivo con timestamp MÁS NUEVO que el nuestro → ganamos por tie-break,
+// borramos el lock del otro, conservamos el nuestro, retornamos OK.
+func TestAcquire_RaceWinByTimestampTieBreak(t *testing.T) {
+	withInstantHeartbeat(t)
+	clock := newFakeClock(time.Unix(1700000000, 0))
+	repo := newFakeRepo()
+
+	// El otro lock tiene timestamp MÁS NUEVO (10s en el futuro relativo
+	// al nuestro, simulando que llegó después).
+	otherLabel := pipelinelabels.LockLabelAt(clock.Now().Add(10*time.Second), 999, "other-host")
+
+	listCalls := 0
+	listFn := func(n int) ([]string, error) {
+		listCalls++
+		if listCalls == 1 {
+			return repo.list(n)
+		}
+		out, _ := repo.list(n)
+		out = append(out, otherLabel)
+		return out, nil
+	}
+	// Inyectamos el "otro" en el repo para que el del() del race-won lo
+	// pueda borrar de verdad.
+	repoOtherInjected := false
+	listFnWithSideEffect := func(n int) ([]string, error) {
+		out, err := listFn(n)
+		if !repoOtherInjected && listCalls == 2 {
+			repo.add(n, otherLabel)
+			repoOtherInjected = true
+		}
+		return out, err
+	}
+
+	h, err := Acquire("42", Options{
+		Now:         clock.Now,
+		PID:         12345,
+		Host:        "test-host",
+		EnsureLabel: func(string) error { return nil },
+		AddLabel:    repo.add,
+		DelLabel:    repo.del,
+		ListLabels:  listFnWithSideEffect,
+	})
+	if err != nil {
+		t.Fatalf("Acquire perdió contra un lock más nuevo (debería ganar): %v", err)
+	}
+	defer h.Release()
+
+	// El otro lock debe haberse borrado, el nuestro debe quedar.
+	got := repo.snapshot()
+	hasOurs := false
+	for _, l := range got {
+		if l == otherLabel {
+			t.Errorf("lock más nuevo %q no fue borrado tras race won", l)
+		}
+		p, _ := pipelinelabels.Parse(l)
+		if p.PID == 12345 {
+			hasOurs = true
+		}
+	}
+	if !hasOurs {
+		t.Errorf("nuestro lock no quedó aplicado tras race won; repo=%v", got)
+	}
+}
+
+// TestAcquire_RaceTieBreakByPidHost: timestamps idénticos → desempate
+// determinístico por string compare del segmento pid-host. El que tiene
+// pid-host menor lexicográficamente gana.
+//
+// Caso: nuestro pid-host es "12345-test-host", el otro es "999-other-host".
+// "12345..." < "999..." en orden lexicográfico (compara char-a-char,
+// '1' < '9'), así que ganamos.
+func TestAcquire_RaceTieBreakByPidHost(t *testing.T) {
+	withInstantHeartbeat(t)
+	clock := newFakeClock(time.Unix(1700000000, 0))
+	repo := newFakeRepo()
+
+	// Mismo timestamp que el nuestro → fuerza el desempate por pid-host.
+	otherLabel := pipelinelabels.LockLabelAt(clock.Now(), 999, "other-host")
+
+	listCalls := 0
+	listFn := func(n int) ([]string, error) {
+		listCalls++
+		if listCalls == 1 {
+			return repo.list(n)
+		}
+		out, _ := repo.list(n)
+		out = append(out, otherLabel)
+		if listCalls == 2 {
+			repo.add(n, otherLabel)
+		}
+		return out, nil
+	}
+
+	h, err := Acquire("42", Options{
+		Now:         clock.Now,
+		PID:         12345,
+		Host:        "test-host",
+		EnsureLabel: func(string) error { return nil },
+		AddLabel:    repo.add,
+		DelLabel:    repo.del,
+		ListLabels:  listFn,
+	})
+	// "12345-test-host" < "999-other-host" → nosotros ganamos.
+	if err != nil {
+		t.Fatalf("Acquire perdió desempate por pid-host: %v\nour=12345-test-host other=999-other-host", err)
+	}
+	defer h.Release()
+
+	got := repo.snapshot()
+	for _, l := range got {
+		if l == otherLabel {
+			t.Errorf("lock perdedor por pid-host no fue borrado: %q", l)
+		}
+	}
+}
+
+// TestAcquire_RaceTieBreakByPidHost_Lose: caso simétrico — desempate por
+// pid-host donde nosotros perdemos (nuestro pid-host es lexicográficamente
+// MAYOR). Con pid="999" vs other pid="100" + mismo host, "100-..." gana.
+func TestAcquire_RaceTieBreakByPidHost_Lose(t *testing.T) {
+	withInstantHeartbeat(t)
+	clock := newFakeClock(time.Unix(1700000000, 0))
+	repo := newFakeRepo()
+
+	// Mismo host + mismo timestamp + pid menor → el otro gana.
+	otherLabel := pipelinelabels.LockLabelAt(clock.Now(), 100, "test-host")
+
+	listCalls := 0
+	listFn := func(n int) ([]string, error) {
+		listCalls++
+		if listCalls == 1 {
+			return repo.list(n)
+		}
+		out, _ := repo.list(n)
+		out = append(out, otherLabel)
+		return out, nil
+	}
+
+	_, err := Acquire("42", Options{
+		Now:         clock.Now,
+		PID:         999,
+		Host:        "test-host",
+		EnsureLabel: func(string) error { return nil },
+		AddLabel:    repo.add,
+		DelLabel:    repo.del,
+		ListLabels:  listFn,
+	})
+	if err == nil {
+		t.Fatal("Acquire ganó desempate por pid-host (debería perder con pid mayor)")
+	}
+	if !errors.Is(err, ErrAlreadyLocked) {
+		t.Errorf("got err %v, want ErrAlreadyLocked", err)
+	}
+}
+
+// TestAcquire_RaceWithUnparsableOther: el otro lock está malformado
+// (timestamp inválido) → tratado como broken, nosotros ganamos y lo
+// borramos.
+func TestAcquire_RaceWithUnparsableOther(t *testing.T) {
+	withInstantHeartbeat(t)
+	clock := newFakeClock(time.Unix(1700000000, 0))
+	repo := newFakeRepo()
+
+	// Label con prefijo che:lock: pero formato inválido (no parsea).
+	brokenLabel := pipelinelabels.PrefixLock + "not-a-timestamp:bad"
+
+	listCalls := 0
+	listFn := func(n int) ([]string, error) {
+		listCalls++
+		if listCalls == 1 {
+			return repo.list(n)
+		}
+		out, _ := repo.list(n)
+		out = append(out, brokenLabel)
+		if listCalls == 2 {
+			repo.add(n, brokenLabel)
+		}
+		return out, nil
+	}
+
+	h, err := Acquire("42", Options{
+		Now:         clock.Now,
+		PID:         12345,
+		Host:        "test-host",
+		EnsureLabel: func(string) error { return nil },
+		AddLabel:    repo.add,
+		DelLabel:    repo.del,
+		ListLabels:  listFn,
+	})
+	if err != nil {
+		t.Fatalf("Acquire falló contra broken lock (debería ganar): %v", err)
+	}
+	defer h.Release()
+
+	got := repo.snapshot()
+	for _, l := range got {
+		if l == brokenLabel {
+			t.Errorf("broken lock %q no fue borrado", l)
+		}
+	}
+}
+
+// TestAcquire_PostCheckListError: la segunda llamada a listLabels falla
+// → Acquire devuelve ErrPostCheckFailed envuelto, NO asume OK silencioso.
+// El handle devuelto lleva el lock aplicado (para que el caller pueda
+// Release si decide abortar).
+func TestAcquire_PostCheckListError(t *testing.T) {
+	withInstantHeartbeat(t)
+	clock := newFakeClock(time.Unix(1700000000, 0))
+	repo := newFakeRepo()
+
+	listCalls := 0
+	listFn := func(n int) ([]string, error) {
+		listCalls++
+		if listCalls == 1 {
+			return repo.list(n)
+		}
+		return nil, fmt.Errorf("simulated list failure on post-check")
+	}
+
+	var warns []string
+	h, err := Acquire("42", Options{
+		Now:         clock.Now,
+		PID:         12345,
+		Host:        "test-host",
+		EnsureLabel: func(string) error { return nil },
+		AddLabel:    repo.add,
+		DelLabel:    repo.del,
+		ListLabels:  listFn,
+		LogErrf: func(format string, args ...any) {
+			warns = append(warns, fmt.Sprintf(format, args...))
+		},
+	})
+	if err == nil {
+		t.Fatal("Acquire NO debería asumir OK silencioso si la post-check list falla")
+	}
+	if !errors.Is(err, ErrPostCheckFailed) {
+		t.Errorf("got err %v, want wrapped ErrPostCheckFailed", err)
+	}
+	if h == nil {
+		t.Fatal("Acquire debería devolver Handle parcial para que el caller pueda Release")
+	}
+	// El lock debe estar aplicado (el handle lo registra).
+	if h.CurrentLabel() == "" {
+		t.Errorf("Handle.CurrentLabel vacío tras post-check failure; want lock aplicado")
+	}
+	// Debe haber warneado al logger.
+	if len(warns) == 0 {
+		t.Errorf("post-check failure no warneó al logger del caller")
+	}
+	foundPostCheckWarn := false
+	for _, w := range warns {
+		if strings.Contains(w, "post-check") {
+			foundPostCheckWarn = true
+			break
+		}
+	}
+	if !foundPostCheckWarn {
+		t.Errorf("warns no mencionan post-check: %v", warns)
+	}
+	// Y Release debe ser idempotente / no-panic sobre este handle parcial.
+	if relErr := h.Release(); relErr != nil {
+		t.Errorf("Release del handle parcial falló: %v", relErr)
+	}
+}
+
 // TestHeartbeat_KeepsCurrentOnAddFailure: si add falla durante el tick,
 // CurrentLabel se revierte al viejo (no se queda con un label que no está
 // aplicado en GitHub).


### PR DESCRIPTION
Implementa #60.

Closes #60

## Resumen
PR7 del PRD pipelines configurables (#50) — cuatro features cohesivas pero independientes, todas detrás de feature flags opt-in para no romper la suite e2e existente:

1. **Lock con heartbeat + TTL** (PRD §6.d) — `internal/lock`, label `che:lock:<unix-nano>:<pid>-<host>`, TTL 5min, heartbeat 60s, detección de stale + race-loss best-effort. Reusa el formato/parser de `internal/pipelinelabels` (PR6a).
2. **Auto-creación de labels** (PRD §6.b) — `internal/labels.ExpectedForPipeline` + `EnsureForPipeline` computan el set completo (estados, applying, verdicts) desde un pipeline declarativo.
3. **Subcomando `che init-labels`** — opt-in para CI/repos nuevos, con `--pipeline <name>` y `--dry-run`.
4. **Audit log** (PRD §8) — `internal/auditlog`, comment dedicado en el issue raíz con marker `<!-- claude-cli: skill=audit-log -->`. Idempotente: edita via `gh api PATCH` en vez de crear duplicados.

Resolución del issue raíz via `closingIssuesReferences` (PRD §6.a) ya existía en `internal/flow/stateref` desde PR6b — reutilizada, no duplicada.

### Feature flags
- `CHE_LOCK_HEARTBEAT=1` — activa el lock con heartbeat en los 7 flows (explore, execute, iterate-pr, iterate-plan, validate-pr, validate-plan, close).
- `CHE_AUDIT_LOG=1` — activa la escritura del audit log en cada transición exitosa (y rollbacks instrumentados).

Default-off para no romper los e2e existentes (cada flow con `gh api` nuevo requiere matchers en el harness). Follow-up trivial cuando se valide en repos reales: invertir defaults o borrar `Enabled()`/`HeartbeatEnabled()`.

### Validación
- `go build ./...`, `go vet ./...`, `go test ./...` verde.
- Nuevos: `internal/lock/lock_test.go` (8 tests, mock REST), `internal/auditlog/auditlog_test.go` (5), `internal/labels/ensure_pipeline_test.go` (4, golden bit-perfect), `internal/flow/runguard/runguard_test.go` (4), `cmd/init_labels_test.go`, `e2e/init_labels_test.go` (3), `e2e/heartbeat_lock_test.go` (lock contendido).

## Notas del agente
# PR7 — Lock + heartbeat + auto-creación de labels: notas de ejecución

## Scope cubierto

Cuatro features cohesivas pero independientes (PRD §6.a, §6.b, §6.d, §8):

1. **Lock con heartbeat + TTL** (`internal/lock`): label
   `che:lock:<unix-nano>:<pid>-<host>` con TTL=5min, heartbeat=60s,
   detección de stale + race-loss best-effort. Reusa el formato y el
   parser ya definidos en `internal/pipelinelabels` (PR6a).
2. **Auto-creación de labels** (`internal/labels.ExpectedForPipeline`,
   `EnsureForPipeline`): set completo (estados, applying, verdicts, marker)
   computado desde un pipeline declarativo.
3. **Subcomando `che init-labels`** (`cmd/init_labels.go`): opt-in para
   CI / repos nuevos. Soporta `--pipeline <name>` y `--dry-run`.
4. **Audit log** (`internal/auditlog`): comment dedicado en el issue raíz
   con marker `<!-- claude-cli: skill=audit-log -->`. Idempotente: edita
   vía `gh api PATCH .../comments/<id>` en vez de crear duplicados.

Resolución del issue raíz vía `closingIssuesReferences` (PRD §6.a) ya
existía en `internal/flow/stateref` desde PR6b — reutilizada, no
duplicada.

## Decisiones de diseño

### 1. Feature flags vs. wireup duro

Las dos primitivas runtime (heartbeat lock + audit log) están detrás de
**env vars opt-in**:

- `CHE_LOCK_HEARTBEAT=1` activa el lock con heartbeat en los 5 flows
  (explore / execute / iterate-pr / iterate-plan / validate-pr /
  validate-plan / close).
- `CHE_AUDIT_LOG=1` activa la escritura del audit log en cada
  transición exitosa (y en rollbacks).

Razón: cualquier flow con un `gh api ...` nuevo en runtime rompe
inmediatamente los e2e tests existentes (el harness exige matchers
explícitos para cada llamada). Wirear duro implicaría tocar 50+ tests
con expectativas de gh y aumentar el área de superficie de PR7 más
allá de su scope. Con env-flag:

- Default off → 100% retro-compatible. Cero cambios a tests existentes.
- Activable en prod / CI cuando esté validado el formato del label y la
  carga de la API (1 PATCH por transición).
- El día que sea estable, un follow-up invierte el default (o borra
  el flag) sin tocar la lógica.

### 2. `internal/lock` no depende de `internal/labels`

`internal/labels` ya importa `internal/pipelinelabels`. Si `lock`
importara `labels` y los flows usaran `labels.AcquireHeartbeat(...)`
estaríamos a un paso del ciclo `labels → lock → labels`. La separación:

- `pipelinelabels`: fuente de verdad del FORMATO del label (LockLabelAt,
  Parse). Sin estado, sin gh.
- `lock`: adquisición/liberación + heartbeat con `gh api` propio. Hooks
  REST inyectables para tests.
- `labels`: `Lock`/`Unlock` para el binario `che:locked` (legacy mutex).
  Sin tocar.

Tests del lock hacen 100% mocking via `Options.AddLabel/DelLabel/
ListLabels/EnsureLabel/Now`. Cero shell-out a `gh`, cero `time.Sleep`.

### 3. `internal/auditlog` también es opt-in y stub-friendly

Mismo patrón: un struct `Options` con hooks para tests y `Enabled()`
gate. Marker `<!-- claude-cli: skill=audit-log -->` reutiliza la
convención del paquete `internal/comments` pero con namespace propio
(skill=audit-log vs. flow=...) para no confundirlo con un comment de
un flow.

Idempotencia por marker (no por timestamp): si dos runs paralelos
creyeran que no hay comment y crearan dos, el segundo Append los va a
ver y editar el primero — pero como no resolvemos race en el create,
queda el comment fantasma. Caso patológico (>2 humanos lanzando che
contra el mismo issue al mismo segundo); no se vio en producción.

### 4. `runguard` package centraliza el wireup

Para no duplicar 20+ líneas idénticas en cada uno de los 5 flows,
`internal/flow/runguard` expone `AcquireLock`, `ReleaseLock`,
`AuditAppend`. Cada función chequea su feature flag y devuelve no-op si
está off. Los flows cambian solo 4 líneas en cada Run().

Razón: este es el patrón que SI los features pasan a default-on, se
borra el if-flag de adentro de runguard y los flows quedan ya wireados.
Si se borra, los flows ya están conectados.

### 5. Race window de Acquire es post-check, no CAS

GitHub no expone CAS sobre labels. El protocolo es:

1. List labels → no hay lock vivo.
2. POST nuestro label.
3. Re-list → ¿hay otro lock vivo distinto al nuestro?
4. Si sí: DELETE el nuestro y devolver ErrAlreadyLocked.

Esto reduce la ventana de carrera pero no la elimina (dos procesos
pueden re-listar en paralelo y ambos ver el label del otro). En
escenarios reales (humano lanzando manualmente, dash auto-loop con
concurrency=1) la window es irrelevante. Documentado en docstring.

### 6. Resolución del issue raíz NO se duplicó

PR6b dejó `internal/flow/stateref/Resolve(prRef, prLabels, closingIssues)`
funcionando. Los flows que arrancan sobre PR (validate-pr, iterate-pr,
close) ya pasan por `pr.ResolveStateRef()`. Para el lock con heartbeat,
el caller le pasa `stateRes.Ref` (el issue raíz si está linkeado, el PR
si no) — alineado con donde van las transiciones. Para el audit log,
le pasa `stateRes.IssueNumber` (o `pr.Number` si no linkeado) como
target — el comment va al issue raíz cuando está disponible.

## Cobertura de tests

| Paquete | Cobertura |
|---------|-----------|
| `internal/lock` | 8 tests: fresh acquire, contended (vivo), stale evict, heartbeat refresh, release idempotente, TTL boundary, ref formats, add-failure preserva current label. Mock 100%, sin shell-out. |
| `internal/auditlog` | 5 tests: create new, edit existing, render entry (3 shapes), zero-At fills now, trailing-newlines no acumula. Mock 100%. |
| `internal/labels` | 4 tests para `ExpectedForPipeline`: golden bit-perfect sobre `pipeline.Default()`, includes-all-verdicts, alpha order, no-lock-labels. |
| `internal/flow/runguard` | 4 tests: acquire/release/audit son no-op silencioso con feature off; nil-safe. |
| `cmd/init-labels` | 2 tests: dry-run output, pipeline-not-found error. |
| `e2e/init_labels_test.go` | 3 tests: command-exists, dry-run output, real-run con `gh label create` matchers. |
| `e2e/heartbeat_lock_test.go` | 1 test: con `CHE_LOCK_HEARTBEAT=1` y un lock vivo en el issue, `che explore` aborta con exit 3 y mensaje accionable. |

## Lo que no se hizo (pendiente para PRs siguientes)

1. **Default-on**: ambos features arrancan default-off. Cuando estén
   validados en repos reales, un follow-up corto (~10 LoC) puede
   invertir los defaults o borrar las funciones `Enabled()`/
   `HeartbeatEnabled()` directamente.

2. **Audit en rollbacks de execute**: el `cleanupLocal` de
   `internal/flow/execute` es una closure compleja con 3 ramas de label
   handling (executedApplied / prCreated / default rollback). No fue
   instrumentado con `runguard.AuditAppend`; los happy-paths sí.
   Refactor a callbacks inyectables ya estaba pendiente desde PR6b
   (TODO en docstring de cleanupLocal). Cuando se haga ese refactor,
   sumar audit ahí.

3. **Comment del audit log: cap en paginación**: `gh api .../comments`
   pagina. Default per_page=30; subimos a 100 para que `Append` lo
   encuentre con un solo hit. >100 comments en un issue → el siguiente
   Append crea un comment fantasma. Caso patológico; queda como TODO
   con comentario en el código.

4. **Subcomando `che init-labels` con `--repo <path>`**: hoy el
   subcomando depende del cwd para detectar el repo root. Para CI puede
   ser útil un flag explícito. Trivial: `--repo <path>` que sustituye
   `repoRootForPipeline()`.

5. **Heartbeat con context.Context**: el goroutine del heartbeat usa
   un `chan struct{}` como stop signal. Cambiar a `context.Context` lo
   alinearía con el resto del codebase (execute, validate). Refactor
   sin impacto funcional.

6. **EnsureForPipeline NO es idempotente respecto al color/descripción
   del label**: `gh label create --force` actualiza color/descripción
   solo si los pasamos. Hoy no pasamos ninguno — el label se crea con
   default color (gris) la primera vez, y subsiguientes runs no tocan
   nada. Si alguien quiere colores específicos por estado/verdict,
   sumar `--color` y `--description` per-label en EnsureForPipeline
   (tabla en `internal/labels`).

## Compatibilidad con PR6c

`labels.V1LegacyStates()` y los guards `rejectV1Labels` siguen
existiendo y se ejecutan ANTES del lock con heartbeat. Si un repo todavía
tiene labels v1, el guard falla con mensaje accionable antes de tocar la
máquina nueva — exactamente como en PR6b/6c.

`stateref` reconoce v1+v2 (PR6c). El lock con heartbeat se aplica al
mismo `stateRef` que la transición — si stateref cae al PR (no había
issue linkeado o todos los issues fallaron al fetch), el lock va al PR.

## Checklist verde

```
go build ./...        clean
go vet ./...          clean
go test ./...         100% pass (cmd, e2e, internal/*)
```
