### PR TITLE
feat(#68): dash loop follows pipeline steps

### DIFF
--- a/internal/dash/gh_source.go
+++ b/internal/dash/gh_source.go
@@ -718,6 +718,10 @@ func applyLabels(e *Entity, ls []ghLabel) {
 			// Mapeamos via v2StatusByLabel; si el label no está en el
 			// mapa (por ej. step nuevo no registrado), preservamos
 			// best-effort el sufijo TrimPrefix.
+			if parsed, err := pipelinelabels.Parse(name); err == nil {
+				e.StateStep = parsed.Step
+				e.StateApplying = parsed.Kind == pipelinelabels.KindApplying
+			}
 			if s, ok := v2StatusByLabel[name]; ok {
 				e.Status = s
 			} else if strings.HasPrefix(name, pipelinelabels.PrefixApplying) {

--- a/internal/dash/loop.go
+++ b/internal/dash/loop.go
@@ -548,9 +548,19 @@ func nextDispatch(e Entity, rules map[LoopRule]bool, rounds int) (flow string, t
 	return "", 0, "status-not-loopable"
 }
 
+func usesPipeline(e Entity, steps []string) bool {
+	// FALLBACK v1/v2: entities without che:state:<step>, or dashboards with an
+	// empty pipeline snapshot, stay on the legacy matcher. This keeps repos with
+	// historical labels loopable instead of coupling fallback to a reason string.
+	return e.StateStep != "" && len(steps) > 0
+}
+
 func nextPipelineDispatch(e Entity, steps []string, rounds int) (flow string, targetRef int, reason string) {
 	if e.StateStep == "" {
-		return "", 0, "no-dynamic-state"
+		return "", 0, "no-pipeline-state"
+	}
+	if len(steps) == 0 {
+		return "", 0, "no-pipeline-steps"
 	}
 	if e.Locked {
 		return "", 0, "locked"
@@ -590,8 +600,8 @@ func runStepFromFlow(flow string) (step string, pr bool, ok bool) {
 }
 
 // entitySide clasifica la entity en issue-side o PR-side para el slot de
-// concurrencia. Por Kind: KindIssue=issue, KindFused=pr. Simple y
-// determinístico.
+// concurrencia. KindFused y KindPR ocupan el slot PR-side: ambos dispatchan
+// sobre un PR cuando viven en el motor dinámico post-adopt.
 func entitySide(e Entity) string {
 	if e.Kind == KindFused || e.Kind == KindPR {
 		return "pr"
@@ -708,8 +718,12 @@ func (s *Server) runTick() int {
 		// que esto es defensa para cuando se sumen reglas adopt-side.
 		key := e.EntityKey()
 		rounds := s.loop.roundsFor(key)
-		flow, targetRef, reason := nextPipelineDispatch(e, steps, rounds)
-		if flow == "" && reason == "no-dynamic-state" {
+		var flow string
+		var targetRef int
+		var reason string
+		if usesPipeline(e, steps) {
+			flow, targetRef, reason = nextPipelineDispatch(e, steps, rounds)
+		} else {
 			flow, targetRef, reason = nextDispatch(e, rules, rounds)
 		}
 		if flow == "" {
@@ -735,12 +749,7 @@ func (s *Server) runTick() int {
 		// (Gates ya viene poblado por overlayRunning, pero acá usamos el
 		// snapshot crudo del Source — overlayRunning no corre en el tick).
 		// computeGates es pura, sin IO; el costo es despreciable.
-		gate := FlowGate{Available: true}
-		if step, _, ok := runStepFromFlow(flow); ok {
-			gate = gatePipelineStep(e, s.pipeline, step)
-		} else {
-			gate = computeGates(e)[flow]
-		}
+		gate := computeDispatchGates(e, s.pipeline, flow)[flow]
 		if !gate.Available {
 			if !s.loop.markGateNotified(key, flow, gate.Reason) {
 				fmt.Fprintf(os.Stderr, "dash auto-loop: skip %s %s — %s\n", flow, entityRef(e), gate.Reason)

--- a/internal/dash/loop.go
+++ b/internal/dash/loop.go
@@ -609,7 +609,12 @@ func nextPipelineDispatch(e Entity, steps []string, rounds int) (flow string, ta
 		// Dynamic verdict handling lives in the pipeline agents/markers: the dash
 		// only resumes from the current StateStep and lets `che run --auto` decide
 		// advance, goto markers and skips. Legacy verdict rules are fallback only.
-		return encodeDynamicRunFlow(dynamicRunFlow{Step: e.StateStep, PR: e.Kind == KindPR}), e.EntityKey(), "step:" + e.StateStep
+		run := dynamicRunFlow{Step: e.StateStep, PR: e.Kind == KindPR || (e.Kind == KindFused && e.PRNumber > 0)}
+		targetRef := e.EntityKey()
+		if run.PR {
+			targetRef = e.PRNumber
+		}
+		return encodeDynamicRunFlow(run), targetRef, "step:" + e.StateStep
 	}
 	return "", 0, "step-not-in-pipeline"
 }
@@ -704,7 +709,7 @@ func (s *Server) runTick() int {
 	}
 	s.mu.Unlock()
 	for _, e := range ents {
-		running := e.RunningFlow != "" || localRunning[e.IssueNumber] != ""
+		running := e.RunningFlow != "" || localRunning[e.EntityKey()] != ""
 		if !running {
 			continue
 		}

--- a/internal/dash/loop.go
+++ b/internal/dash/loop.go
@@ -29,7 +29,7 @@
 //   - verdict=needs-human    → done (requiere ojo humano), no dispatch.
 //   - Locked=true            → skip este tick (no terminal; el próximo
 //     intenta de vuelta cuando se destrabe).
-//   - rounds[id] >= LoopCap  → cap alcanzado, no dispatch.
+//   - rounds[id] >= cap efectivo → cap alcanzado, no dispatch.
 //
 // Concurrency: a lo sumo 1 flow issue-side + 1 PR-side simultáneos en todo
 // el board. La clasificación es por Kind (KindIssue=issue-side, KindFused
@@ -71,15 +71,25 @@ import (
 	"github.com/chichex/che/internal/pipelinelabels"
 )
 
-// LoopCap es el número máximo de dispatches automáticos + manuales que el
-// loop engine permite para una misma entidad desde que arrancó el server.
+// LoopCap es el número máximo legacy de dispatches automáticos + manuales que
+// el loop engine permite para una misma entidad desde que arrancó el server.
 // El contador se resetea al reiniciar (in-memory). 10 cubre ~5 rondas
-// iterate↔validate — suficiente para un feature que necesita varios pulidos
-// antes de aprobarse, sin entrar en loops infinitos si el validador nunca
-// converge. El handler manual de /action NO consulta este cap (solo gatea
-// el auto-loop engine), así que el humano puede seguir disparando a mano
-// desde el modal después de que el cap se alcance.
+// iterate↔validate en el motor legacy, sin entrar en loops infinitos si el
+// validador nunca converge. El motor dinámico usa DynamicLoopCap para mitigar
+// loops de pipeline más temprano.
 const LoopCap = 10
+
+// DynamicLoopCap es el cap efectivo para dispatches dinámicos `che run --auto`.
+// Mantiene LoopCap=10 para entidades legacy, pero corta pipelines dinámicos a
+// 3 intentos sobre la misma entity antes de requerir intervención humana.
+const DynamicLoopCap = 3
+
+func loopCapForEntity(e Entity) int {
+	if e.StateStep != "" {
+		return DynamicLoopCap
+	}
+	return LoopCap
+}
 
 // LoopRule es el identificador de una de las 4 reglas loopeables. Usado
 // como clave del map del state y en la URL del endpoint POST /loop/rule/...
@@ -430,7 +440,7 @@ type loopFromGroup struct {
 //
 // Reglas de corte (en orden de chequeo):
 //  1. Locked=true → skip (motivo: "locked").
-//  2. Cap hit (rounds >= LoopCap) → stop (motivo: "cap-reached").
+//  2. Cap hit (rounds >= LoopCap legacy) → stop (motivo: "cap-reached").
 //  3. Verdict terminal (approve / needs-human) → stop.
 //  4. Match de reglas ON → dispatch.
 //
@@ -636,7 +646,7 @@ func nextPipelineDispatch(e Entity, steps []string, rules map[LoopRule]bool, rou
 	if e.StateApplying {
 		return "", 0, "applying"
 	}
-	if rounds >= LoopCap {
+	if rounds >= DynamicLoopCap {
 		return "", 0, "cap-reached"
 	}
 	for i, step := range steps {
@@ -791,7 +801,9 @@ func (s *Server) runTick() int {
 		var targetRef int
 		var reason string
 		usedPipeline := usesPipeline(e, steps)
+		cap := LoopCap
 		if usedPipeline {
+			cap = DynamicLoopCap
 			flow, targetRef, reason = nextPipelineDispatch(e, steps, rules, rounds)
 		} else {
 			flow, targetRef, reason = nextDispatch(e, rules, rounds)
@@ -817,7 +829,7 @@ func (s *Server) runTick() int {
 			// Cap hit: log una vez a stderr.
 			if reason == "cap-reached" {
 				if !s.loop.markCapNotified(key) {
-					fmt.Fprintf(os.Stderr, "dash auto-loop: cap %d reached for %s — stop\n", LoopCap, entityRef(e))
+					fmt.Fprintf(os.Stderr, "dash auto-loop: cap %d reached for %s — stop\n", cap, entityRef(e))
 				}
 			}
 			continue

--- a/internal/dash/loop.go
+++ b/internal/dash/loop.go
@@ -6,29 +6,29 @@
 // cerrando el ciclo humano → IA sin intervención manual.
 //
 // Reglas (7), enumeradas en orden didáctico (issue-side primero, después PR-side):
-//   1. Status=idea (o "")                          → che explore  <IssueNumber>
-//      (idea→plan: arranca el ciclo desde un issue con `ct:plan` aplicado.)
-//   2. Status=plan sin PlanVerdict                 → che validate <IssueNumber>
-//   3. Status=validated + PlanVerdict=changes-req  → che iterate  <IssueNumber>
-//      (post-v0.0.49: validate transiciona plan→validated; el verdict
-//       "changes-requested" queda como label plan-validated:* sobre un
-//       issue en che:validated.)
-//   4. Status=validated + PlanVerdict=approve      → che execute  <IssueNumber>
-//      (issue-only; sin PR previo. Cierra el gap post-validate plan:
-//       un plan aprobado automáticamente pasa a ejecución.)
-//   5. Status=plan sin PlanVerdict                 → che execute  <IssueNumber>
-//      (fast-lane "plan→executed" sin pasar por validate. Mutuamente
-//       excluyente con regla 2 a nivel de UI: si ambas están ON, validate
-//       gana — preferimos validar antes de ejecutar cuando hay duda.)
-//   6. Status=executed sin PRVerdict               → che validate <PRNumber>
-//   7. Status=executed + PRVerdict=changes-req     → che iterate  <PRNumber>
-//      (también matchea Status=validated cuando validate-pr ya transicionó.)
+//  1. Status=idea (o "")                          → che explore  <IssueNumber>
+//     (idea→plan: arranca el ciclo desde un issue con `ct:plan` aplicado.)
+//  2. Status=plan sin PlanVerdict                 → che validate <IssueNumber>
+//  3. Status=validated + PlanVerdict=changes-req  → che iterate  <IssueNumber>
+//     (post-v0.0.49: validate transiciona plan→validated; el verdict
+//     "changes-requested" queda como label plan-validated:* sobre un
+//     issue en che:validated.)
+//  4. Status=validated + PlanVerdict=approve      → che execute  <IssueNumber>
+//     (issue-only; sin PR previo. Cierra el gap post-validate plan:
+//     un plan aprobado automáticamente pasa a ejecución.)
+//  5. Status=plan sin PlanVerdict                 → che execute  <IssueNumber>
+//     (fast-lane "plan→executed" sin pasar por validate. Mutuamente
+//     excluyente con regla 2 a nivel de UI: si ambas están ON, validate
+//     gana — preferimos validar antes de ejecutar cuando hay duda.)
+//  6. Status=executed sin PRVerdict               → che validate <PRNumber>
+//  7. Status=executed + PRVerdict=changes-req     → che iterate  <PRNumber>
+//     (también matchea Status=validated cuando validate-pr ya transicionó.)
 //
 // Stop conditions por entity:
 //   - verdict=approve        → done (feliz), no dispatch.
 //   - verdict=needs-human    → done (requiere ojo humano), no dispatch.
 //   - Locked=true            → skip este tick (no terminal; el próximo
-//                              intenta de vuelta cuando se destrabe).
+//     intenta de vuelta cuando se destrabe).
 //   - rounds[id] >= LoopCap  → cap alcanzado, no dispatch.
 //
 // Concurrency: a lo sumo 1 flow issue-side + 1 PR-side simultáneos en todo
@@ -52,9 +52,10 @@
 //     diseño del flow.
 //   - execute:  1x opus  — `che execute` default de `--agent` es opus.
 //     El loop dispatcha execute via dos reglas: RuleExecutePlan (validated
-//     + approve = luz verde explícita del validador) o RuleExecuteRaw
+//   - approve = luz verde explícita del validador) o RuleExecuteRaw
 //     (plan sin verdict = fast-lane, opt-in para usuarios que confían en
 //     el plan sin validarlo).
+//
 // El loop invoca los subcomandos sin flags de agent — heredan estos
 // defaults. Mantener esto sincronizado si los defaults cambien en cmd/.
 package dash
@@ -426,10 +427,10 @@ type loopFromGroup struct {
 // puro y vive en el tick.
 //
 // Reglas de corte (en orden de chequeo):
-//   1. Locked=true → skip (motivo: "locked").
-//   2. Cap hit (rounds >= LoopCap) → stop (motivo: "cap-reached").
-//   3. Verdict terminal (approve / needs-human) → stop.
-//   4. Match de reglas ON → dispatch.
+//  1. Locked=true → skip (motivo: "locked").
+//  2. Cap hit (rounds >= LoopCap) → stop (motivo: "cap-reached").
+//  3. Verdict terminal (approve / needs-human) → stop.
+//  4. Match de reglas ON → dispatch.
 //
 // Devuelve flow="" si nada dispatcha; reason siempre describe por qué.
 func nextDispatch(e Entity, rules map[LoopRule]bool, rounds int) (flow string, targetRef int, reason string) {
@@ -547,11 +548,52 @@ func nextDispatch(e Entity, rules map[LoopRule]bool, rounds int) (flow string, t
 	return "", 0, "status-not-loopable"
 }
 
+func nextPipelineDispatch(e Entity, steps []string, rounds int) (flow string, targetRef int, reason string) {
+	if e.StateStep == "" {
+		return "", 0, "no-dynamic-state"
+	}
+	if e.Locked {
+		return "", 0, "locked"
+	}
+	if e.StateApplying {
+		return "", 0, "applying"
+	}
+	if rounds >= LoopCap {
+		return "", 0, "cap-reached"
+	}
+	for i, step := range steps {
+		if step != e.StateStep {
+			continue
+		}
+		if i+1 >= len(steps) {
+			return "", 0, "pipeline-complete"
+		}
+		next := steps[i+1]
+		prefix := "run#:"
+		if e.Kind == KindPR {
+			prefix = "run!:"
+		}
+		return prefix + next, e.EntityKey(), "step:" + next
+	}
+	return "", 0, "step-not-in-pipeline"
+}
+
+func runStepFromFlow(flow string) (step string, pr bool, ok bool) {
+	switch {
+	case len(flow) > len("run#:") && flow[:len("run#:")] == "run#:":
+		return flow[len("run#:"):], false, true
+	case len(flow) > len("run!:") && flow[:len("run!:")] == "run!:":
+		return flow[len("run!:"):], true, true
+	default:
+		return "", false, false
+	}
+}
+
 // entitySide clasifica la entity en issue-side o PR-side para el slot de
 // concurrencia. Por Kind: KindIssue=issue, KindFused=pr. Simple y
 // determinístico.
 func entitySide(e Entity) string {
-	if e.Kind == KindFused {
+	if e.Kind == KindFused || e.Kind == KindPR {
 		return "pr"
 	}
 	return "issue"
@@ -603,6 +645,10 @@ func (s *Server) runTick() int {
 	}
 	if !anyOn {
 		return 0
+	}
+	steps := make([]string, 0, len(s.pipeline.Steps))
+	for _, step := range s.pipeline.Steps {
+		steps = append(steps, step.Name)
 	}
 
 	snap := s.source.Snapshot()
@@ -662,7 +708,10 @@ func (s *Server) runTick() int {
 		// que esto es defensa para cuando se sumen reglas adopt-side.
 		key := e.EntityKey()
 		rounds := s.loop.roundsFor(key)
-		flow, targetRef, reason := nextDispatch(e, rules, rounds)
+		flow, targetRef, reason := nextPipelineDispatch(e, steps, rounds)
+		if flow == "" && reason == "no-dynamic-state" {
+			flow, targetRef, reason = nextDispatch(e, rules, rounds)
+		}
 		if flow == "" {
 			// Cap hit: log una vez a stderr.
 			if reason == "cap-reached" {
@@ -686,7 +735,12 @@ func (s *Server) runTick() int {
 		// (Gates ya viene poblado por overlayRunning, pero acá usamos el
 		// snapshot crudo del Source — overlayRunning no corre en el tick).
 		// computeGates es pura, sin IO; el costo es despreciable.
-		gate := computeGates(e)[flow]
+		gate := FlowGate{Available: true}
+		if step, _, ok := runStepFromFlow(flow); ok {
+			gate = gatePipelineStep(e, s.pipeline, step)
+		} else {
+			gate = computeGates(e)[flow]
+		}
 		if !gate.Available {
 			if !s.loop.markGateNotified(key, flow, gate.Reason) {
 				fmt.Fprintf(os.Stderr, "dash auto-loop: skip %s %s — %s\n", flow, entityRef(e), gate.Reason)
@@ -950,4 +1004,3 @@ func pillLabel(data loopPopoverData) string {
 func pillLabelHasSpinner(data loopPopoverData) bool {
 	return data.ActiveRules > 0 && data.AutoLoops > 0
 }
-

--- a/internal/dash/loop.go
+++ b/internal/dash/loop.go
@@ -549,10 +549,38 @@ func nextDispatch(e Entity, rules map[LoopRule]bool, rounds int) (flow string, t
 }
 
 func usesPipeline(e Entity, steps []string) bool {
-	// FALLBACK v1/v2: entities without che:state:<step>, or dashboards with an
-	// empty pipeline snapshot, stay on the legacy matcher. This keeps repos with
-	// historical labels loopable instead of coupling fallback to a reason string.
+	// FALLBACK v1/v2: entities without che:state:<step> stay on the legacy
+	// matcher. An empty pipeline snapshot also falls back so migrated entities do
+	// not get stranded if pipeline resolution is temporarily unavailable.
 	return e.StateStep != "" && len(steps) > 0
+}
+
+const (
+	dynamicRunIssuePrefix = "run#:"
+	dynamicRunPRPrefix    = "run!:"
+)
+
+type dynamicRunFlow struct {
+	Step string
+	PR   bool
+}
+
+func encodeDynamicRunFlow(run dynamicRunFlow) string {
+	if run.PR {
+		return dynamicRunPRPrefix + run.Step
+	}
+	return dynamicRunIssuePrefix + run.Step
+}
+
+func decodeDynamicRunFlow(flow string) (dynamicRunFlow, bool) {
+	switch {
+	case len(flow) > len(dynamicRunIssuePrefix) && flow[:len(dynamicRunIssuePrefix)] == dynamicRunIssuePrefix:
+		return dynamicRunFlow{Step: flow[len(dynamicRunIssuePrefix):]}, true
+	case len(flow) > len(dynamicRunPRPrefix) && flow[:len(dynamicRunPRPrefix)] == dynamicRunPRPrefix:
+		return dynamicRunFlow{Step: flow[len(dynamicRunPRPrefix):], PR: true}, true
+	default:
+		return dynamicRunFlow{}, false
+	}
 }
 
 func nextPipelineDispatch(e Entity, steps []string, rounds int) (flow string, targetRef int, reason string) {
@@ -578,25 +606,12 @@ func nextPipelineDispatch(e Entity, steps []string, rounds int) (flow string, ta
 		if i+1 >= len(steps) {
 			return "", 0, "pipeline-complete"
 		}
-		next := steps[i+1]
-		prefix := "run#:"
-		if e.Kind == KindPR {
-			prefix = "run!:"
-		}
-		return prefix + next, e.EntityKey(), "step:" + next
+		// Dynamic verdict handling lives in the pipeline agents/markers: the dash
+		// only resumes from the current StateStep and lets `che run --auto` decide
+		// advance, goto markers and skips. Legacy verdict rules are fallback only.
+		return encodeDynamicRunFlow(dynamicRunFlow{Step: e.StateStep, PR: e.Kind == KindPR}), e.EntityKey(), "step:" + e.StateStep
 	}
 	return "", 0, "step-not-in-pipeline"
-}
-
-func runStepFromFlow(flow string) (step string, pr bool, ok bool) {
-	switch {
-	case len(flow) > len("run#:") && flow[:len("run#:")] == "run#:":
-		return flow[len("run#:"):], false, true
-	case len(flow) > len("run!:") && flow[:len("run!:")] == "run!:":
-		return flow[len("run!:"):], true, true
-	default:
-		return "", false, false
-	}
 }
 
 // entitySide clasifica la entity en issue-side o PR-side para el slot de
@@ -656,8 +671,9 @@ func (s *Server) runTick() int {
 	if !anyOn {
 		return 0
 	}
-	steps := make([]string, 0, len(s.pipeline.Steps))
-	for _, step := range s.pipeline.Steps {
+	activePipeline := s.activePipeline()
+	steps := make([]string, 0, len(activePipeline.Steps))
+	for _, step := range activePipeline.Steps {
 		steps = append(steps, step.Name)
 	}
 
@@ -718,13 +734,32 @@ func (s *Server) runTick() int {
 		// que esto es defensa para cuando se sumen reglas adopt-side.
 		key := e.EntityKey()
 		rounds := s.loop.roundsFor(key)
+		if e.StateStep != "" && len(steps) == 0 {
+			if !s.loop.markGateNotified(key, "pipeline", "no-pipeline-steps:"+e.StateStep) {
+				fmt.Fprintf(os.Stderr, "dash auto-loop: dynamic fallback for %s — no-pipeline-steps (step=%s)\n", entityRef(e), e.StateStep)
+			}
+		}
 		var flow string
 		var targetRef int
 		var reason string
-		if usesPipeline(e, steps) {
+		usedPipeline := usesPipeline(e, steps)
+		if usedPipeline {
 			flow, targetRef, reason = nextPipelineDispatch(e, steps, rounds)
 		} else {
 			flow, targetRef, reason = nextDispatch(e, rules, rounds)
+		}
+		if usedPipeline && flow == "" {
+			switch reason {
+			case "step-not-in-pipeline", "no-pipeline-steps":
+				if !s.loop.markGateNotified(key, "pipeline", reason+":"+e.StateStep) {
+					fmt.Fprintf(os.Stderr, "dash auto-loop: dynamic fallback for %s — %s (step=%s)\n", entityRef(e), reason, e.StateStep)
+				}
+				flow, targetRef, reason = nextDispatch(e, rules, rounds)
+			case "pipeline-complete":
+				if !s.loop.markGateNotified(key, "pipeline", reason+":"+e.StateStep) {
+					fmt.Fprintf(os.Stderr, "dash auto-loop: pipeline complete for %s at step %s — stop\n", entityRef(e), e.StateStep)
+				}
+			}
 		}
 		if flow == "" {
 			// Cap hit: log una vez a stderr.
@@ -749,7 +784,7 @@ func (s *Server) runTick() int {
 		// (Gates ya viene poblado por overlayRunning, pero acá usamos el
 		// snapshot crudo del Source — overlayRunning no corre en el tick).
 		// computeGates es pura, sin IO; el costo es despreciable.
-		gate := computeDispatchGates(e, s.pipeline, flow)[flow]
+		gate := computeDispatchGates(e, activePipeline, flow)[flow]
 		if !gate.Available {
 			if !s.loop.markGateNotified(key, flow, gate.Reason) {
 				fmt.Fprintf(os.Stderr, "dash auto-loop: skip %s %s — %s\n", flow, entityRef(e), gate.Reason)

--- a/internal/dash/loop.go
+++ b/internal/dash/loop.go
@@ -67,6 +67,8 @@ import (
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/chichex/che/internal/pipelinelabels"
 )
 
 // LoopCap es el número máximo de dispatches automáticos + manuales que el
@@ -583,7 +585,45 @@ func decodeDynamicRunFlow(flow string) (dynamicRunFlow, bool) {
 	}
 }
 
-func nextPipelineDispatch(e Entity, steps []string, rounds int) (flow string, targetRef int, reason string) {
+func dynamicRulesForStateStep(e Entity) []LoopRule {
+	switch e.StateStep {
+	case pipelinelabels.StepIdea:
+		if e.Kind == KindIssue {
+			return []LoopRule{RuleExploreIdea}
+		}
+	case pipelinelabels.StepExplore:
+		if e.Kind == KindIssue {
+			return []LoopRule{RuleValidatePlan, RuleExecuteRaw}
+		}
+	case pipelinelabels.StepExecute:
+		if e.PRNumber > 0 {
+			return []LoopRule{RuleValidatePR}
+		}
+	case pipelinelabels.StepValidatePR:
+		if e.Kind == KindFused || e.Kind == KindPR {
+			return []LoopRule{RuleIteratePR}
+		}
+		if e.Kind == KindIssue {
+			return []LoopRule{RuleIteratePlan, RuleExecutePlan}
+		}
+	}
+	return nil
+}
+
+func dynamicRuleEnabled(e Entity, rules map[LoopRule]bool) (bool, string) {
+	dynamicRules := dynamicRulesForStateStep(e)
+	if len(dynamicRules) == 0 {
+		return false, "no-dynamic-rule-for-step"
+	}
+	for _, rule := range dynamicRules {
+		if rules[rule] {
+			return true, "rule:" + string(rule)
+		}
+	}
+	return false, "dynamic-rule-disabled"
+}
+
+func nextPipelineDispatch(e Entity, steps []string, rules map[LoopRule]bool, rounds int) (flow string, targetRef int, reason string) {
 	if e.StateStep == "" {
 		return "", 0, "no-pipeline-state"
 	}
@@ -605,6 +645,9 @@ func nextPipelineDispatch(e Entity, steps []string, rounds int) (flow string, ta
 		}
 		if i+1 >= len(steps) {
 			return "", 0, "pipeline-complete"
+		}
+		if ok, reason := dynamicRuleEnabled(e, rules); !ok {
+			return "", 0, reason
 		}
 		// Dynamic verdict handling lives in the pipeline agents/markers: the dash
 		// only resumes from the current StateStep and lets `che run --auto` decide
@@ -749,7 +792,7 @@ func (s *Server) runTick() int {
 		var reason string
 		usedPipeline := usesPipeline(e, steps)
 		if usedPipeline {
-			flow, targetRef, reason = nextPipelineDispatch(e, steps, rounds)
+			flow, targetRef, reason = nextPipelineDispatch(e, steps, rules, rounds)
 		} else {
 			flow, targetRef, reason = nextDispatch(e, rules, rounds)
 		}
@@ -763,6 +806,10 @@ func (s *Server) runTick() int {
 			case "pipeline-complete":
 				if !s.loop.markGateNotified(key, "pipeline", reason+":"+e.StateStep) {
 					fmt.Fprintf(os.Stderr, "dash auto-loop: pipeline complete for %s at step %s — stop\n", entityRef(e), e.StateStep)
+				}
+			case "no-dynamic-rule-for-step", "dynamic-rule-disabled":
+				if !s.loop.markGateNotified(key, "pipeline", reason+":"+e.StateStep) {
+					fmt.Fprintf(os.Stderr, "dash auto-loop: dynamic skip for %s — %s (step=%s)\n", entityRef(e), reason, e.StateStep)
 				}
 			}
 		}

--- a/internal/dash/loop_test.go
+++ b/internal/dash/loop_test.go
@@ -353,40 +353,40 @@ func TestNextDispatch_RuleTable(t *testing.T) {
 }
 
 func TestNextPipelineDispatch_DispatchesFromStateStep(t *testing.T) {
-	steps := []string{"triage", "spec", "build", "ship"}
-	if !usesPipeline(Entity{StateStep: "spec"}, steps) {
+	steps := []string{"idea", "explore", "validate_issue"}
+	if !usesPipeline(Entity{StateStep: "idea"}, steps) {
 		t.Fatalf("usesPipeline should be true when entity has a state step and the pipeline has steps")
 	}
-	if usesPipeline(Entity{StateStep: "spec"}, nil) {
+	if usesPipeline(Entity{StateStep: "idea"}, nil) {
 		t.Fatalf("usesPipeline should fall back to legacy matcher when the pipeline has no steps")
 	}
 	flow, ref, reason := nextPipelineDispatch(Entity{
 		Kind:        KindIssue,
 		IssueNumber: 42,
-		StateStep:   "spec",
-		Status:      "spec",
-	}, steps, 0)
-	if flow != "run#:spec" {
-		t.Fatalf("flow: got %q want run#:spec (reason=%s)", flow, reason)
+		StateStep:   "idea",
+		Status:      "idea",
+	}, steps, map[LoopRule]bool{RuleExploreIdea: true}, 0)
+	if flow != "run#:idea" {
+		t.Fatalf("flow: got %q want run#:idea (reason=%s)", flow, reason)
 	}
 	if ref != 42 {
 		t.Fatalf("ref: got %d want 42", ref)
 	}
 
-	flow, _, reason = nextPipelineDispatch(Entity{Kind: KindIssue, IssueNumber: 42, StateStep: "spec", StateApplying: true}, steps, 0)
+	flow, _, reason = nextPipelineDispatch(Entity{Kind: KindIssue, IssueNumber: 42, StateStep: "idea", StateApplying: true}, steps, map[LoopRule]bool{RuleExploreIdea: true}, 0)
 	if flow != "" || reason != "applying" {
 		t.Fatalf("applying: flow=%q reason=%q, want no flow/applying", flow, reason)
 	}
 }
 
 func TestNextPipelineDispatch_EdgeReasons(t *testing.T) {
-	if flow, _, reason := nextPipelineDispatch(Entity{Kind: KindIssue, IssueNumber: 1, StateStep: "ship"}, []string{"spec", "ship"}, 0); flow != "" || reason != "pipeline-complete" {
+	if flow, _, reason := nextPipelineDispatch(Entity{Kind: KindIssue, IssueNumber: 1, StateStep: "ship"}, []string{"spec", "ship"}, map[LoopRule]bool{RuleExploreIdea: true}, 0); flow != "" || reason != "pipeline-complete" {
 		t.Fatalf("complete: flow=%q reason=%q, want no flow/pipeline-complete", flow, reason)
 	}
-	if flow, _, reason := nextPipelineDispatch(Entity{Kind: KindIssue, IssueNumber: 1, StateStep: "ghost"}, []string{"spec", "ship"}, 0); flow != "" || reason != "step-not-in-pipeline" {
+	if flow, _, reason := nextPipelineDispatch(Entity{Kind: KindIssue, IssueNumber: 1, StateStep: "ghost"}, []string{"spec", "ship"}, map[LoopRule]bool{RuleExploreIdea: true}, 0); flow != "" || reason != "step-not-in-pipeline" {
 		t.Fatalf("orphan: flow=%q reason=%q, want no flow/step-not-in-pipeline", flow, reason)
 	}
-	if flow, _, reason := nextPipelineDispatch(Entity{Kind: KindIssue, IssueNumber: 1, StateStep: "spec"}, nil, 0); flow != "" || reason != "no-pipeline-steps" {
+	if flow, _, reason := nextPipelineDispatch(Entity{Kind: KindIssue, IssueNumber: 1, StateStep: "spec"}, nil, map[LoopRule]bool{RuleExploreIdea: true}, 0); flow != "" || reason != "no-pipeline-steps" {
 		t.Fatalf("empty: flow=%q reason=%q, want no flow/no-pipeline-steps", flow, reason)
 	}
 }
@@ -483,28 +483,33 @@ func TestTick_ConcurrencyIssueSide(t *testing.T) {
 	}
 }
 
-func TestTick_DynamicPipelineDispatchesFromStateStep(t *testing.T) {
+func TestTick_DynamicPipelineRequiresMatchingRule(t *testing.T) {
 	s, fr := newLoopServer(t, []Entity{{
 		Kind:        KindIssue,
 		IssueNumber: 42,
-		Status:      "spec",
-		StateStep:   "spec",
+		Status:      "idea",
+		StateStep:   "idea",
 	}})
 	s.pipeline = pipeline.Pipeline{Version: pipeline.CurrentVersion, Steps: []pipeline.Step{
-		{Name: "triage", Agents: []string{"claude-opus"}},
-		{Name: "spec", Agents: []string{"claude-opus"}},
-		{Name: "build", Agents: []string{"claude-opus"}},
+		{Name: "idea", Agents: []string{"claude-opus"}},
+		{Name: "explore", Agents: []string{"claude-opus"}},
 	}}
-	// En el motor dinámico las reglas existentes funcionan como switch del
-	// auto-loop; el step concreto sale del pipeline activo, no del enum legacy.
 	s.loop.rules[RuleValidatePlan] = true
 
+	if n := s.runTick(); n != 0 {
+		t.Fatalf("tick dispatches with only validate-plan enabled: got %d want 0", n)
+	}
+	if fr.count() != 0 {
+		t.Fatalf("runner calls with only validate-plan enabled: got %d want 0", fr.count())
+	}
+
+	s.loop.rules[RuleExploreIdea] = true
 	if n := s.runTick(); n != 1 {
 		t.Fatalf("tick dispatches: got %d want 1", n)
 	}
 	call := fr.last()
-	if call.Flow != "run#:spec" {
-		t.Fatalf("flow: got %q want run#:spec", call.Flow)
+	if call.Flow != "run#:idea" {
+		t.Fatalf("flow: got %q want run#:idea", call.Flow)
 	}
 	if call.TargetRef != 42 || call.EntityKey != 42 {
 		t.Fatalf("refs: target=%d key=%d, want 42/42", call.TargetRef, call.EntityKey)

--- a/internal/dash/loop_test.go
+++ b/internal/dash/loop_test.go
@@ -352,7 +352,7 @@ func TestNextDispatch_RuleTable(t *testing.T) {
 	}
 }
 
-func TestNextPipelineDispatch_UsesStepOrder(t *testing.T) {
+func TestNextPipelineDispatch_DispatchesFromStateStep(t *testing.T) {
 	steps := []string{"triage", "spec", "build", "ship"}
 	if !usesPipeline(Entity{StateStep: "spec"}, steps) {
 		t.Fatalf("usesPipeline should be true when entity has a state step and the pipeline has steps")
@@ -366,8 +366,8 @@ func TestNextPipelineDispatch_UsesStepOrder(t *testing.T) {
 		StateStep:   "spec",
 		Status:      "spec",
 	}, steps, 0)
-	if flow != "run#:build" {
-		t.Fatalf("flow: got %q want run#:build (reason=%s)", flow, reason)
+	if flow != "run#:spec" {
+		t.Fatalf("flow: got %q want run#:spec (reason=%s)", flow, reason)
 	}
 	if ref != 42 {
 		t.Fatalf("ref: got %d want 42", ref)
@@ -376,6 +376,18 @@ func TestNextPipelineDispatch_UsesStepOrder(t *testing.T) {
 	flow, _, reason = nextPipelineDispatch(Entity{Kind: KindIssue, IssueNumber: 42, StateStep: "spec", StateApplying: true}, steps, 0)
 	if flow != "" || reason != "applying" {
 		t.Fatalf("applying: flow=%q reason=%q, want no flow/applying", flow, reason)
+	}
+}
+
+func TestNextPipelineDispatch_EdgeReasons(t *testing.T) {
+	if flow, _, reason := nextPipelineDispatch(Entity{Kind: KindIssue, IssueNumber: 1, StateStep: "ship"}, []string{"spec", "ship"}, 0); flow != "" || reason != "pipeline-complete" {
+		t.Fatalf("complete: flow=%q reason=%q, want no flow/pipeline-complete", flow, reason)
+	}
+	if flow, _, reason := nextPipelineDispatch(Entity{Kind: KindIssue, IssueNumber: 1, StateStep: "ghost"}, []string{"spec", "ship"}, 0); flow != "" || reason != "step-not-in-pipeline" {
+		t.Fatalf("orphan: flow=%q reason=%q, want no flow/step-not-in-pipeline", flow, reason)
+	}
+	if flow, _, reason := nextPipelineDispatch(Entity{Kind: KindIssue, IssueNumber: 1, StateStep: "spec"}, nil, 0); flow != "" || reason != "no-pipeline-steps" {
+		t.Fatalf("empty: flow=%q reason=%q, want no flow/no-pipeline-steps", flow, reason)
 	}
 }
 
@@ -471,7 +483,7 @@ func TestTick_ConcurrencyIssueSide(t *testing.T) {
 	}
 }
 
-func TestTick_DynamicPipelineDispatchesNextStep(t *testing.T) {
+func TestTick_DynamicPipelineDispatchesFromStateStep(t *testing.T) {
 	s, fr := newLoopServer(t, []Entity{{
 		Kind:        KindIssue,
 		IssueNumber: 42,
@@ -491,11 +503,63 @@ func TestTick_DynamicPipelineDispatchesNextStep(t *testing.T) {
 		t.Fatalf("tick dispatches: got %d want 1", n)
 	}
 	call := fr.last()
-	if call.Flow != "run#:build" {
-		t.Fatalf("flow: got %q want run#:build", call.Flow)
+	if call.Flow != "run#:spec" {
+		t.Fatalf("flow: got %q want run#:spec", call.Flow)
 	}
 	if call.TargetRef != 42 || call.EntityKey != 42 {
 		t.Fatalf("refs: target=%d key=%d, want 42/42", call.TargetRef, call.EntityKey)
+	}
+}
+
+func TestTick_FallbackWithoutStateStepUsesLegacyMatcher(t *testing.T) {
+	s, fr := newLoopServer(t, []Entity{{Kind: KindIssue, IssueNumber: 42, Status: "plan"}})
+	s.pipeline = pipeline.Pipeline{Version: pipeline.CurrentVersion, Steps: []pipeline.Step{{Name: "spec", Agents: []string{"claude-opus"}}}}
+	s.loop.rules[RuleValidatePlan] = true
+
+	if n := s.runTick(); n != 1 {
+		t.Fatalf("tick dispatches: got %d want 1", n)
+	}
+	if got := fr.last().Flow; got != "validate" {
+		t.Fatalf("flow: got %q want validate", got)
+	}
+}
+
+func TestTick_PipelineEmptyFallsBackToLegacyMatcher(t *testing.T) {
+	s, fr := newLoopServer(t, []Entity{{Kind: KindIssue, IssueNumber: 42, Status: "plan", StateStep: "spec"}})
+	s.pipeline = pipeline.Pipeline{Version: pipeline.CurrentVersion}
+	s.loop.rules[RuleValidatePlan] = true
+
+	if n := s.runTick(); n != 1 {
+		t.Fatalf("tick dispatches: got %d want 1", n)
+	}
+	if got := fr.last().Flow; got != "validate" {
+		t.Fatalf("flow: got %q want validate", got)
+	}
+}
+
+func TestTick_OrphanStepFallsBackToLegacyMatcher(t *testing.T) {
+	s, fr := newLoopServer(t, []Entity{{Kind: KindIssue, IssueNumber: 42, Status: "plan", StateStep: "ghost"}})
+	s.pipeline = pipeline.Pipeline{Version: pipeline.CurrentVersion, Steps: []pipeline.Step{{Name: "spec", Agents: []string{"claude-opus"}}, {Name: "build", Agents: []string{"claude-opus"}}}}
+	s.loop.rules[RuleValidatePlan] = true
+
+	if n := s.runTick(); n != 1 {
+		t.Fatalf("tick dispatches: got %d want 1", n)
+	}
+	if got := fr.last().Flow; got != "validate" {
+		t.Fatalf("flow: got %q want validate", got)
+	}
+}
+
+func TestTick_PipelineCompleteLogsAndStops(t *testing.T) {
+	s, fr := newLoopServer(t, []Entity{{Kind: KindIssue, IssueNumber: 42, Status: "validated", StateStep: "ship", PlanVerdict: "approve"}})
+	s.pipeline = pipeline.Pipeline{Version: pipeline.CurrentVersion, Steps: []pipeline.Step{{Name: "spec", Agents: []string{"claude-opus"}}, {Name: "ship", Agents: []string{"claude-opus"}}}}
+	s.loop.rules[RuleExecutePlan] = true
+
+	if n := s.runTick(); n != 0 {
+		t.Fatalf("tick dispatches: got %d want 0", n)
+	}
+	if fr.count() != 0 {
+		t.Fatalf("runner calls: got %d want 0", fr.count())
 	}
 }
 

--- a/internal/dash/loop_test.go
+++ b/internal/dash/loop_test.go
@@ -596,6 +596,28 @@ func TestTick_IssueAndPRSimultaneous(t *testing.T) {
 	}
 }
 
+func TestTick_KindPRRunningOccupiesPRSlot(t *testing.T) {
+	ents := []Entity{
+		{Kind: KindPR, PRNumber: 301, Status: "validated", PRVerdict: "changes-requested", RunningFlow: "validate"},
+		{Kind: KindFused, IssueNumber: 2, PRNumber: 22, Status: "executed"},
+		{Kind: KindIssue, IssueNumber: 1, Status: "plan"},
+	}
+	s, fr := newLoopServer(t, ents)
+	s.loop.rules[RuleValidatePlan] = true
+	s.loop.rules[RuleValidatePR] = true
+
+	if n := s.runTick(); n != 1 {
+		t.Fatalf("tick dispatches: got %d want 1 (KindPR running ocupa slot PR, issue slot queda libre)", n)
+	}
+	if fr.count() != 1 {
+		t.Fatalf("runner calls: got %d want 1", fr.count())
+	}
+	got := fr.last()
+	if got.Flow != "validate" || got.TargetRef != 1 || got.EntityKey != 1 {
+		t.Errorf("dispatch: got %+v want issue-side validate target=1 key=1", got)
+	}
+}
+
 // TestTick_CapFive: mismo entity pasa por 5 rondas; el 6to tick no dispatcha.
 func TestTick_CapFive(t *testing.T) {
 	ents := []Entity{

--- a/internal/dash/loop_test.go
+++ b/internal/dash/loop_test.go
@@ -354,6 +354,12 @@ func TestNextDispatch_RuleTable(t *testing.T) {
 
 func TestNextPipelineDispatch_UsesStepOrder(t *testing.T) {
 	steps := []string{"triage", "spec", "build", "ship"}
+	if !usesPipeline(Entity{StateStep: "spec"}, steps) {
+		t.Fatalf("usesPipeline should be true when entity has a state step and the pipeline has steps")
+	}
+	if usesPipeline(Entity{StateStep: "spec"}, nil) {
+		t.Fatalf("usesPipeline should fall back to legacy matcher when the pipeline has no steps")
+	}
 	flow, ref, reason := nextPipelineDispatch(Entity{
 		Kind:        KindIssue,
 		IssueNumber: 42,
@@ -1381,6 +1387,9 @@ func TestEntitySide(t *testing.T) {
 	}
 	if got := entitySide(Entity{Kind: KindFused}); got != "pr" {
 		t.Errorf("KindFused: got %q want 'pr'", got)
+	}
+	if got := entitySide(Entity{Kind: KindPR}); got != "pr" {
+		t.Errorf("KindPR: got %q want 'pr'", got)
 	}
 }
 

--- a/internal/dash/loop_test.go
+++ b/internal/dash/loop_test.go
@@ -389,6 +389,9 @@ func TestNextPipelineDispatch_EdgeReasons(t *testing.T) {
 	if flow, _, reason := nextPipelineDispatch(Entity{Kind: KindIssue, IssueNumber: 1, StateStep: "spec"}, nil, map[LoopRule]bool{RuleExploreIdea: true}, 0); flow != "" || reason != "no-pipeline-steps" {
 		t.Fatalf("empty: flow=%q reason=%q, want no flow/no-pipeline-steps", flow, reason)
 	}
+	if flow, _, reason := nextPipelineDispatch(Entity{Kind: KindIssue, IssueNumber: 1, StateStep: "spec"}, []string{"spec", "ship"}, map[LoopRule]bool{RuleExploreIdea: true}, DynamicLoopCap); flow != "" || reason != "cap-reached" {
+		t.Fatalf("dynamic cap: flow=%q reason=%q, want no flow/cap-reached", flow, reason)
+	}
 }
 
 // ================== Tick & concurrency ==================
@@ -623,8 +626,9 @@ func TestTick_KindPRRunningOccupiesPRSlot(t *testing.T) {
 	}
 }
 
-// TestTick_CapFive: mismo entity pasa por 5 rondas; el 6to tick no dispatcha.
-func TestTick_CapFive(t *testing.T) {
+// TestTick_LegacyCapTen: mismo entity legacy pasa por LoopCap rondas; el
+// siguiente tick no dispatcha.
+func TestTick_LegacyCapTen(t *testing.T) {
 	ents := []Entity{
 		{Kind: KindIssue, IssueNumber: 42, Status: "plan"},
 	}
@@ -647,6 +651,31 @@ func TestTick_CapFive(t *testing.T) {
 	}
 	if fr.count() != LoopCap {
 		t.Errorf("runner calls tras cap: got %d want %d", fr.count(), LoopCap)
+	}
+}
+
+func TestTick_DynamicPipelineCapThree(t *testing.T) {
+	s, fr := newLoopServer(t, []Entity{{Kind: KindIssue, IssueNumber: 42, Status: "idea", StateStep: "idea"}})
+	s.pipeline = pipeline.Pipeline{Version: pipeline.CurrentVersion, Steps: []pipeline.Step{
+		{Name: "idea", Agents: []string{"claude-opus"}},
+		{Name: "explore", Agents: []string{"claude-opus"}},
+	}}
+	s.loop.rules[RuleExploreIdea] = true
+
+	for i := 1; i <= DynamicLoopCap; i++ {
+		if n := s.runTick(); n != 1 {
+			t.Fatalf("tick #%d dispatches: got %d want 1", i, n)
+		}
+		s.clearRunning(42)
+	}
+	if fr.count() != DynamicLoopCap {
+		t.Fatalf("runner calls tras %d ticks: got %d want %d", DynamicLoopCap, fr.count(), DynamicLoopCap)
+	}
+	if n := s.runTick(); n != 0 {
+		t.Errorf("tick #%d (post-cap dinámico) dispatches: got %d want 0", DynamicLoopCap+1, n)
+	}
+	if fr.count() != DynamicLoopCap {
+		t.Errorf("runner calls tras cap dinámico: got %d want %d", fr.count(), DynamicLoopCap)
 	}
 }
 
@@ -736,7 +765,7 @@ func TestTick_ManualDispatchCountsForCap(t *testing.T) {
 		s.clearRunning(42)
 	}
 	if fr.count() != LoopCap {
-		t.Fatalf("calls tras 5 manuales: got %d want %d", fr.count(), LoopCap)
+		t.Fatalf("calls tras %d manuales: got %d want %d", LoopCap, fr.count(), LoopCap)
 	}
 	// Ahora el counter debería estar en cap.
 	if r := s.loop.roundsFor(42); r != LoopCap {

--- a/internal/dash/loop_test.go
+++ b/internal/dash/loop_test.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/chichex/che/internal/pipeline"
 )
 
 // ================== Matcher puro ==================
@@ -18,12 +20,12 @@ import (
 // alguien cambió la semántica y conviene discutirla antes de mergear.
 func TestNextDispatch_RuleTable(t *testing.T) {
 	tests := []struct {
-		name      string
-		e         Entity
-		rules     map[LoopRule]bool
-		rounds    int
-		wantFlow  string
-		wantRef   int
+		name       string
+		e          Entity
+		rules      map[LoopRule]bool
+		rounds     int
+		wantFlow   string
+		wantRef    int
 		wantSubstr string // substring que debe aparecer en reason
 	}{
 		{
@@ -350,6 +352,27 @@ func TestNextDispatch_RuleTable(t *testing.T) {
 	}
 }
 
+func TestNextPipelineDispatch_UsesStepOrder(t *testing.T) {
+	steps := []string{"triage", "spec", "build", "ship"}
+	flow, ref, reason := nextPipelineDispatch(Entity{
+		Kind:        KindIssue,
+		IssueNumber: 42,
+		StateStep:   "spec",
+		Status:      "spec",
+	}, steps, 0)
+	if flow != "run#:build" {
+		t.Fatalf("flow: got %q want run#:build (reason=%s)", flow, reason)
+	}
+	if ref != 42 {
+		t.Fatalf("ref: got %d want 42", ref)
+	}
+
+	flow, _, reason = nextPipelineDispatch(Entity{Kind: KindIssue, IssueNumber: 42, StateStep: "spec", StateApplying: true}, steps, 0)
+	if flow != "" || reason != "applying" {
+		t.Fatalf("applying: flow=%q reason=%q, want no flow/applying", flow, reason)
+	}
+}
+
 // ================== Tick & concurrency ==================
 
 // newLoopServer arma un Server con fixedSource mutable + fakeRunner. El
@@ -439,6 +462,34 @@ func TestTick_ConcurrencyIssueSide(t *testing.T) {
 	}
 	if got := fr.last().EntityKey; got != 2 {
 		t.Errorf("tick #3 key: got %d want 2 (#1 approved → stop; #2 primero disponible)", got)
+	}
+}
+
+func TestTick_DynamicPipelineDispatchesNextStep(t *testing.T) {
+	s, fr := newLoopServer(t, []Entity{{
+		Kind:        KindIssue,
+		IssueNumber: 42,
+		Status:      "spec",
+		StateStep:   "spec",
+	}})
+	s.pipeline = pipeline.Pipeline{Version: pipeline.CurrentVersion, Steps: []pipeline.Step{
+		{Name: "triage", Agents: []string{"claude-opus"}},
+		{Name: "spec", Agents: []string{"claude-opus"}},
+		{Name: "build", Agents: []string{"claude-opus"}},
+	}}
+	// En el motor dinámico las reglas existentes funcionan como switch del
+	// auto-loop; el step concreto sale del pipeline activo, no del enum legacy.
+	s.loop.rules[RuleValidatePlan] = true
+
+	if n := s.runTick(); n != 1 {
+		t.Fatalf("tick dispatches: got %d want 1", n)
+	}
+	call := fr.last()
+	if call.Flow != "run#:build" {
+		t.Fatalf("flow: got %q want run#:build", call.Flow)
+	}
+	if call.TargetRef != 42 || call.EntityKey != 42 {
+		t.Fatalf("refs: target=%d key=%d, want 42/42", call.TargetRef, call.EntityKey)
 	}
 }
 

--- a/internal/dash/model.go
+++ b/internal/dash/model.go
@@ -56,10 +56,12 @@ type Entity struct {
 	// "idea", "planning", "plan", "executing", "executed", "validating",
 	// "validated", "closing", "closed". Vacío o desconocido cae a "idea"
 	// (default defensivo en Column()).
-	Status      string
-	PlanVerdict string // "approve" | "changes-requested" | "needs-human" — vacío = no validado
-	PRVerdict   string // idem, solo aplica si KindFused
-	Locked      bool   // che:locked
+	Status        string
+	StateStep     string // step real de che:state:<step> / che:state:applying:<step>
+	StateApplying bool   // true si el label activo es che:state:applying:<step>
+	PlanVerdict   string // "approve" | "changes-requested" | "needs-human" — vacío = no validado
+	PRVerdict     string // idem, solo aplica si KindFused
+	Locked        bool   // che:locked
 
 	RunningFlow string // "explore" | "execute" | "iterate" | "validate" | "close" — vacío = idle
 	RunIter     int    // iteración actual (1-based)

--- a/internal/dash/model.go
+++ b/internal/dash/model.go
@@ -67,7 +67,7 @@ type Entity struct {
 	RunIter     int    // iteración actual (1-based)
 	RunMax      int    // max iteraciones del loop
 	// CapReached: el auto-loop dejó de dispatchar sobre este issue porque
-	// rounds[id] ya alcanzó LoopCap. Señal visual para el humano: "no vas a
+	// rounds[id] ya alcanzó el cap efectivo. Señal visual para el humano: "no vas a
 	// ver esto moverse solo, decidí algo". Se setea en overlayRunning solo
 	// para entities en status loopable (plan / validated / executed) — en
 	// closing/closed/idea/etc el cap es irrelevante.

--- a/internal/dash/preflight.go
+++ b/internal/dash/preflight.go
@@ -29,6 +29,7 @@ package dash
 import (
 	"fmt"
 
+	"github.com/chichex/che/internal/pipeline"
 	planpkg "github.com/chichex/che/internal/plan"
 )
 
@@ -94,6 +95,36 @@ func computeGates(e Entity) FlowGates {
 		flowExecute:  gateExecute(e),
 		flowClose:    gateClose(e),
 	}
+}
+
+func gatePipelineStep(e Entity, p pipeline.Pipeline, step string) FlowGate {
+	if e.Locked {
+		return FlowGate{false, lockedReason(e)}
+	}
+	if e.StateApplying {
+		return FlowGate{false, fmt.Sprintf("step %s en curso — esperá que termine", e.StateStep)}
+	}
+	if step == "" {
+		return FlowGate{false, "step vacío"}
+	}
+	current := e.StateStep
+	if current == "" {
+		current = e.Status
+	}
+	for i, s := range p.Steps {
+		if s.Name != current {
+			continue
+		}
+		if i+1 >= len(p.Steps) {
+			return FlowGate{false, fmt.Sprintf("%s es el último step del pipeline", current)}
+		}
+		next := p.Steps[i+1].Name
+		if next != step {
+			return FlowGate{false, fmt.Sprintf("el próximo step desde %s es %s", current, next)}
+		}
+		return FlowGate{true, ""}
+	}
+	return FlowGate{false, fmt.Sprintf("step actual %s no existe en el pipeline activo", emptyAsIdea(current))}
 }
 
 // adoptGates devuelve el set fijo por kind para entities en columna "adopt".

--- a/internal/dash/preflight.go
+++ b/internal/dash/preflight.go
@@ -97,6 +97,14 @@ func computeGates(e Entity) FlowGates {
 	}
 }
 
+func computeDispatchGates(e Entity, p pipeline.Pipeline, flow string) FlowGates {
+	gates := computeGates(e)
+	if step, _, ok := runStepFromFlow(flow); ok {
+		gates[flow] = gatePipelineStep(e, p, step)
+	}
+	return gates
+}
+
 func gatePipelineStep(e Entity, p pipeline.Pipeline, step string) FlowGate {
 	if e.Locked {
 		return FlowGate{false, lockedReason(e)}

--- a/internal/dash/preflight.go
+++ b/internal/dash/preflight.go
@@ -99,13 +99,13 @@ func computeGates(e Entity) FlowGates {
 
 func computeDispatchGates(e Entity, p pipeline.Pipeline, flow string) FlowGates {
 	gates := computeGates(e)
-	if step, _, ok := runStepFromFlow(flow); ok {
-		gates[flow] = gatePipelineStep(e, p, step)
+	if run, ok := decodeDynamicRunFlow(flow); ok {
+		gates[flow] = gatePipelineRunFrom(e, p, run.Step)
 	}
 	return gates
 }
 
-func gatePipelineStep(e Entity, p pipeline.Pipeline, step string) FlowGate {
+func gatePipelineRunFrom(e Entity, _ pipeline.Pipeline, step string) FlowGate {
 	if e.Locked {
 		return FlowGate{false, lockedReason(e)}
 	}
@@ -115,24 +115,16 @@ func gatePipelineStep(e Entity, p pipeline.Pipeline, step string) FlowGate {
 	if step == "" {
 		return FlowGate{false, "step vacío"}
 	}
-	current := e.StateStep
-	if current == "" {
-		current = e.Status
+	if e.StateStep == "" {
+		return FlowGate{false, "entity sin che:state:<step> — fallback legacy"}
 	}
-	for i, s := range p.Steps {
-		if s.Name != current {
-			continue
-		}
-		if i+1 >= len(p.Steps) {
-			return FlowGate{false, fmt.Sprintf("%s es el último step del pipeline", current)}
-		}
-		next := p.Steps[i+1].Name
-		if next != step {
-			return FlowGate{false, fmt.Sprintf("el próximo step desde %s es %s", current, next)}
-		}
-		return FlowGate{true, ""}
+	if step != e.StateStep {
+		return FlowGate{false, fmt.Sprintf("run dinámico debe reanudar desde %s, no %s", e.StateStep, step)}
 	}
-	return FlowGate{false, fmt.Sprintf("step actual %s no existe en el pipeline activo", emptyAsIdea(current))}
+	// TODO(#58): los botones del drawer siguen usando las gates legacy de
+	// computeGates. El auto-loop dinámico enchufa su gate en este shape común
+	// sólo para el tick; la UI dinámica completa queda para el wiring de #58.
+	return FlowGate{true, ""}
 }
 
 // adoptGates devuelve el set fijo por kind para entities en columna "adopt".

--- a/internal/dash/preflight.go
+++ b/internal/dash/preflight.go
@@ -105,7 +105,7 @@ func computeDispatchGates(e Entity, p pipeline.Pipeline, flow string) FlowGates 
 	return gates
 }
 
-func gatePipelineRunFrom(e Entity, _ pipeline.Pipeline, step string) FlowGate {
+func gatePipelineRunFrom(e Entity, p pipeline.Pipeline, step string) FlowGate {
 	if e.Locked {
 		return FlowGate{false, lockedReason(e)}
 	}
@@ -114,6 +114,16 @@ func gatePipelineRunFrom(e Entity, _ pipeline.Pipeline, step string) FlowGate {
 	}
 	if step == "" {
 		return FlowGate{false, "step vacío"}
+	}
+	stepFound := false
+	for _, pipelineStep := range p.Steps {
+		if pipelineStep.Name == step {
+			stepFound = true
+			break
+		}
+	}
+	if !stepFound {
+		return FlowGate{false, fmt.Sprintf("step %s no existe en el pipeline activo", step)}
 	}
 	if e.StateStep == "" {
 		return FlowGate{false, "entity sin che:state:<step> — fallback legacy"}

--- a/internal/dash/preflight_test.go
+++ b/internal/dash/preflight_test.go
@@ -3,6 +3,8 @@ package dash
 import (
 	"strings"
 	"testing"
+
+	"github.com/chichex/che/internal/pipeline"
 )
 
 // TestComputeGates es un table-driven sweep por las 5 funciones de gate.
@@ -329,7 +331,7 @@ func TestComputeGates(t *testing.T) {
 			},
 		},
 		{
-			name: "KindPR validated sin verdict → iterate OFF con razón explícita",
+			name:   "KindPR validated sin verdict → iterate OFF con razón explícita",
 			entity: Entity{Kind: KindPR, PRNumber: 26, Status: "validated"},
 			wantAvail: map[string]bool{
 				flowIterate:  false,
@@ -416,6 +418,18 @@ func TestComputeGatesAllFlowsCovered(t *testing.T) {
 		if _, ok := gates[f]; !ok {
 			t.Errorf("computeGates no devuelve gate para flow=%q (drift entre allFlows y computeGates)", f)
 		}
+	}
+}
+
+func TestGatePipelineRunFrom_RequiresStepInActivePipeline(t *testing.T) {
+	p := pipeline.Pipeline{Version: pipeline.CurrentVersion, Steps: []pipeline.Step{{Name: "spec", Agents: []string{"claude-opus"}}}}
+	e := Entity{Kind: KindIssue, IssueNumber: 42, StateStep: "spec"}
+
+	if gate := gatePipelineRunFrom(e, p, "spec"); !gate.Available {
+		t.Fatalf("gate available: got false reason=%q", gate.Reason)
+	}
+	if gate := gatePipelineRunFrom(e, p, "ghost"); gate.Available || !strings.Contains(gate.Reason, "no existe") {
+		t.Fatalf("missing step gate: got available=%v reason=%q, want unavailable/no existe", gate.Available, gate.Reason)
 	}
 }
 

--- a/internal/dash/server.go
+++ b/internal/dash/server.go
@@ -31,11 +31,14 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/chichex/che/internal/pipeline"
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
 	"github.com/yuin/goldmark/parser"
@@ -100,6 +103,19 @@ func Run(ctx context.Context, opts Options, stdout, stderr io.Writer) error {
 	srv := NewServer(source, repoName, opts.Poll)
 	srv.repoPath = opts.Repo
 	srv.version = opts.Version
+	root, err := dashPipelineRoot(opts.Repo)
+	if err != nil {
+		return err
+	}
+	mgr, err := pipeline.NewManager(root)
+	if err != nil {
+		return fmt.Errorf("init pipeline manager: %w", err)
+	}
+	resolved, err := mgr.Resolve("")
+	if err != nil {
+		return fmt.Errorf("resolve dashboard pipeline: %w", err)
+	}
+	srv.pipeline = resolved.Pipeline
 
 	ln, err := listenWithFallback(opts.Port, !opts.PortExplicit)
 	if err != nil {
@@ -162,6 +178,13 @@ func Run(ctx context.Context, opts Options, stdout, stderr io.Writer) error {
 	}
 }
 
+func dashPipelineRoot(repo string) (string, error) {
+	if repo == "" {
+		return os.Getwd()
+	}
+	return filepath.Abs(repo)
+}
+
 // Server es el handler HTTP del dashboard. Mantiene una referencia a la
 // Source para poder leer snapshots actualizados en cada request, y los
 // datos estáticos del page (repo, poll interval).
@@ -209,6 +232,11 @@ type Server struct {
 	// Separado del lock `mu` porque el dominio es distinto y el RWMutex
 	// interno del LogStore admite múltiples readers (Snapshot) en paralelo.
 	logs *LogStore
+
+	// pipeline es el pipeline activo del repo para gates/auto-loop dinámicos.
+	// NewServer usa pipeline.Default() para tests y mock mode; Run lo reemplaza
+	// por el default resuelto desde `.che/pipelines.config.json` cuando existe.
+	pipeline pipeline.Pipeline
 }
 
 // allowedFlows es la allowlist de flows disparables desde el dashboard. Se
@@ -261,6 +289,7 @@ func NewServer(source Source, repoName string, pollInterval int) *Server {
 		autoRunning:  map[int]bool{},
 		loop:         newLoopState(),
 		logs:         NewLogStore(),
+		pipeline:     pipeline.Default(),
 	}
 	s.runAction = s.spawnChe
 	tmpl := template.New("dash").Funcs(s.templateFuncs())
@@ -494,8 +523,8 @@ func (s *Server) templateFuncs() template.FuncMap {
 		// Step 6 — auto-loop pill label helpers. Se exponen acá para
 		// que el partial "auto-loop-toggle" los use tanto en render
 		// inicial como en OOB swap. Ambos reciben loopPopoverData.
-		"pillLabel":            pillLabel,
-		"pillLabelHasSpinner":  pillLabelHasSpinner,
+		"pillLabel":           pillLabel,
+		"pillLabelHasSpinner": pillLabelHasSpinner,
 		// Preflight gates (PR de gates UI, abril 2026): resolución del
 		// estado de un botón hx-post a partir de RunningFlow + Gates.
 		// flowBtnState centraliza la prioridad: RunningFlow gana sobre
@@ -879,11 +908,24 @@ func (s *Server) spawnChe(flow string, targetRef, entityKey int, repo string) er
 			return fmt.Errorf("no se pudo resolver el binario che: %w", err)
 		}
 	}
-	cmd := exec.Command(bin, flow, strconv.Itoa(targetRef))
+	var cmd *exec.Cmd
+	if step, prRef, ok := runStepFromFlow(flow); ok {
+		ref := "#" + strconv.Itoa(targetRef)
+		if prRef {
+			ref = "!" + strconv.Itoa(targetRef)
+		}
+		cmd = exec.Command(bin, "run", "--auto", "--from", step, "--input", ref)
+	} else {
+		cmd = exec.Command(bin, flow, strconv.Itoa(targetRef))
+	}
 	if repo != "" {
 		cmd.Dir = repo
 	}
-	return s.runCmdWithLogs(cmd, entityKey, fmt.Sprintf("che %s %d (en %s)", flow, targetRef, repo))
+	banner := fmt.Sprintf("che %s %d (en %s)", flow, targetRef, repo)
+	if strings.HasPrefix(flow, "run") {
+		banner = fmt.Sprintf("che %s (en %s)", strings.Join(cmd.Args[1:], " "), repo)
+	}
+	return s.runCmdWithLogs(cmd, entityKey, banner)
 }
 
 // runCmdWithLogs setea pipes en cmd, arranca el proceso, tee-ea stdout/

--- a/internal/dash/server.go
+++ b/internal/dash/server.go
@@ -206,9 +206,9 @@ type Server struct {
 	//
 	// targetRef = número que recibe el subcomando como argumento (PRNumber
 	// para fused validate/iterate, IssueNumber para el resto — ver
-	// resolveTargetRef). entityKey = IssueNumber de la entidad; se usa como
-	// clave del overlay de running y del LogStore para que el modal y el
-	// stream SSE la encuentren.
+	// resolveTargetRef). entityKey = EntityKey de la entidad; se usa como clave
+	// del overlay de running y del LogStore para que el modal y el stream SSE la
+	// encuentren.
 	runAction func(flow string, targetRef, entityKey int, repo string) error
 
 	// mu protege running y autoRunning. El map running trackea flows
@@ -218,8 +218,8 @@ type Server struct {
 	// paralelo que distingue "disparado por el auto-loop engine" de
 	// "disparado por el humano" para pintar un chip extra en el drawer.
 	mu          sync.Mutex
-	running     map[int]string // IssueNumber → flow corriendo
-	autoRunning map[int]bool   // IssueNumber → disparado por auto-loop (step 6)
+	running     map[int]string // EntityKey → flow corriendo
+	autoRunning map[int]bool   // EntityKey → disparado por auto-loop (step 6)
 
 	// loop es el estado del auto-loop engine (step 6): master switch +
 	// flags por regla + contador de rounds. Protegido por su propio
@@ -835,7 +835,7 @@ func (s *Server) overlayRunning(in []Entity) []Entity {
 		// el chip (ahí el cap no tiene sentido — el auto-loop no iba a
 		// dispatchar igual). Sí aplica durante un run (RunningFlow != "")
 		// para cubrir el caso "este run es el #5 y el próximo tick corta".
-		if rounds[e.IssueNumber] >= LoopCap {
+		if rounds[key] >= LoopCap {
 			switch e.Status {
 			case "plan", "validated", "executed":
 				e.CapReached = true
@@ -866,7 +866,7 @@ func (s *Server) markRunning(id int, flow string) (string, bool) {
 	// fuera de lock sería ok (Snapshot() es concurrency-safe), pero
 	// mantenerlo bajo lock simplifica razonar sobre ordenamientos.
 	for _, e := range s.source.Snapshot().Entities {
-		if e.IssueNumber == id && e.RunningFlow != "" {
+		if e.EntityKey() == id && e.RunningFlow != "" {
 			return e.RunningFlow, false
 		}
 	}

--- a/internal/dash/server.go
+++ b/internal/dash/server.go
@@ -239,6 +239,7 @@ type Server struct {
 	// pipelineRoot y activePipeline() lo re-resuelve por tick para no quedar con
 	// un snapshot stale si el usuario edita `.che/pipelines/` mientras el dash
 	// sigue abierto.
+	pipelineMu   sync.RWMutex
 	pipeline     pipeline.Pipeline
 	pipelineRoot string
 }
@@ -309,21 +310,50 @@ func NewServer(source Source, repoName string, pollInterval int) *Server {
 }
 
 func (s *Server) activePipeline() pipeline.Pipeline {
+	s.pipelineMu.RLock()
+	root := s.pipelineRoot
 	if s.pipelineRoot == "" {
-		return s.pipeline
+		p := clonePipeline(s.pipeline)
+		s.pipelineMu.RUnlock()
+		return p
 	}
-	mgr, err := pipeline.NewManager(s.pipelineRoot)
+	s.pipelineMu.RUnlock()
+
+	mgr, err := pipeline.NewManager(root)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "dash auto-loop: init pipeline manager failed: %v — using last pipeline snapshot\n", err)
-		return s.pipeline
+		s.pipelineMu.RLock()
+		p := clonePipeline(s.pipeline)
+		s.pipelineMu.RUnlock()
+		return p
 	}
 	resolved, err := mgr.Resolve("")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "dash auto-loop: resolve pipeline failed: %v — using last pipeline snapshot\n", err)
-		return s.pipeline
+		s.pipelineMu.RLock()
+		p := clonePipeline(s.pipeline)
+		s.pipelineMu.RUnlock()
+		return p
 	}
+	s.pipelineMu.Lock()
 	s.pipeline = resolved.Pipeline
-	return s.pipeline
+	p := clonePipeline(s.pipeline)
+	s.pipelineMu.Unlock()
+	return p
+}
+
+func clonePipeline(p pipeline.Pipeline) pipeline.Pipeline {
+	out := p
+	if p.Entry != nil {
+		entry := *p.Entry
+		entry.Agents = append([]string(nil), p.Entry.Agents...)
+		out.Entry = &entry
+	}
+	out.Steps = append([]pipeline.Step(nil), p.Steps...)
+	for i := range out.Steps {
+		out.Steps[i].Agents = append([]string(nil), out.Steps[i].Agents...)
+	}
+	return out
 }
 
 // ServeHTTP delega al mux interno; lo implementamos explícito para poder
@@ -823,23 +853,24 @@ func (s *Server) overlayRunning(in []Entity) []Entity {
 			e.RunningFlow = flow
 		}
 		// Inyectar counter de rounds al chip magenta del card. RunMax es
-		// el cap compartido; si nunca se disparó un flow para este id,
-		// rounds[id]=0 → RunIter=0, lo cual es el estado correcto (el cap
-		// va al renderer igual, para que se vea "⟳ execute 0/5").
+		// el cap efectivo (dinámico=3, legacy=10); si nunca se disparó un
+		// flow para este id, rounds[id]=0 → RunIter=0, lo cual es correcto (el cap
+		// va al renderer igual, para que se vea "⟳ execute 0/N").
+		cap := loopCapForEntity(e)
 		if e.RunningFlow != "" {
 			e.RunIter = rounds[key]
-			e.RunMax = LoopCap
+			e.RunMax = cap
 		}
-		// Cap-reached chip: rounds >= LoopCap + entity en status loopable.
+		// Cap-reached chip: rounds >= cap efectivo + entity en status loopable.
 		// Gate por status para que cards en closed/closing/idea no prendan
 		// el chip (ahí el cap no tiene sentido — el auto-loop no iba a
 		// dispatchar igual). Sí aplica durante un run (RunningFlow != "")
 		// para cubrir el caso "este run es el #5 y el próximo tick corta".
-		if rounds[key] >= LoopCap {
+		if rounds[key] >= cap {
 			switch e.Status {
 			case "plan", "validated", "executed":
 				e.CapReached = true
-				e.RunMax = LoopCap
+				e.RunMax = cap
 			}
 		}
 		// Computamos gates sobre el estado YA mutado (con RunningFlow del

--- a/internal/dash/server.go
+++ b/internal/dash/server.go
@@ -107,6 +107,7 @@ func Run(ctx context.Context, opts Options, stdout, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
+	srv.pipelineRoot = root
 	mgr, err := pipeline.NewManager(root)
 	if err != nil {
 		return fmt.Errorf("init pipeline manager: %w", err)
@@ -234,9 +235,12 @@ type Server struct {
 	logs *LogStore
 
 	// pipeline es el pipeline activo del repo para gates/auto-loop dinámicos.
-	// NewServer usa pipeline.Default() para tests y mock mode; Run lo reemplaza
-	// por el default resuelto desde `.che/pipelines.config.json` cuando existe.
-	pipeline pipeline.Pipeline
+	// NewServer usa pipeline.Default() para tests y mock mode. Run setea
+	// pipelineRoot y activePipeline() lo re-resuelve por tick para no quedar con
+	// un snapshot stale si el usuario edita `.che/pipelines/` mientras el dash
+	// sigue abierto.
+	pipeline     pipeline.Pipeline
+	pipelineRoot string
 }
 
 // allowedFlows es la allowlist de flows disparables desde el dashboard. Se
@@ -302,6 +306,24 @@ func NewServer(source Source, repoName string, pollInterval int) *Server {
 	s.tmpl = tmpl
 	s.mux = s.buildMux()
 	return s
+}
+
+func (s *Server) activePipeline() pipeline.Pipeline {
+	if s.pipelineRoot == "" {
+		return s.pipeline
+	}
+	mgr, err := pipeline.NewManager(s.pipelineRoot)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dash auto-loop: init pipeline manager failed: %v — using last pipeline snapshot\n", err)
+		return s.pipeline
+	}
+	resolved, err := mgr.Resolve("")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dash auto-loop: resolve pipeline failed: %v — using last pipeline snapshot\n", err)
+		return s.pipeline
+	}
+	s.pipeline = resolved.Pipeline
+	return s.pipeline
 }
 
 // ServeHTTP delega al mux interno; lo implementamos explícito para poder
@@ -909,12 +931,12 @@ func (s *Server) spawnChe(flow string, targetRef, entityKey int, repo string) er
 		}
 	}
 	var cmd *exec.Cmd
-	if step, prRef, ok := runStepFromFlow(flow); ok {
+	if run, ok := decodeDynamicRunFlow(flow); ok {
 		ref := "#" + strconv.Itoa(targetRef)
-		if prRef {
+		if run.PR {
 			ref = "!" + strconv.Itoa(targetRef)
 		}
-		cmd = exec.Command(bin, "run", "--auto", "--from", step, "--input", ref)
+		cmd = exec.Command(bin, "run", "--auto", "--from", run.Step, "--input", ref)
 	} else {
 		cmd = exec.Command(bin, flow, strconv.Itoa(targetRef))
 	}
@@ -922,7 +944,7 @@ func (s *Server) spawnChe(flow string, targetRef, entityKey int, repo string) er
 		cmd.Dir = repo
 	}
 	banner := fmt.Sprintf("che %s %d (en %s)", flow, targetRef, repo)
-	if strings.HasPrefix(flow, "run") {
+	if _, ok := decodeDynamicRunFlow(flow); ok {
 		banner = fmt.Sprintf("che %s (en %s)", strings.Join(cmd.Args[1:], " "), repo)
 	}
 	return s.runCmdWithLogs(cmd, entityKey, banner)

--- a/internal/dash/server_test.go
+++ b/internal/dash/server_test.go
@@ -1441,7 +1441,7 @@ func TestStatusChip_UsesNextPollSec(t *testing.T) {
 // TestOverlayRunning_InjectsRoundsCounter: el chip magenta del card muestra
 // ⟳ <flow> <RunIter>/<RunMax>. Esos campos nunca se asignaban, siempre
 // mostraba "0/0". Ahora overlayRunning lee el counter del loopState y el
-// cap (LoopCap) y los copia al Entity cuando RunningFlow != "".
+// cap efectivo y los copia al Entity cuando RunningFlow != "".
 func TestOverlayRunning_InjectsRoundsCounter(t *testing.T) {
 	src := &fixedSource{snap: Snapshot{LastOK: time.Now()}}
 	s := NewServer(src, "repo", 15)
@@ -1470,6 +1470,22 @@ func TestOverlayRunning_InjectsRoundsCounter(t *testing.T) {
 	// Entity sin flow corriendo no debe tener RunIter/RunMax seteados.
 	if out[1].RunIter != 0 || out[1].RunMax != 0 {
 		t.Errorf("out[1] idle: got RunIter=%d RunMax=%d, want 0/0", out[1].RunIter, out[1].RunMax)
+	}
+}
+
+func TestOverlayRunning_InjectsDynamicRunMax(t *testing.T) {
+	s := NewServer(&fixedSource{snap: Snapshot{LastOK: time.Now()}}, "repo", 15)
+	s.loop.incRounds(42)
+	s.mu.Lock()
+	s.running[42] = "run#:idea"
+	s.mu.Unlock()
+
+	out := s.overlayRunning([]Entity{{Kind: KindIssue, IssueNumber: 42, Status: "idea", StateStep: "idea"}})
+	if out[0].RunIter != 1 {
+		t.Errorf("RunIter: got %d want 1", out[0].RunIter)
+	}
+	if out[0].RunMax != DynamicLoopCap {
+		t.Errorf("RunMax: got %d want %d (DynamicLoopCap)", out[0].RunMax, DynamicLoopCap)
 	}
 }
 

--- a/internal/dash/server_test.go
+++ b/internal/dash/server_test.go
@@ -724,6 +724,47 @@ func TestAction_FusedValidateUsesPR(t *testing.T) {
 	}
 }
 
+func TestResolveTargetRef_FusedPRSideUsesPR(t *testing.T) {
+	e := Entity{Kind: KindFused, IssueNumber: 122, PRNumber: 140}
+	for _, flow := range []string{"validate", "iterate", "close"} {
+		if got := resolveTargetRef(e, flow); got != 140 {
+			t.Errorf("%s target: got %d want PRNumber 140", flow, got)
+		}
+	}
+	for _, flow := range []string{"explore", "execute"} {
+		if got := resolveTargetRef(e, flow); got != 122 {
+			t.Errorf("%s target: got %d want IssueNumber 122", flow, got)
+		}
+	}
+}
+
+func TestAction_KindPRSnapshotRunningBlocksDispatch(t *testing.T) {
+	src := &fixedSource{snap: Snapshot{
+		NWO:    "demo/che",
+		LastOK: time.Now(),
+		Entities: []Entity{
+			{Kind: KindPR, PRNumber: 301, PRTitle: "orphan", Status: "validated", PRVerdict: "changes-requested", RunningFlow: "validate"},
+		},
+	}}
+	s := NewServer(src, "repo", 15)
+	fr := &fakeRunner{}
+	s.runAction = fr.run
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/action/iterate/301", "", nil)
+	if err != nil {
+		t.Fatalf("POST iterate/301: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status: got %d want 409", resp.StatusCode)
+	}
+	if fr.count() != 0 {
+		t.Fatalf("runner calls: got %d want 0", fr.count())
+	}
+}
+
 // TestAction_FusedCloseUsesPR: close en fused también mapea a PRNumber
 // (che close acepta <pr>, no issue). Same pattern que validate/iterate.
 func TestAction_FusedCloseUsesPR(t *testing.T) {
@@ -1186,12 +1227,12 @@ func min(a, b int) int {
 // bumpableSource es una Source que implementa Bumper contando calls.
 // Alrededor de fixedSource — embebe el snapshot y agrega el counter.
 type bumpableSource struct {
-	snap     Snapshot
+	snap      Snapshot
 	bumpCalls atomic.Int64
 }
 
 func (b *bumpableSource) Snapshot() Snapshot { return b.snap }
-func (b *bumpableSource) Bump()                { b.bumpCalls.Add(1) }
+func (b *bumpableSource) Bump()              { b.bumpCalls.Add(1) }
 
 // TestBuildData_NextPollSecIsBaselineWhenIdle: sin flows locales corriendo,
 // NextPollSec == PollInterval (tick regular).
@@ -1495,6 +1536,24 @@ func TestOverlayRunning_SetsCapReachedWhenIdle(t *testing.T) {
 	}
 	if out[0].RunMax != LoopCap {
 		t.Errorf("out[0].RunMax: got %d want %d (cap debe inyectarse aunque no haya run)", out[0].RunMax, LoopCap)
+	}
+}
+
+func TestOverlayRunning_KindPRCapUsesPRKey(t *testing.T) {
+	src := &fixedSource{snap: Snapshot{LastOK: time.Now()}}
+	s := NewServer(src, "repo", 15)
+	for i := 0; i < LoopCap; i++ {
+		s.loop.incRounds(301)
+	}
+	in := []Entity{
+		{Kind: KindPR, PRNumber: 301, Status: "validated", PRVerdict: "changes-requested"},
+	}
+	out := s.overlayRunning(in)
+	if !out[0].CapReached {
+		t.Errorf("KindPR CapReached: got false, want true (rounds keyed by PRNumber)")
+	}
+	if out[0].RunMax != LoopCap {
+		t.Errorf("KindPR RunMax: got %d want %d", out[0].RunMax, LoopCap)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Resolve the dashboard's active pipeline and preserve parsed `che:state:<step>` metadata on entities.
- Add dynamic auto-loop dispatch from the current pipeline step to the next step via `che run --auto --from <step>`.
- Add a pipeline-step preflight gate that respects lock/applying state and the per-entity loop cap path remains unchanged.

## Tests
- `go test ./...`

Closes #68