### PR TITLE
feat(#58): add generic pipeline dash UI

### DIFF
--- a/internal/dash/server.go
+++ b/internal/dash/server.go
@@ -370,6 +370,8 @@ type pageData struct {
 	Columns      []columnData
 	Snapshot     Snapshot
 	PollInterval int
+	Pipeline     pipeline.Pipeline
+	ColCount     int
 	// NextPollSec es el intervalo que el partial board-partial va a pasar
 	// al hx-trigger del wrapper. Adaptivo: cuando hay flows locales en curso
 	// (s.running no vacío) bajamos a hotPollSec; en idle usamos PollInterval.
@@ -407,8 +409,20 @@ const hotPollSec = 3
 // humano — se refleja como chip "auto" en el drawer.
 type drawerData struct {
 	Entity
-	NWO  string
-	Auto bool
+	NWO           string
+	Auto          bool
+	PipelineSteps []drawerStepData
+}
+
+type drawerStepData struct {
+	Name       string
+	Agents     []string
+	Aggregator pipeline.Aggregator
+	Comment    string
+	Current    bool
+	Applying   bool
+	Flow       string
+	Gate       FlowGate
 }
 
 // columnData representa una columna del Kanban con sus entidades ya
@@ -416,7 +430,7 @@ type drawerData struct {
 // trabajo activo en una columna transient (RunningFlow != "" en alguna
 // entidad de planning, executing, validating o closing).
 type columnData struct {
-	Key      string // 1 de los 9: idea | planning | plan | executing | executed | validating | validated | closing | closed
+	Key      string
 	Title    string
 	Hot      bool
 	Entities []Entity
@@ -475,6 +489,55 @@ func groupByColumn(entities []Entity) []columnData {
 		})
 	}
 	return out
+}
+
+func groupByPipelineColumn(entities []Entity, p pipeline.Pipeline) []columnData {
+	if len(p.Steps) == 0 || isDefaultPipeline(p) {
+		return groupByColumn(entities)
+	}
+	stepSet := make(map[string]bool, len(p.Steps))
+	for _, step := range p.Steps {
+		stepSet[step.Name] = true
+	}
+	buckets := map[string][]Entity{}
+	hot := map[string]bool{}
+	for _, e := range entities {
+		col := e.Column()
+		if e.StateStep != "" && stepSet[e.StateStep] {
+			col = e.StateStep
+		}
+		buckets[col] = append(buckets[col], e)
+		if e.RunningFlow != "" || e.StateApplying {
+			hot[col] = true
+		}
+	}
+	out := make([]columnData, 0, len(p.Steps)+1)
+	if len(buckets["adopt"]) > 0 {
+		out = append(out, columnData{Key: "adopt", Title: "adopt", Hot: hot["adopt"], Entities: buckets["adopt"]})
+	}
+	for _, step := range p.Steps {
+		out = append(out, columnData{Key: step.Name, Title: step.Name, Hot: hot[step.Name], Entities: buckets[step.Name]})
+	}
+	for _, c := range columnsOrder {
+		if c.Key == "adopt" || stepSet[c.Key] || len(buckets[c.Key]) == 0 {
+			continue
+		}
+		out = append(out, columnData{Key: c.Key, Title: c.Title, Hot: hot[c.Key], Entities: buckets[c.Key]})
+	}
+	return out
+}
+
+func isDefaultPipeline(p pipeline.Pipeline) bool {
+	def := pipeline.Default()
+	if len(p.Steps) != len(def.Steps) {
+		return false
+	}
+	for i := range p.Steps {
+		if p.Steps[i].Name != def.Steps[i].Name {
+			return false
+		}
+	}
+	return true
 }
 
 // templateFuncs son las funciones expuestas a los templates. Son helpers de
@@ -588,8 +651,17 @@ func (s *Server) templateFuncs() template.FuncMap {
 		// gateOf devuelve el FlowGate para un flow puntual con un fallback
 		// "Available=true" si gates es nil (no rompe templates pre-gates,
 		// p.ej. tests que arman drawerData a mano).
-		"gateOf": gateOf,
+		"gateOf":      gateOf,
+		"displayFlow": displayFlow,
+		"joinStrings": strings.Join,
 	}
+}
+
+func displayFlow(flow string) string {
+	if run, ok := decodeDynamicRunFlow(flow); ok {
+		return "run --from " + run.Step
+	}
+	return flow
 }
 
 // FlowBtnState es el resultado de resolver el estado UI de un botón de
