### PR TITLE
feat(#65): add dash pipeline editor

### DIFF
--- a/internal/dash/server.go
+++ b/internal/dash/server.go
@@ -355,7 +355,6 @@ func (s *Server) activePipeline() pipeline.Pipeline {
 }
 
 func (s *Server) activePipelineResolved() pipelineEditorData {
-	_ = s.activePipeline()
 	s.pipelineMu.RLock()
 	defer s.pipelineMu.RUnlock()
 	return pipelineEditorData{
@@ -959,31 +958,33 @@ func (s *Server) saveDashboardPipeline(p pipeline.Pipeline) (pipelineEditorData,
 	if err != nil {
 		return pipelineEditorData{}, fmt.Errorf("init pipeline manager: %w", err)
 	}
-	resolved := s.activePipelineResolved()
-	name := resolved.Name
-	path := resolved.Path
-	source := resolved.Source
+	s.pipelineMu.Lock()
+	name := s.pipelineName
+	path := s.pipelinePath
+	source := s.pipelineKind
 	if path == "" {
 		name = "default"
 		path = filepath.Join(mgr.PipelinesDir(), name+".json")
 		source = pipeline.SourceConfig
 	}
 	if err := writePipelineFile(path, p); err != nil {
+		s.pipelineMu.Unlock()
 		return pipelineEditorData{}, fmt.Errorf("escribir %s: %w", path, err)
 	}
-	if resolved.Path == "" || mgr.Config.Default == "" {
+	if s.pipelinePath == "" || mgr.Config.Default == "" {
 		if err := writePipelineConfig(mgr.ConfigPath(), pipeline.Config{Version: pipeline.ConfigVersion, Default: name}); err != nil {
+			s.pipelineMu.Unlock()
 			return pipelineEditorData{}, fmt.Errorf("escribir %s: %w", mgr.ConfigPath(), err)
 		}
 	}
-	s.pipelineMu.Lock()
 	s.pipeline = clonePipeline(p)
 	s.pipelineName = name
 	s.pipelinePath = path
 	s.pipelineKind = source
+	out := pipelineEditorData{Name: name, Source: source, Path: path, Pipe: clonePipeline(p), Saved: true}
 	s.pipelineMu.Unlock()
 	s.bumpSource()
-	return pipelineEditorData{Name: name, Source: source, Path: path, Pipe: clonePipeline(p), Saved: true}, nil
+	return out, nil
 }
 
 func writePipelineFile(path string, p pipeline.Pipeline) error {
@@ -1533,6 +1534,7 @@ func (s *Server) buildMux() *http.ServeMux {
 	mux.HandleFunc("GET /pipeline/editor", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.Header().Set("Cache-Control", "no-store")
+		_ = s.activePipeline()
 		if err := s.tmpl.ExecuteTemplate(w, "pipeline_editor.html.tmpl", s.activePipelineResolved()); err != nil {
 			http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
 			return
@@ -1540,6 +1542,10 @@ func (s *Server) buildMux() *http.ServeMux {
 	})
 
 	mux.HandleFunc("POST /pipeline/editor", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("HX-Request") != "true" {
+			http.Error(w, "HX-Request header required", http.StatusForbidden)
+			return
+		}
 		p, err := s.pipelineEditorFromRequest(r)
 		data := s.activePipelineResolved()
 		status := http.StatusOK

--- a/internal/dash/server.go
+++ b/internal/dash/server.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"io"
@@ -46,7 +47,7 @@ import (
 	"github.com/yuin/goldmark/renderer/html"
 )
 
-//go:embed templates/dashboard.html.tmpl templates/drawer.html.tmpl templates/board.html.tmpl templates/loop.html.tmpl
+//go:embed templates/dashboard.html.tmpl templates/drawer.html.tmpl templates/board.html.tmpl templates/loop.html.tmpl templates/pipeline_editor.html.tmpl
 var templatesFS embed.FS
 
 //go:embed static/htmx.min.js static/dash.js
@@ -118,6 +119,9 @@ func Run(ctx context.Context, opts Options, stdout, stderr io.Writer) error {
 		return fmt.Errorf("resolve dashboard pipeline: %w", err)
 	}
 	srv.pipeline = resolved.Pipeline
+	srv.pipelineName = resolved.Name
+	srv.pipelinePath = resolved.Path
+	srv.pipelineKind = resolved.Source
 
 	ln, err := listenWithFallback(opts.Port, !opts.PortExplicit)
 	if err != nil {
@@ -242,6 +246,9 @@ type Server struct {
 	// sigue abierto.
 	pipelineMu   sync.RWMutex
 	pipeline     pipeline.Pipeline
+	pipelineName string
+	pipelinePath string
+	pipelineKind pipeline.SourceKind
 	pipelineRoot string
 }
 
@@ -304,6 +311,7 @@ func NewServer(source Source, repoName string, pollInterval int) *Server {
 		"templates/drawer.html.tmpl",
 		"templates/board.html.tmpl",
 		"templates/loop.html.tmpl",
+		"templates/pipeline_editor.html.tmpl",
 	))
 	s.tmpl = tmpl
 	s.mux = s.buildMux()
@@ -338,9 +346,24 @@ func (s *Server) activePipeline() pipeline.Pipeline {
 	}
 	s.pipelineMu.Lock()
 	s.pipeline = resolved.Pipeline
+	s.pipelineName = resolved.Name
+	s.pipelinePath = resolved.Path
+	s.pipelineKind = resolved.Source
 	p := clonePipeline(s.pipeline)
 	s.pipelineMu.Unlock()
 	return p
+}
+
+func (s *Server) activePipelineResolved() pipelineEditorData {
+	_ = s.activePipeline()
+	s.pipelineMu.RLock()
+	defer s.pipelineMu.RUnlock()
+	return pipelineEditorData{
+		Name:   s.pipelineName,
+		Source: s.pipelineKind,
+		Path:   s.pipelinePath,
+		Pipe:   clonePipeline(s.pipeline),
+	}
 }
 
 func clonePipeline(p pipeline.Pipeline) pipeline.Pipeline {
@@ -395,6 +418,15 @@ type pageData struct {
 	// hx-get de /board y al EventSource de /stream (reconexión sin perder
 	// el estado del toggle).
 	Adopt bool
+}
+
+type pipelineEditorData struct {
+	Name   string
+	Source pipeline.SourceKind
+	Path   string
+	Pipe   pipeline.Pipeline
+	Error  string
+	Saved  bool
 }
 
 // hotPollSec es el intervalo de polling adaptivo cuando hay flows locales
@@ -658,7 +690,25 @@ func (s *Server) templateFuncs() template.FuncMap {
 		"gateOf":      gateOf,
 		"displayFlow": displayFlow,
 		"joinStrings": strings.Join,
+		"aggregators": func() []pipeline.Aggregator { return pipeline.ValidAggregators },
+		"splitAgents": splitPipelineAgents,
 	}
+}
+
+func splitPipelineAgents(agents []string) string {
+	return strings.Join(agents, ", ")
+}
+
+func parsePipelineAgents(raw string) []string {
+	parts := strings.Split(raw, ",")
+	agents := make([]string, 0, len(parts))
+	for _, part := range parts {
+		agent := strings.TrimSpace(part)
+		if agent != "" {
+			agents = append(agents, agent)
+		}
+	}
+	return agents
 }
 
 func displayFlow(flow string) string {
@@ -868,6 +918,117 @@ func (s *Server) buildData(adopt bool) pageData {
 		Loop:         s.buildLoopData(),
 		Adopt:        adopt,
 	}
+}
+
+func (s *Server) pipelineEditorFromRequest(r *http.Request) (pipeline.Pipeline, error) {
+	if err := r.ParseForm(); err != nil {
+		return pipeline.Pipeline{}, err
+	}
+	names := r.PostForm["step_name"]
+	agents := r.PostForm["step_agents"]
+	aggregators := r.PostForm["step_aggregator"]
+	comments := r.PostForm["step_comment"]
+	if len(names) != len(agents) || len(names) != len(aggregators) || len(names) != len(comments) {
+		return pipeline.Pipeline{}, fmt.Errorf("form inválido: filas de steps desalineadas")
+	}
+	out := pipeline.Pipeline{Version: pipeline.CurrentVersion, Steps: make([]pipeline.Step, 0, len(names))}
+	for i := range names {
+		name := strings.TrimSpace(names[i])
+		if name == "" && strings.TrimSpace(agents[i]) == "" && strings.TrimSpace(comments[i]) == "" {
+			continue
+		}
+		out.Steps = append(out.Steps, pipeline.Step{
+			Name:       name,
+			Agents:     parsePipelineAgents(agents[i]),
+			Aggregator: pipeline.Aggregator(strings.TrimSpace(aggregators[i])),
+			Comment:    strings.TrimSpace(comments[i]),
+		})
+	}
+	if err := pipeline.Validate(out); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
+func (s *Server) saveDashboardPipeline(p pipeline.Pipeline) (pipelineEditorData, error) {
+	root := s.pipelineRoot
+	if root == "" {
+		return pipelineEditorData{}, fmt.Errorf("pipelineRoot vacío: el editor requiere repo path")
+	}
+	mgr, err := pipeline.NewManager(root)
+	if err != nil {
+		return pipelineEditorData{}, fmt.Errorf("init pipeline manager: %w", err)
+	}
+	resolved := s.activePipelineResolved()
+	name := resolved.Name
+	path := resolved.Path
+	source := resolved.Source
+	if path == "" {
+		name = "default"
+		path = filepath.Join(mgr.PipelinesDir(), name+".json")
+		source = pipeline.SourceConfig
+	}
+	if err := writePipelineFile(path, p); err != nil {
+		return pipelineEditorData{}, fmt.Errorf("escribir %s: %w", path, err)
+	}
+	if resolved.Path == "" || mgr.Config.Default == "" {
+		if err := writePipelineConfig(mgr.ConfigPath(), pipeline.Config{Version: pipeline.ConfigVersion, Default: name}); err != nil {
+			return pipelineEditorData{}, fmt.Errorf("escribir %s: %w", mgr.ConfigPath(), err)
+		}
+	}
+	s.pipelineMu.Lock()
+	s.pipeline = clonePipeline(p)
+	s.pipelineName = name
+	s.pipelinePath = path
+	s.pipelineKind = source
+	s.pipelineMu.Unlock()
+	s.bumpSource()
+	return pipelineEditorData{Name: name, Source: source, Path: path, Pipe: clonePipeline(p), Saved: true}, nil
+}
+
+func writePipelineFile(path string, p pipeline.Pipeline) error {
+	return writeJSONFileAtomic(path, p)
+}
+
+func writePipelineConfig(path string, cfg pipeline.Config) error {
+	return writeJSONFileAtomic(path, cfg)
+}
+
+func writeJSONFileAtomic(path string, v any) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("rechazado symlink en destino %s", path)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o644); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }
 
 // findEntity busca por EntityKey en el snapshot actual. Usado por el
@@ -1367,6 +1528,39 @@ func (s *Server) buildMux() *http.ServeMux {
 	mux.HandleFunc("GET /drawer/close", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
 		w.Header().Set("Cache-Control", "no-store")
+	})
+
+	mux.HandleFunc("GET /pipeline/editor", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-store")
+		if err := s.tmpl.ExecuteTemplate(w, "pipeline_editor.html.tmpl", s.activePipelineResolved()); err != nil {
+			http.Error(w, "template error: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+	})
+
+	mux.HandleFunc("POST /pipeline/editor", func(w http.ResponseWriter, r *http.Request) {
+		p, err := s.pipelineEditorFromRequest(r)
+		data := s.activePipelineResolved()
+		status := http.StatusOK
+		if err != nil {
+			if p.Version != 0 || len(p.Steps) > 0 {
+				data.Pipe = p
+			}
+			data.Error = err.Error()
+		} else if saved, err := s.saveDashboardPipeline(p); err != nil {
+			data.Pipe = p
+			data.Error = err.Error()
+			status = http.StatusInternalServerError
+		} else {
+			data = saved
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(status)
+		if err := s.tmpl.ExecuteTemplate(w, "pipeline_editor.html.tmpl", data); err != nil {
+			return
+		}
 	})
 
 	// POST /action/{flow}/{id} — dispara un subcomando che en background.

--- a/internal/dash/server_test.go
+++ b/internal/dash/server_test.go
@@ -1,11 +1,15 @@
 package dash
 
 import (
+	"encoding/json"
 	"errors"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -2158,6 +2162,112 @@ func TestIsDefaultPipeline_ConsidersAgentChangesCustom(t *testing.T) {
 	p.Steps[0].Agents = []string{"claude-sonnet"}
 	if isDefaultPipeline(p) {
 		t.Fatalf("pipeline with default step names but changed agents should be treated as custom")
+	}
+}
+
+func TestPipelineEditor_RendersActivePipeline(t *testing.T) {
+	s := NewServer(&fixedSource{snap: Snapshot{LastOK: time.Now()}}, "repo", 15)
+	s.pipeline = pipeline.Pipeline{Version: pipeline.CurrentVersion, Steps: []pipeline.Step{
+		{Name: "build", Agents: []string{"claude-opus", "claude-haiku"}, Aggregator: pipeline.AggregatorFirstBlocker, Comment: "compile"},
+	}}
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/pipeline/editor")
+	if err != nil {
+		t.Fatalf("GET editor: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	got := string(body)
+	for _, want := range []string{
+		`class="modal pipeline-editor"`,
+		`value="build"`,
+		`value="claude-opus, claude-haiku"`,
+		`first_blocker`,
+		`value="compile"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("editor missing %q\nbody=%s", want, got)
+		}
+	}
+}
+
+func TestPipelineEditor_SaveMaterializesBuiltinDefault(t *testing.T) {
+	root := t.TempDir()
+	s := NewServer(&fixedSource{snap: Snapshot{LastOK: time.Now()}}, "repo", 15)
+	s.pipelineRoot = root
+	s.pipeline = pipeline.Default()
+	s.pipelineName = "default"
+	s.pipelineKind = pipeline.SourceBuiltin
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	form := url.Values{}
+	form.Add("step_name", "spec")
+	form.Add("step_agents", "claude-sonnet")
+	form.Add("step_aggregator", string(pipeline.AggregatorMajority))
+	form.Add("step_comment", "write spec")
+	resp, err := http.PostForm(ts.URL+"/pipeline/editor", form)
+	if err != nil {
+		t.Fatalf("POST editor: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200 body=%s", resp.StatusCode, body)
+	}
+	path := filepath.Join(root, pipeline.PipelinesDirRel, "default.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read saved pipeline: %v", err)
+	}
+	var got pipeline.Pipeline
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal saved pipeline: %v", err)
+	}
+	if len(got.Steps) != 1 || got.Steps[0].Name != "spec" || got.Steps[0].Agents[0] != "claude-sonnet" {
+		t.Fatalf("saved pipeline mismatch: %+v", got)
+	}
+	cfgRaw, err := os.ReadFile(filepath.Join(root, pipeline.ConfigFileRel))
+	if err != nil {
+		t.Fatalf("read pipeline config: %v", err)
+	}
+	var cfg pipeline.Config
+	if err := json.Unmarshal(cfgRaw, &cfg); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	if cfg.Default != "default" {
+		t.Fatalf("config default: got %q want default", cfg.Default)
+	}
+}
+
+func TestPipelineEditor_SaveRejectsInvalidPipeline(t *testing.T) {
+	root := t.TempDir()
+	s := NewServer(&fixedSource{snap: Snapshot{LastOK: time.Now()}}, "repo", 15)
+	s.pipelineRoot = root
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	form := url.Values{}
+	form.Add("step_name", "Bad Name")
+	form.Add("step_agents", "claude-sonnet")
+	form.Add("step_aggregator", string(pipeline.AggregatorMajority))
+	form.Add("step_comment", "")
+	resp, err := http.PostForm(ts.URL+"/pipeline/editor", form)
+	if err != nil {
+		t.Fatalf("POST editor: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: got %d want 200 body=%s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "invalid step name") {
+		t.Fatalf("body missing validation error: %s", body)
+	}
+	if _, err := os.Stat(filepath.Join(root, pipeline.PipelinesDirRel, "default.json")); !os.IsNotExist(err) {
+		t.Fatalf("invalid pipeline should not be written, stat err=%v", err)
 	}
 }
 

--- a/internal/dash/server_test.go
+++ b/internal/dash/server_test.go
@@ -2208,7 +2208,7 @@ func TestPipelineEditor_SaveMaterializesBuiltinDefault(t *testing.T) {
 	form.Add("step_agents", "claude-sonnet")
 	form.Add("step_aggregator", string(pipeline.AggregatorMajority))
 	form.Add("step_comment", "write spec")
-	resp, err := http.PostForm(ts.URL+"/pipeline/editor", form)
+	resp, err := postPipelineEditorForm(ts.URL, form)
 	if err != nil {
 		t.Fatalf("POST editor: %v", err)
 	}
@@ -2254,7 +2254,7 @@ func TestPipelineEditor_SaveRejectsInvalidPipeline(t *testing.T) {
 	form.Add("step_agents", "claude-sonnet")
 	form.Add("step_aggregator", string(pipeline.AggregatorMajority))
 	form.Add("step_comment", "")
-	resp, err := http.PostForm(ts.URL+"/pipeline/editor", form)
+	resp, err := postPipelineEditorForm(ts.URL, form)
 	if err != nil {
 		t.Fatalf("POST editor: %v", err)
 	}
@@ -2269,6 +2269,40 @@ func TestPipelineEditor_SaveRejectsInvalidPipeline(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(root, pipeline.PipelinesDirRel, "default.json")); !os.IsNotExist(err) {
 		t.Fatalf("invalid pipeline should not be written, stat err=%v", err)
 	}
+}
+
+func TestPipelineEditor_RejectsNonHTMXPost(t *testing.T) {
+	s := NewServer(&fixedSource{snap: Snapshot{LastOK: time.Now()}}, "repo", 15)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	form := url.Values{}
+	form.Add("step_name", "spec")
+	form.Add("step_agents", "claude-sonnet")
+	form.Add("step_aggregator", string(pipeline.AggregatorMajority))
+	form.Add("step_comment", "")
+	resp, err := http.PostForm(ts.URL+"/pipeline/editor", form)
+	if err != nil {
+		t.Fatalf("POST editor without HX: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status: got %d want 403 body=%s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "HX-Request") {
+		t.Fatalf("body missing HX reason: %s", body)
+	}
+}
+
+func postPipelineEditorForm(baseURL string, form url.Values) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodPost, baseURL+"/pipeline/editor", strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	return http.DefaultClient.Do(req)
 }
 
 func newCustomPipelineRunServer(t *testing.T, e Entity) (*Server, *fakeRunner, *httptest.Server) {

--- a/internal/dash/static/dash.js
+++ b/internal/dash/static/dash.js
@@ -144,6 +144,41 @@
     }
   });
 
+  // Editor visual de pipelines: add/remove rows client-side; el server valida
+  // todo en POST antes de escribir el JSON.
+  document.body.addEventListener("click", function (e) {
+    var t = e.target;
+    if (!(t instanceof Element)) return;
+    var add = t.closest("[data-add-step]");
+    if (add) {
+      e.preventDefault();
+      var modal = add.closest(".pipeline-editor");
+      var rows = modal && modal.querySelector("[data-pipeline-rows]");
+      if (!rows) return;
+      var row = document.createElement("div");
+      row.className = "pipeline-editor-row";
+      row.innerHTML = '<input name="step_name" value="" autocomplete="off" spellcheck="false">' +
+        '<input name="step_agents" value="claude-sonnet" autocomplete="off" spellcheck="false">' +
+        '<select name="step_aggregator">' +
+        '<option value="majority">majority</option>' +
+        '<option value="unanimous">unanimous</option>' +
+        '<option value="first_blocker">first_blocker</option>' +
+        '</select>' +
+        '<input name="step_comment" value="" autocomplete="off" spellcheck="false">' +
+        '<button type="button" class="btn ghost" data-remove-step title="eliminar step">×</button>';
+      rows.appendChild(row);
+      var first = row.querySelector('input[name="step_name"]');
+      if (first) first.focus();
+      return;
+    }
+    var remove = t.closest("[data-remove-step]");
+    if (remove) {
+      e.preventDefault();
+      var r = remove.closest(".pipeline-editor-row");
+      if (r) r.remove();
+    }
+  });
+
   // Countdown al próximo poll en el status-chip. El chip tiene
   // data-poll-interval (segundos) que usamos como baseline.
   //

--- a/internal/dash/templates/dashboard.html.tmpl
+++ b/internal/dash/templates/dashboard.html.tmpl
@@ -128,6 +128,19 @@
      del resto. */
   .col[data-status="adopt"] .col-hdr b { color: var(--orange); }
 
+  .pipeline-editor-btn {
+    background: var(--panel);
+    border: 1px solid var(--elevated);
+    color: var(--cyan);
+    font: inherit;
+    font-size: 11px;
+    padding: 4px 10px;
+    border-radius: 16px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .pipeline-editor-btn:hover { border-color: var(--cyan); }
+
   .auto-loop-wrap {
     position: relative;
   }
@@ -908,6 +921,43 @@
   .md img { max-width: 100%; border-radius: 4px; }
   .md input[type="checkbox"] { margin-right: 6px; }
   .md del { color: var(--muted); }
+
+  .pipeline-editor .drawer-hdr { border-bottom: 1px solid var(--elevated); }
+  .pipeline-editor-form { padding: 14px; overflow: auto; min-height: 0; }
+  .pipeline-editor-head,
+  .pipeline-editor-row {
+    display: grid;
+    grid-template-columns: 1fr 1.8fr 1.1fr 1.8fr 32px;
+    gap: 8px;
+    align-items: center;
+  }
+  .pipeline-editor-head {
+    color: var(--muted);
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 6px;
+  }
+  .pipeline-editor-row { margin-bottom: 8px; }
+  .pipeline-editor-row input,
+  .pipeline-editor-row select {
+    width: 100%;
+    background: #15161b;
+    border: 1px solid var(--elevated);
+    color: var(--text);
+    border-radius: 4px;
+    font: inherit;
+    padding: 6px 8px;
+  }
+  .pipeline-editor-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 12px; }
+  .pipeline-editor-error,
+  .pipeline-editor-ok { margin-top: 8px; padding: 6px 8px; border-radius: 4px; font-size: 11px; }
+  .pipeline-editor-error { color: var(--red); background: rgba(255,85,85,0.1); border: 1px solid rgba(255,85,85,0.35); }
+  .pipeline-editor-ok { color: var(--green); background: rgba(80,250,123,0.1); border: 1px solid rgba(80,250,123,0.35); }
+  @media (max-width: 860px) {
+    .pipeline-editor-head { display: none; }
+    .pipeline-editor-row { grid-template-columns: 1fr; border: 1px solid var(--elevated); border-radius: 6px; padding: 8px; }
+  }
 </style>
 </head>
 <body>
@@ -927,6 +977,11 @@
       <span class="switch"></span>
       <span class="label">show untracked PRs</span>
     </label>
+    <button class="pipeline-editor-btn"
+            hx-get="/pipeline/editor"
+            hx-target="#modal-slot"
+            hx-swap="innerHTML"
+            title="editar pipeline activo">pipeline</button>
     <div class="auto-loop-wrap">
       {{template "auto-loop-toggle" .Loop}}
       <div id="loop-popover" class="loop-popover" aria-hidden="true"></div>

--- a/internal/dash/templates/pipeline_editor.html.tmpl
+++ b/internal/dash/templates/pipeline_editor.html.tmpl
@@ -1,0 +1,52 @@
+{{/* pipeline_editor.html.tmpl — modal HTMX para editar el pipeline activo. */}}
+<div class="modal-backdrop">
+<div class="modal pipeline-editor" data-pipeline-editor="1">
+  <div class="drawer-hdr">
+    <div class="drawer-hdr-top">
+      <div class="entity-row">
+        pipeline <b>{{.Name}}</b> · {{.Source}}{{if .Path}} · <code>{{.Path}}</code>{{else}} · built-in se materializa como <code>.che/pipelines/default.json</code>{{end}}
+      </div>
+      <button class="drawer-close"
+              hx-get="/drawer/close"
+              hx-target="#modal-slot"
+              hx-swap="innerHTML"
+              title="cerrar (Esc)">×</button>
+    </div>
+    <h3>editor visual de pipeline</h3>
+    <div class="sub">editá orden, step, agentes, aggregator y comentario; guardar valida el JSON antes de escribir.</div>
+    {{if .Saved}}<div class="pipeline-editor-ok">guardado · el board recarga en el próximo poll</div>{{end}}
+    {{if .Error}}<div class="pipeline-editor-error">{{.Error}}</div>{{end}}
+  </div>
+
+  <form class="pipeline-editor-form"
+        hx-post="/pipeline/editor"
+        hx-target="#modal-slot"
+        hx-swap="innerHTML">
+    <div class="pipeline-editor-head">
+      <span>step</span>
+      <span>agents (coma)</span>
+      <span>aggregator</span>
+      <span>comment</span>
+      <span></span>
+    </div>
+    <div class="pipeline-editor-rows" data-pipeline-rows>
+      {{range .Pipe.Steps}}
+      {{$agg := .Aggregator}}
+      <div class="pipeline-editor-row">
+        <input name="step_name" value="{{.Name}}" autocomplete="off" spellcheck="false">
+        <input name="step_agents" value="{{splitAgents .Agents}}" autocomplete="off" spellcheck="false">
+        <select name="step_aggregator">
+          {{range aggregators}}<option value="{{.}}" {{if eq . $agg}}selected{{end}}>{{.}}</option>{{end}}
+        </select>
+        <input name="step_comment" value="{{.Comment}}" autocomplete="off" spellcheck="false">
+        <button type="button" class="btn ghost" data-remove-step title="eliminar step">×</button>
+      </div>
+      {{end}}
+    </div>
+    <div class="pipeline-editor-actions">
+      <button type="button" class="btn ghost" data-add-step>+ step</button>
+      <button type="submit" class="btn primary">guardar pipeline</button>
+    </div>
+  </form>
+</div>
+</div>


### PR DESCRIPTION
## Summary
- Adds a Dash topbar entry point and HTMX modal for editing the active pipeline visually.
- Validates edited steps before persisting and materializes the built-in pipeline to `.che/pipelines/default.json` when needed.
- Covers editor rendering, successful save, and invalid pipeline handling in Dash tests.

## Tests
- `go test ./...`

Closes #65