@@ -729,6 +801,7 @@ func errShort(err error) string {
 // snapshot antes de agrupar — el dash se ve idéntico a pre-adopt-mode.
 // Con adopt=true, esas entities pasan y se agrupan en la columna "adopt".
 func (s *Server) buildData(adopt bool) pageData {
+	activePipeline := s.activePipeline()
 	snap := s.source.Snapshot()
 	snap.Entities = s.overlayRunning(snap.Entities)
 	if !adopt {
@@ -764,7 +837,7 @@ func (s *Server) buildData(adopt bool) pageData {
 	if hot && next > hotPollSec {
 		next = hotPollSec
 	}
-	cols := groupByColumn(snap.Entities)
+	cols := groupByPipelineColumn(snap.Entities, activePipeline)
 	if !adopt {
 		// Con el toggle OFF también dropeamos la columna "adopt" para que el
 		// board quede idéntico a como estaba pre-feature (9 columnas, no 10).
@@ -782,6 +855,8 @@ func (s *Server) buildData(adopt bool) pageData {
 		Columns:      cols,
 		Snapshot:     snap,
 		PollInterval: s.pollInterval,
+		Pipeline:     activePipeline,
+		ColCount:     len(cols),
 		NextPollSec:  next,
 		ActiveLoops:  active,
 		Version:      s.version,
@@ -801,6 +876,7 @@ func (s *Server) buildData(adopt bool) pageData {
 // Clave canónica: IssueNumber para KindIssue/KindFused, PRNumber para
 // KindPR (adopt sin issue linkeado). Ver Entity.EntityKey.
 func (s *Server) findEntity(id int) (Entity, bool) {
+	activePipeline := s.activePipeline()
 	for _, e := range s.source.Snapshot().Entities {
 		if e.EntityKey() == id {
 			s.mu.Lock()
@@ -813,10 +889,35 @@ func (s *Server) findEntity(id int) (Entity, bool) {
 			// RunningFlow per se. Si en el futuro alguna gate consulta
 			// RunningFlow, el orden ya está bien (overlay primero).
 			e.Gates = computeGates(e)
+			for _, step := range activePipeline.Steps {
+				flow := encodeDynamicRunFlow(dynamicRunFlow{Step: step.Name, PR: e.Kind == KindPR || (e.Kind == KindFused && e.PRNumber > 0)})
+				e.Gates[flow] = gatePipelineRunFrom(e, activePipeline, step.Name)
+			}
 			return e, true
 		}
 	}
 	return Entity{}, false
+}
+
+func buildDrawerSteps(e Entity, p pipeline.Pipeline) []drawerStepData {
+	if len(p.Steps) == 0 || e.StateStep == "" || isDefaultPipeline(p) {
+		return nil
+	}
+	out := make([]drawerStepData, 0, len(p.Steps))
+	for _, step := range p.Steps {
+		flow := encodeDynamicRunFlow(dynamicRunFlow{Step: step.Name, PR: e.Kind == KindPR || (e.Kind == KindFused && e.PRNumber > 0)})
+		out = append(out, drawerStepData{
+			Name:       step.Name,
+			Agents:     append([]string(nil), step.Agents...),
+			Aggregator: step.Aggregator,
+			Comment:    step.Comment,
+			Current:    step.Name == e.StateStep,
+			Applying:   step.Name == e.StateStep && e.StateApplying,
+			Flow:       flow,
+			Gate:       gatePipelineRunFrom(e, p, step.Name),
+		})
+	}
+	return out
 }
 
 // overlayRunning aplica el estado local (s.running) sobre un slice de
@@ -1237,7 +1338,8 @@ func (s *Server) buildMux() *http.ServeMux {
 		// Wrapper drawerData: el template necesita NWO para armar URLs a GH
 		// en los refs del header; Entity pelada no lo lleva. Auto (step 6)
 		// indica si el RunningFlow fue disparado por el auto-loop engine.
-		data := drawerData{Entity: entity, NWO: s.source.Snapshot().NWO, Auto: s.isAutoRunning(id)}
+		activePipeline := s.activePipeline()
+		data := drawerData{Entity: entity, NWO: s.source.Snapshot().NWO, Auto: s.isAutoRunning(id), PipelineSteps: buildDrawerSteps(entity, activePipeline)}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.Header().Set("Cache-Control", "no-store")
 		if err := s.tmpl.ExecuteTemplate(w, "drawer.html.tmpl", data); err != nil {
@@ -1258,6 +1360,56 @@ func (s *Server) buildMux() *http.ServeMux {
 	// flow se valida contra allowedFlows antes de pasarlo a exec.Command.
 	// Responde con el partial del drawer refreshado (que ahora mostrará
 	// el chip ⟳ y los botones disabled por RunningFlow != "").
+	mux.HandleFunc("POST /action/run/{step}/{id}", func(w http.ResponseWriter, r *http.Request) {
+		step := r.PathValue("step")
+		idStr := r.PathValue("id")
+		id, err := strconv.Atoi(idStr)
+		if err != nil {
+			http.Error(w, "invalid id", http.StatusBadRequest)
+			return
+		}
+		entity, ok := s.findEntity(id)
+		if !ok {
+			http.Error(w, "entity not found", http.StatusNotFound)
+			return
+		}
+		activePipeline := s.activePipeline()
+		flow := encodeDynamicRunFlow(dynamicRunFlow{Step: step, PR: entity.Kind == KindPR || (entity.Kind == KindFused && entity.PRNumber > 0)})
+		gate := gatePipelineRunFrom(entity, activePipeline, step)
+		if !gate.Available {
+			reason := gate.Reason
+			if reason == "" {
+				reason = "step no disponible para esta entity"
+			}
+			http.Error(w, reason, http.StatusConflict)
+			return
+		}
+		if _, okRes := s.markRunning(id, flow); !okRes {
+			http.Error(w, "flow already running for this entity", http.StatusConflict)
+			return
+		}
+		s.loop.incRounds(id)
+		targetRef := entity.EntityKey()
+		if run, ok := decodeDynamicRunFlow(flow); ok && run.PR {
+			targetRef = entity.PRNumber
+		}
+		if err := s.runAction(flow, targetRef, id, s.repoPath); err != nil {
+			s.clearRunning(id)
+			http.Error(w, "spawn failed: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+		s.bumpSource()
+		entity.RunningFlow = flow
+		entity.Gates[flow] = gate
+		data := drawerData{Entity: entity, NWO: s.source.Snapshot().NWO, Auto: false, PipelineSteps: buildDrawerSteps(entity, activePipeline)}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-store")
+		if err := s.tmpl.ExecuteTemplate(w, "drawer.html.tmpl", data); err != nil {
+			http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
+
 	mux.HandleFunc("POST /action/{flow}/{id}", func(w http.ResponseWriter, r *http.Request) {
 		flow := r.PathValue("flow")
 		if !allowedFlows[flow] {
@@ -1333,7 +1485,8 @@ func (s *Server) buildMux() *http.ServeMux {
 		// y los botones disabled sin esperar al próximo poll. Auto=false
 		// porque este dispatch vino del handler manual.
 		entity.RunningFlow = flow
-		data := drawerData{Entity: entity, NWO: s.source.Snapshot().NWO, Auto: false}
+		activePipeline := s.activePipeline()
+		data := drawerData{Entity: entity, NWO: s.source.Snapshot().NWO, Auto: false, PipelineSteps: buildDrawerSteps(entity, activePipeline)}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.Header().Set("Cache-Control", "no-store")
 		if err := s.tmpl.ExecuteTemplate(w, "drawer.html.tmpl", data); err != nil {

--- a/internal/dash/server.go
+++ b/internal/dash/server.go
@@ -33,6 +33,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -533,7 +534,10 @@ func isDefaultPipeline(p pipeline.Pipeline) bool {
 		return false
 	}
 	for i := range p.Steps {
-		if p.Steps[i].Name != def.Steps[i].Name {
+		if p.Steps[i].Name != def.Steps[i].Name ||
+			p.Steps[i].Aggregator != def.Steps[i].Aggregator ||
+			p.Steps[i].Comment != def.Steps[i].Comment ||
+			!slices.Equal(p.Steps[i].Agents, def.Steps[i].Agents) {
 			return false
 		}
 	}
@@ -918,6 +922,15 @@ func buildDrawerSteps(e Entity, p pipeline.Pipeline) []drawerStepData {
 		})
 	}
 	return out
+}
+
+func (s *Server) newDrawerData(e Entity, auto bool, p pipeline.Pipeline) drawerData {
+	return drawerData{
+		Entity:        e,
+		NWO:           s.source.Snapshot().NWO,
+		Auto:          auto,
+		PipelineSteps: buildDrawerSteps(e, p),
+	}
 }
 
 // overlayRunning aplica el estado local (s.running) sobre un slice de
@@ -1339,7 +1352,7 @@ func (s *Server) buildMux() *http.ServeMux {
 		// en los refs del header; Entity pelada no lo lleva. Auto (step 6)
 		// indica si el RunningFlow fue disparado por el auto-loop engine.
 		activePipeline := s.activePipeline()
-		data := drawerData{Entity: entity, NWO: s.source.Snapshot().NWO, Auto: s.isAutoRunning(id), PipelineSteps: buildDrawerSteps(entity, activePipeline)}
+		data := s.newDrawerData(entity, s.isAutoRunning(id), activePipeline)
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.Header().Set("Cache-Control", "no-store")
 		if err := s.tmpl.ExecuteTemplate(w, "drawer.html.tmpl", data); err != nil {
@@ -1375,6 +1388,8 @@ func (s *Server) buildMux() *http.ServeMux {
 		}
 		activePipeline := s.activePipeline()
 		flow := encodeDynamicRunFlow(dynamicRunFlow{Step: step, PR: entity.Kind == KindPR || (entity.Kind == KindFused && entity.PRNumber > 0)})
+		// No hay allowlist constante para steps: la whitelist dinámica es el
+		// pipeline activo, validado por gatePipelineRunFrom(step ∈ p.Steps).
 		gate := gatePipelineRunFrom(entity, activePipeline, step)
 		if !gate.Available {
 			reason := gate.Reason
@@ -1401,7 +1416,7 @@ func (s *Server) buildMux() *http.ServeMux {
 		s.bumpSource()
 		entity.RunningFlow = flow
 		entity.Gates[flow] = gate
-		data := drawerData{Entity: entity, NWO: s.source.Snapshot().NWO, Auto: false, PipelineSteps: buildDrawerSteps(entity, activePipeline)}
+		data := s.newDrawerData(entity, false, activePipeline)
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.Header().Set("Cache-Control", "no-store")
 		if err := s.tmpl.ExecuteTemplate(w, "drawer.html.tmpl", data); err != nil {
@@ -1486,7 +1501,7 @@ func (s *Server) buildMux() *http.ServeMux {
 		// porque este dispatch vino del handler manual.
 		entity.RunningFlow = flow
 		activePipeline := s.activePipeline()
-		data := drawerData{Entity: entity, NWO: s.source.Snapshot().NWO, Auto: false, PipelineSteps: buildDrawerSteps(entity, activePipeline)}
+		data := s.newDrawerData(entity, false, activePipeline)
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.Header().Set("Cache-Control", "no-store")
 		if err := s.tmpl.ExecuteTemplate(w, "drawer.html.tmpl", data); err != nil {

--- a/internal/dash/server_test.go
+++ b/internal/dash/server_test.go
@@ -10,6 +10,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/chichex/che/internal/pipeline"
 )
 
 // TestListenWithFallback_PicksNextWhenBusy: motivación del cambio — correr
@@ -1928,6 +1930,99 @@ func TestDrawerKindPR_PostAdoptValidated(t *testing.T) {
 	// a validated — antes se renderizaba hardcodeado para todo KindPR.
 	if strings.Contains(got, `>adopt</span>`) {
 		t.Errorf("KindPR validated drawer: chip 'adopt' no debería aparecer post-adopt")
+	}
+}
+
+func TestBuildData_CustomPipelineUsesStepColumns(t *testing.T) {
+	src := &fixedSource{snap: Snapshot{
+		LastOK: time.Now(),
+		Entities: []Entity{
+			{Kind: KindIssue, IssueNumber: 42, Status: "build", StateStep: "build", IssueTitle: "compile"},
+		},
+	}}
+	s := NewServer(src, "repo", 15)
+	s.pipeline = pipeline.Pipeline{Version: pipeline.CurrentVersion, Steps: []pipeline.Step{
+		{Name: "spec", Agents: []string{"claude-sonnet"}},
+		{Name: "build", Agents: []string{"claude-opus"}},
+		{Name: "ship", Agents: []string{"claude-haiku"}},
+	}}
+
+	data := s.buildData(false)
+	if data.ColCount != 3 {
+		t.Fatalf("ColCount: got %d want 3", data.ColCount)
+	}
+	want := []string{"spec", "build", "ship"}
+	for i, key := range want {
+		if data.Columns[i].Key != key {
+			t.Fatalf("Columns[%d].Key: got %q want %q (all=%+v)", i, data.Columns[i].Key, key, data.Columns)
+		}
+	}
+	if len(data.Columns[1].Entities) != 1 || data.Columns[1].Entities[0].IssueNumber != 42 {
+		t.Fatalf("build column entities: got %+v", data.Columns[1].Entities)
+	}
+}
+
+func TestDrawer_CustomPipelineRendersStepActions(t *testing.T) {
+	src := &fixedSource{snap: Snapshot{
+		LastOK: time.Now(),
+		NWO:    "demo/che",
+		Entities: []Entity{
+			{Kind: KindIssue, IssueNumber: 42, Status: "build", StateStep: "build", IssueTitle: "compile"},
+		},
+	}}
+	s := NewServer(src, "repo", 15)
+	s.pipeline = pipeline.Pipeline{Version: pipeline.CurrentVersion, Steps: []pipeline.Step{
+		{Name: "spec", Agents: []string{"claude-sonnet"}},
+		{Name: "build", Agents: []string{"claude-opus", "claude-haiku"}, Aggregator: pipeline.AggregatorFirstBlocker, Comment: "compile checks"},
+	}}
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/drawer/42")
+	if err != nil {
+		t.Fatalf("GET drawer: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	got := string(body)
+	for _, want := range []string{
+		`hx-post="/action/run/build/42"`,
+		`claude-opus, claude-haiku`,
+		`compile checks`,
+		`che run --manual --from &lt;step&gt;`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("drawer missing %q\nbody=%s", want, got)
+		}
+	}
+}
+
+func TestActionRunFrom_CustomPipelineCallsDynamicRun(t *testing.T) {
+	src := &fixedSource{snap: Snapshot{
+		LastOK: time.Now(),
+		NWO:    "demo/che",
+		Entities: []Entity{
+			{Kind: KindIssue, IssueNumber: 42, Status: "build", StateStep: "build", IssueTitle: "compile"},
+		},
+	}}
+	s := NewServer(src, "repo", 15)
+	s.pipeline = pipeline.Pipeline{Version: pipeline.CurrentVersion, Steps: []pipeline.Step{{Name: "build", Agents: []string{"claude-opus"}}}}
+	fr := &fakeRunner{}
+	s.runAction = fr.run
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/action/run/build/42", "", nil)
+	if err != nil {
+		t.Fatalf("POST run/build: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200", resp.StatusCode)
+	}
+	got := fr.last()
+	if got.Flow != "run#:build" || got.TargetRef != 42 || got.EntityKey != 42 {
+		t.Fatalf("runner call: got %+v want flow=run#:build target=42 key=42", got)
 	}
 }
 

--- a/internal/dash/server_test.go
+++ b/internal/dash/server_test.go
@@ -1,6 +1,7 @@
 package dash
 
 import (
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -2024,6 +2025,154 @@ func TestActionRunFrom_CustomPipelineCallsDynamicRun(t *testing.T) {
 	if got.Flow != "run#:build" || got.TargetRef != 42 || got.EntityKey != 42 {
 		t.Fatalf("runner call: got %+v want flow=run#:build target=42 key=42", got)
 	}
+}
+
+func TestActionRunFrom_RejectsUnknownStep(t *testing.T) {
+	_, fr, ts := newCustomPipelineRunServer(t, Entity{Kind: KindIssue, IssueNumber: 42, Status: "build", StateStep: "build"})
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/action/run/ship/42", "", nil)
+	if err != nil {
+		t.Fatalf("POST run/ship: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status: got %d want 409 body=%s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "step ship no existe") {
+		t.Fatalf("body: got %q want unknown-step reason", body)
+	}
+	if fr.count() != 0 {
+		t.Fatalf("runner calls: got %d want 0", fr.count())
+	}
+}
+
+func TestActionRunFrom_RejectsNonCurrentStep(t *testing.T) {
+	_, fr, ts := newCustomPipelineRunServer(t, Entity{Kind: KindIssue, IssueNumber: 42, Status: "build", StateStep: "build"})
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/action/run/spec/42", "", nil)
+	if err != nil {
+		t.Fatalf("POST run/spec: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status: got %d want 409 body=%s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "run dinámico debe reanudar desde build, no spec") {
+		t.Fatalf("body: got %q want current-step reason", body)
+	}
+	if fr.count() != 0 {
+		t.Fatalf("runner calls: got %d want 0", fr.count())
+	}
+}
+
+func TestActionRunFrom_NotFound(t *testing.T) {
+	_, fr, ts := newCustomPipelineRunServer(t, Entity{Kind: KindIssue, IssueNumber: 42, Status: "build", StateStep: "build"})
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/action/run/build/99", "", nil)
+	if err != nil {
+		t.Fatalf("POST run/build/99: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status: got %d want 404", resp.StatusCode)
+	}
+	if fr.count() != 0 {
+		t.Fatalf("runner calls: got %d want 0", fr.count())
+	}
+}
+
+func TestActionRunFrom_RejectsRunningEntity(t *testing.T) {
+	_, fr, ts := newCustomPipelineRunServer(t, Entity{Kind: KindIssue, IssueNumber: 42, Status: "build", StateStep: "build", RunningFlow: "run#:build"})
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/action/run/build/42", "", nil)
+	if err != nil {
+		t.Fatalf("POST run/build: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status: got %d want 409 body=%s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "flow already running") {
+		t.Fatalf("body: got %q want already-running reason", body)
+	}
+	if fr.count() != 0 {
+		t.Fatalf("runner calls: got %d want 0", fr.count())
+	}
+}
+
+func TestActionRunFrom_RunActionFailureClearsRunning(t *testing.T) {
+	s, fr, ts := newCustomPipelineRunServer(t, Entity{Kind: KindIssue, IssueNumber: 42, Status: "build", StateStep: "build"})
+	fr.err = errors.New("boom")
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/action/run/build/42", "", nil)
+	if err != nil {
+		t.Fatalf("POST run/build: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status: got %d want 500 body=%s", resp.StatusCode, body)
+	}
+	if fr.count() != 1 {
+		t.Fatalf("runner calls: got %d want 1", fr.count())
+	}
+	s.mu.Lock()
+	_, stillRunning := s.running[42]
+	s.mu.Unlock()
+	if stillRunning {
+		t.Fatalf("running overlay for entity 42 was not cleared after spawn failure")
+	}
+}
+
+func TestActionRunFrom_RejectsLockedEntity(t *testing.T) {
+	_, fr, ts := newCustomPipelineRunServer(t, Entity{Kind: KindIssue, IssueNumber: 42, Status: "build", StateStep: "build", Locked: true})
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/action/run/build/42", "", nil)
+	if err != nil {
+		t.Fatalf("POST run/build: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status: got %d want 409 body=%s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "locked") {
+		t.Fatalf("body: got %q want locked reason", body)
+	}
+	if fr.count() != 0 {
+		t.Fatalf("runner calls: got %d want 0", fr.count())
+	}
+}
+
+func TestIsDefaultPipeline_ConsidersAgentChangesCustom(t *testing.T) {
+	p := pipeline.Default()
+	p.Steps[0].Agents = []string{"claude-sonnet"}
+	if isDefaultPipeline(p) {
+		t.Fatalf("pipeline with default step names but changed agents should be treated as custom")
+	}
+}
+
+func newCustomPipelineRunServer(t *testing.T, e Entity) (*Server, *fakeRunner, *httptest.Server) {
+	t.Helper()
+	src := &fixedSource{snap: Snapshot{LastOK: time.Now(), NWO: "demo/che", Entities: []Entity{e}}}
+	s := NewServer(src, "repo", 15)
+	s.pipeline = pipeline.Pipeline{Version: pipeline.CurrentVersion, Steps: []pipeline.Step{
+		{Name: "spec", Agents: []string{"claude-sonnet"}},
+		{Name: "build", Agents: []string{"claude-opus"}},
+	}}
+	fr := &fakeRunner{}
+	s.runAction = fr.run
+	ts := httptest.NewServer(s)
+	return s, fr, ts
 }
 
 // TestColumn_Adopt: Entity.Column() devuelve "adopt" cuando Status=="adopt".

--- a/internal/dash/templates/board.html.tmpl
+++ b/internal/dash/templates/board.html.tmpl
@@ -72,10 +72,11 @@
               <div class="card-title">{{if .PRTitle}}{{.PRTitle}}{{else}}{{.IssueTitle}}{{end}}</div>
               <div class="card-chips">
                 {{if eq .Status "adopt"}}<span class="chip chip-orange" title="PR con close-keyword a un issue sin labels che:* — adoptable desde acá">adopt</span>{{end}}
+                {{if .StateStep}}<span class="chip chip-cyan">{{if .StateApplying}}applying:{{end}}{{.StateStep}}</span>{{end}}
                 {{if .PRVerdict}}<span class="chip {{verdictChipClass .PRVerdict}}">validated:{{.PRVerdict}}</span>{{end}}
                 {{if checksLabel . }}<span class="chip {{checksChipClass .}}">{{checksLabel .}}</span>{{end}}
                 {{if .Locked}}<span class="chip chip-lock">🔒 locked</span>{{end}}
-                {{if .RunningFlow}}<span class="chip chip-magenta">⟳ {{.RunningFlow}} {{.RunIter}}/{{.RunMax}}</span>{{end}}
+                {{if .RunningFlow}}<span class="chip chip-magenta">⟳ {{displayFlow .RunningFlow}} {{.RunIter}}/{{.RunMax}}</span>{{end}}
                 {{if .CapReached}}<span class="chip chip-cap" title="auto-loop detenido: alcanzó el cap de {{.RunMax}} rondas. Re-corré che manualmente para seguir.">⛔ cap {{.RunMax}}/{{.RunMax}}</span>{{end}}
               </div>
             {{else if eq .Kind 2}}
@@ -87,8 +88,9 @@
               <div class="card-title">{{.PRTitle}}</div>
               <div class="card-chips">
                 <span class="chip chip-orange" title="PR sin close-keyword — adoptable desde acá (validate / close)">adopt</span>
+                {{if .StateStep}}<span class="chip chip-cyan">{{if .StateApplying}}applying:{{end}}{{.StateStep}}</span>{{end}}
                 {{if checksLabel . }}<span class="chip {{checksChipClass .}}">{{checksLabel .}}</span>{{end}}
-                {{if .RunningFlow}}<span class="chip chip-magenta">⟳ {{.RunningFlow}} {{.RunIter}}/{{.RunMax}}</span>{{end}}
+                {{if .RunningFlow}}<span class="chip chip-magenta">⟳ {{displayFlow .RunningFlow}} {{.RunIter}}/{{.RunMax}}</span>{{end}}
               </div>
             {{else}}
               {{/* Issue-only: ref del issue (clickable) + título del issue */}}
@@ -98,11 +100,12 @@
               <div class="card-title">{{.IssueTitle}}</div>
               <div class="card-chips">
                 <span class="chip chip-cyan">ct:plan</span>
+                {{if .StateStep}}<span class="chip chip-cyan">{{if .StateApplying}}applying:{{end}}{{.StateStep}}</span>{{end}}
                 {{if .Type}}<span class="chip {{typeChipClass .Type}}">type:{{.Type}}</span>{{end}}
                 {{if .Size}}<span class="chip">size:{{.Size}}</span>{{end}}
                 {{if .PlanVerdict}}<span class="chip {{verdictChipClass .PlanVerdict}}">plan-validated:{{.PlanVerdict}}</span>{{end}}
                 {{if .Locked}}<span class="chip chip-lock">🔒 locked</span>{{end}}
-                {{if .RunningFlow}}<span class="chip chip-magenta">⟳ {{.RunningFlow}} {{.RunIter}}/{{.RunMax}}</span>{{end}}
+                {{if .RunningFlow}}<span class="chip chip-magenta">⟳ {{displayFlow .RunningFlow}} {{.RunIter}}/{{.RunMax}}</span>{{end}}
                 {{if .CapReached}}<span class="chip chip-cap" title="auto-loop detenido: alcanzó el cap de {{.RunMax}} rondas. Re-corré che manualmente para seguir.">⛔ cap {{.RunMax}}/{{.RunMax}}</span>{{end}}
               </div>
             {{end}}
@@ -124,11 +127,11 @@
      auto-loop salen como OOB swaps — HTMX los aplica aunque el target
      principal sea outerHTML. El flag adopt se propaga al hx-get para que
      el toggle del header no se pierda entre polls. --col-count ajusta el
-     grid-template (9 columnas default, 10 con adopt). */}}
+     grid-template al pipeline activo. */}}
 {{template "status-chip" .}}
 {{template "auto-loop-toggle" .Loop}}
 <div id="dash-board" class="dash-board"
-     style="--col-count: {{if .Adopt}}10{{else}}9{{end}};"
+     style="--col-count: {{.ColCount}};"
      hx-get="/board{{if .Adopt}}?adopt=1{{end}}"
      hx-trigger="every {{.NextPollSec}}s"
      hx-swap="outerHTML">

--- a/internal/dash/templates/dashboard.html.tmpl
+++ b/internal/dash/templates/dashboard.html.tmpl
@@ -946,9 +946,9 @@
          (con id=dash-board del partial) tiene solo "every NextPollSec s".
          El polling es adaptivo: idle → PollInterval, hot (hay flows locales
          en curso) → hotPollSec. Ver buildData.NextPollSec.
-         --col-count: adopt OFF → 9 columnas, adopt ON → 10. */}}
+         --col-count sigue la cantidad de columnas del pipeline activo. */}}
     <div id="dash-board" class="dash-board"
-         style="--col-count: {{if .Adopt}}10{{else}}9{{end}};"
+         style="--col-count: {{.ColCount}};"
          hx-get="/board{{if .Adopt}}?adopt=1{{end}}"
          hx-trigger="load delay:200ms, every {{.NextPollSec}}s"
          hx-swap="outerHTML">

--- a/internal/dash/templates/drawer.html.tmpl
+++ b/internal/dash/templates/drawer.html.tmpl
@@ -13,6 +13,34 @@
 {{/* $key es la clave canónica del routing: IssueNumber para KindIssue/Fused,
      PRNumber para KindPR (adopt sin issue linkeado). Se usa en hx-post,
      data-entity y SSE stream. Ver Entity.EntityKey. */}}
+{{define "pipeline-step-actions"}}
+  {{if .PipelineSteps}}
+    {{$key := .IssueNumber}}{{if eq .Kind 2}}{{$key = .PRNumber}}{{end}}
+    <div class="drawer-meta pipeline-meta">
+      <dt>pipeline</dt><dd>steps del pipeline activo; el step actual queda habilitado para reanudar con <code>che run --auto --from</code></dd>
+      {{range .PipelineSteps}}
+        <dt>{{if .Current}}actual{{else}}step{{end}}</dt>
+        <dd><code>{{.Name}}</code>{{if .Applying}} · applying{{end}}{{if .Agents}} · agents: {{joinStrings .Agents ", "}}{{end}}{{if .Aggregator}} · {{.Aggregator}}{{end}}{{if .Comment}} · {{.Comment}}{{end}}</dd>
+      {{end}}
+    </div>
+    <div class="drawer-actions pipeline-actions">
+      {{range .PipelineSteps}}
+        {{$btn := flowBtnState .Flow $.RunningFlow $.Gates (printf "run --from %s" .Name)}}
+        <button class="btn {{if .Current}}primary{{else}}ghost{{end}}"
+                hx-post="/action/run/{{.Name}}/{{$key}}"
+                hx-target="#modal-slot"
+                hx-swap="innerHTML"
+                {{if $btn.Disabled}}disabled{{end}} title="{{$btn.Title}}">{{.Name}}</button>
+      {{end}}
+      <span class="needs-human-hint" style="color:var(--muted); font-size: 11px; padding: 6px 0;">manual: elegí agentes desde <code>che run --manual --from &lt;step&gt;</code></span>
+    </div>
+    {{if not .RunningFlow}}
+      <div class="drawer-blocked-reasons">
+        {{range .PipelineSteps}}{{if not .Gate.Available}}<div class="reason"><span class="flow">{{.Name}}</span> ⛔ {{.Gate.Reason}}</div>{{end}}{{end}}
+      </div>
+    {{end}}
+  {{end}}
+{{end}}
 {{$key := .IssueNumber}}{{if eq .Kind 2}}{{$key = .PRNumber}}{{end}}
 <div class="modal-backdrop">
 <div class="modal" data-entity="{{$key}}" data-tab="pr">
@@ -45,11 +73,13 @@
         {{if checksLabel .Entity }}<span class="chip {{checksChipClass .Entity}}">{{checksLabel .Entity}}</span>{{end}}
         {{if .PRVerdict}}<span class="chip {{verdictChipClass .PRVerdict}}">validated:{{.PRVerdict}}</span>{{end}}
         {{if .Locked}}<span class="chip chip-lock">🔒 locked</span>{{end}}
-        {{if .RunningFlow}}<span class="chip chip-magenta">⟳ {{.RunningFlow}} {{.RunIter}}/{{.RunMax}}</span>{{end}}
+        {{if .RunningFlow}}<span class="chip chip-magenta">⟳ {{displayFlow .RunningFlow}} {{.RunIter}}/{{.RunMax}}</span>{{end}}
         {{if and .RunningFlow .Auto}}<span class="chip chip-magenta" title="disparado por el auto-loop engine">auto</span>{{end}}
         {{if .CapReached}}<span class="chip chip-cap" title="auto-loop detenido: alcanzó el cap de {{.RunMax}} rondas. Re-corré che manualmente para seguir.">⛔ cap {{.RunMax}}/{{.RunMax}}</span>{{end}}
       </div>
     </div>
+
+    {{template "pipeline-step-actions" .}}
 
     <div class="drawer-actions">
       {{/* Botones por Status (espejo del bloque fused, líneas 161+):
@@ -109,7 +139,7 @@
 
     <div class="drawer-logs">
       <div class="drawer-logs-hdr">
-        <span><b>stream</b>{{if .RunningFlow}} · claude {{.RunningFlow}} · run {{.RunIter}}{{end}}</span>
+        <span><b>stream</b>{{if .RunningFlow}} · claude {{displayFlow .RunningFlow}} · run {{.RunIter}}{{end}}</span>
         <div class="ctl">
           <span class="on">● auto-scroll</span>
           <span>pause</span>
@@ -160,7 +190,7 @@
                gracias al embedding. */}}
           {{if checksLabel .Entity }}<span class="chip {{checksChipClass .Entity}}">{{checksLabel .Entity}}</span>{{end}}
           {{if .Locked}}<span class="chip chip-lock">🔒 locked</span>{{end}}
-          {{if .RunningFlow}}<span class="chip chip-magenta">⟳ {{.RunningFlow}} {{.RunIter}}/{{.RunMax}}</span>{{end}}
+          {{if .RunningFlow}}<span class="chip chip-magenta">⟳ {{displayFlow .RunningFlow}} {{.RunIter}}/{{.RunMax}}</span>{{end}}
           {{if and .RunningFlow .Auto}}<span class="chip chip-magenta" title="disparado por el auto-loop engine">auto</span>{{end}}
           {{if .CapReached}}<span class="chip chip-cap" title="auto-loop detenido: alcanzó el cap de {{.RunMax}} rondas. Re-corré che manualmente para seguir.">⛔ cap {{.RunMax}}/{{.RunMax}}</span>{{end}}
         </div>
@@ -180,6 +210,8 @@
         {{end}}
         {{if .PRVerdict}}<dt>verdict</dt><dd style="color:{{verdictColor .PRVerdict}}">validated:{{.PRVerdict}}</dd>{{end}}
       </div>
+
+      {{template "pipeline-step-actions" .}}
 
       <div class="drawer-actions">
         {{/* Botones fire-and-forget: hx-post lanza el subcomando y swapea
@@ -255,7 +287,7 @@
 
       <div class="drawer-logs">
         <div class="drawer-logs-hdr">
-          <span><b>stream</b>{{if .RunningFlow}} · claude {{.RunningFlow}} · run {{.RunIter}}{{end}}</span>
+          <span><b>stream</b>{{if .RunningFlow}} · claude {{displayFlow .RunningFlow}} · run {{.RunIter}}{{end}}</span>
           <div class="ctl">
             <span class="on">● auto-scroll</span>
             <span>pause</span>
@@ -338,7 +370,7 @@
         {{if .Size}}<span class="chip">size:{{.Size}}</span>{{end}}
         {{if .PlanVerdict}}<span class="chip {{verdictChipClass .PlanVerdict}}">plan-validated:{{.PlanVerdict}}</span>{{end}}
         {{if .Locked}}<span class="chip chip-lock">🔒 locked</span>{{end}}
-        {{if .RunningFlow}}<span class="chip chip-magenta">⟳ {{.RunningFlow}} {{.RunIter}}/{{.RunMax}}</span>{{end}}
+        {{if .RunningFlow}}<span class="chip chip-magenta">⟳ {{displayFlow .RunningFlow}} {{.RunIter}}/{{.RunMax}}</span>{{end}}
         {{if and .RunningFlow .Auto}}<span class="chip chip-magenta" title="disparado por el auto-loop engine">auto</span>{{end}}
         {{if .CapReached}}<span class="chip chip-cap" title="auto-loop detenido: alcanzó el cap de {{.RunMax}} rondas. Re-corré che manualmente para seguir.">⛔ cap {{.RunMax}}/{{.RunMax}}</span>{{end}}
       </div>
@@ -350,6 +382,8 @@
       {{if .NextAction}}<dt>next</dt><dd>{{.NextAction}}</dd>{{end}}
       {{if .PlanVerdict}}<dt>verdict</dt><dd style="color:{{verdictColor .PlanVerdict}}">plan-validated:{{.PlanVerdict}}</dd>{{end}}
     </div>
+
+    {{template "pipeline-step-actions" .}}
 
     <div class="drawer-actions">
       {{/* Issue-only: botones varían por Status. flowBtnState consulta gates
@@ -476,7 +510,7 @@
 
     <div class="drawer-logs">
       <div class="drawer-logs-hdr">
-        <span><b>stream</b>{{if .RunningFlow}} · claude {{.RunningFlow}} · run {{.RunIter}}{{end}}</span>
+        <span><b>stream</b>{{if .RunningFlow}} · claude {{displayFlow .RunningFlow}} · run {{.RunIter}}{{end}}</span>
         <div class="ctl">
           <span class="on">● auto-scroll</span>
           <span>pause</span>


### PR DESCRIPTION
## Summary
- Derives dash board columns from custom pipeline steps while preserving the legacy default pipeline layout.
- Adds drawer step metadata/actions for custom pipelines and dispatches `che run --auto --from <step>` through a gated endpoint.
- Displays dynamic run labels as `run --from <step>` and covers custom column/drawer/dispatch behavior with tests.

## Tests
- `go test ./internal/dash`
- `go test ./...`

Closes #58