### PR TITLE
feat(#69): add pipeline docs examples and e2e

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,36 @@ La TUI y los subcomandos comparten el mismo motor; los subcomandos siguen existi
 | `che doctor` | — | Chequea entorno (gh auth, CLIs de agentes en PATH, etc.). |
 | `che upgrade` | — | Actualiza che a la última versión publicada. |
 
+## Pipelines Configurables
+
+`che` puede correr pipelines declarativos por repo. Cada pipeline vive en `.che/pipelines/<name>.json` y `.che/pipelines.config.json` define el default activo.
+
+Quickstart:
+
+```sh
+# A. Usar el built-in sin configurar nada
+che pipeline simulate
+
+# B. Materializar y editar un pipeline local
+che pipeline new default
+che pipeline use default
+che dash
+
+# C. Crear uno desde wizard y correrlo desde un step puntual
+che pipeline create fast
+che run --pipeline fast --from execute --input "fix issue #123"
+```
+
+Ejemplos canónicos para copiar o adaptar: [`schemas/examples/default.json`](./schemas/examples/default.json), [`fast.json`](./schemas/examples/fast.json), [`thorough.json`](./schemas/examples/thorough.json), [`with-entry.json`](./schemas/examples/with-entry.json), [`pr-only.json`](./schemas/examples/pr-only.json). El schema para autocomplete está en [`schemas/pipeline.json`](./schemas/pipeline.json).
+
+Reglas operativas:
+
+- Resolución: `--pipeline` gana sobre `.che/pipelines.config.json`; sin ambos, corre el built-in.
+- `entry` es opcional; puede emitir `[goto: step]`, `[next]` o `[stop]` antes del primer step.
+- `--from <step>` bypassa el entry y reanuda desde ese step.
+- Los saltos viven en markers de agentes (`[goto: execute]`), no en el JSON.
+- `aggregator` sólo resuelve conflictos cuando hay varios agentes: `majority`, `unanimous` o `first_blocker`.
+
 ## Pre-conditions globales
 
 - Estar parado en un repo con remote de GitHub.

--- a/e2e/pipeline_test.go
+++ b/e2e/pipeline_test.go
@@ -1,0 +1,146 @@
+package e2e_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chichex/che/e2e/harness"
+)
+
+func TestPipelineE2E_SimulateBuiltinWithoutCustomConfig(t *testing.T) {
+	t.Parallel()
+	env := setupPipelineRepo(t)
+
+	out := env.MustRun("pipeline", "simulate")
+	harness.AssertContains(t, out, "pipeline: default")
+	harness.AssertContains(t, out, "source:   built-in")
+	harness.AssertContains(t, out, "step[0]: idea")
+	env.Invocations().AssertNotCalled(t, "claude")
+}
+
+func TestPipelineE2E_RunCustomConfigFlagAndFrom(t *testing.T) {
+	t.Parallel()
+	env := setupPipelineRepo(t)
+	writePipeline(t, env.RepoDir, "fast", `{
+  "version": 1,
+  "steps": [
+    {"name": "plan", "agents": ["claude-opus"]},
+    {"name": "execute", "agents": ["claude-opus"]}
+  ]
+}`)
+	writePipeline(t, env.RepoDir, "slow", `{
+  "version": 1,
+  "steps": [
+    {"name": "ignored", "agents": ["claude-opus"]}
+  ]
+}`)
+	writeConfig(t, env.RepoDir, "slow")
+	env.ExpectAgent("claude").WhenArgsMatch(`--output-format text`).RespondStdout("[next]\n", 0)
+
+	out := env.MustRun("run", "--pipeline", "fast", "--from", "execute", "--input", "ship it")
+	harness.AssertContains(t, out, "pipeline: fast")
+	harness.AssertContains(t, out, "source:   flag")
+	harness.AssertContains(t, out, "from:     execute (entry bypassed)")
+	harness.AssertContains(t, out, "step[0]: execute")
+	harness.AssertNotContains(t, out, "step[0]: plan")
+
+	calls := env.Invocations().For("claude")
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 agent call from --from execute, got %d", len(calls))
+	}
+}
+
+func TestPipelineE2E_EntryCanStopBeforeSteps(t *testing.T) {
+	t.Parallel()
+	env := setupPipelineRepo(t)
+	writePipeline(t, env.RepoDir, "gated", `{
+  "version": 1,
+  "entry": {"agents": ["claude-opus"], "aggregator": "first_blocker"},
+  "steps": [
+    {"name": "execute", "agents": ["claude-opus"]}
+  ]
+}`)
+	env.ExpectAgent("claude").WhenArgsMatch(`--output-format text`).Consumable().RespondStdout("[stop]\n", 0)
+
+	out := env.MustRun("run", "gated", "--input", "not actionable")
+	harness.AssertContains(t, out, "entry: agent=claude-opus marker=[stop]")
+	harness.AssertContains(t, out, "stopped: entry agent emitted [stop]")
+	if calls := env.Invocations().For("claude"); len(calls) != 1 {
+		t.Fatalf("entry stop should avoid step agents, got %d claude calls", len(calls))
+	}
+}
+
+func TestPipelineE2E_AgentFailureStopsTechnically(t *testing.T) {
+	t.Parallel()
+	env := setupPipelineRepo(t)
+	writePipeline(t, env.RepoDir, "fails", `{
+  "version": 1,
+  "steps": [
+    {"name": "execute", "agents": ["claude-opus"]}
+  ]
+}`)
+	env.ExpectAgent("claude").WhenArgsMatch(`--output-format text`).RespondExitWithError(1, "boom\n")
+
+	r := env.Run("run", "fails")
+	if r.ExitCode == 0 {
+		t.Fatalf("expected non-zero exit on agent failure\nstdout:\n%s\nstderr:\n%s", r.Stdout, r.Stderr)
+	}
+	harness.AssertContains(t, r.Stdout+r.Stderr, "agent technical error")
+}
+
+func TestPipelineE2E_WizardGeneratesValidJSON(t *testing.T) {
+	t.Parallel()
+	env := setupPipelineRepo(t)
+	stdin := strings.Join([]string{
+		"n",          // clonar desde un pipeline existente
+		"n",          // agregar entry agent
+		"execute",    // nombre del step
+		"1",          // claude-opus
+		"quick path", // comment
+		"n",          // agregar otro step
+		"y",          // guardar
+		"",
+	}, "\n")
+
+	out := env.RunWithStdin(stdin, "pipeline", "create", "quick")
+	if out.ExitCode != 0 {
+		t.Fatalf("pipeline create failed: stdout:\n%s\nstderr:\n%s", out.Stdout, out.Stderr)
+	}
+	harness.AssertContains(t, out.Stdout+out.Stderr, "creado")
+
+	validate := env.MustRun("pipeline", "validate", "quick", "--skip-agents")
+	harness.AssertContains(t, validate, "ok")
+}
+
+func setupPipelineRepo(t *testing.T) *harness.Env {
+	t.Helper()
+	env := harness.New(t)
+	env.RemoveFake("git")
+	runIn(t, env.RepoDir, "git", "init", "-q", "-b", "main")
+	return env
+}
+
+func writePipeline(t *testing.T, repo, name, body string) {
+	t.Helper()
+	dir := filepath.Join(repo, ".che", "pipelines")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir pipeline dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name+".json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write pipeline %s: %v", name, err)
+	}
+}
+
+func writeConfig(t *testing.T, repo, name string) {
+	t.Helper()
+	dir := filepath.Join(repo, ".che")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir .che: %v", err)
+	}
+	body := `{"version":1,"default":"` + name + `"}` + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "pipelines.config.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -22,6 +22,11 @@ const CurrentVersion = 1
 // archivo `.che/pipelines/<name>.json`. El nombre del pipeline no vive en
 // la struct: lo provee el filename.
 type Pipeline struct {
+	// Schema es opcional y existe sólo para tooling de editores. El loader lo
+	// ignora en runtime, pero debe aceptarlo porque schemas/pipeline.json lo
+	// documenta como forma recomendada para autocomplete.
+	Schema string `json:"$schema,omitempty"`
+
 	// Version siempre debe ser CurrentVersion en v1. El loader rechaza
 	// otras versiones; mantener la verificación explícita en cada llamada
 	// permite mensajes de error puntuales.

--- a/internal/pipeline/pipeline_test.go
+++ b/internal/pipeline/pipeline_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"testing"
 )
 
@@ -137,6 +138,36 @@ func TestSchemaFileExists(t *testing.T) {
 	}
 	if doc["$schema"] == nil {
 		t.Errorf("schema missing $schema (meta-schema URL)")
+	}
+}
+
+func TestExamples_Load(t *testing.T) {
+	repoRoot := filepath.Join("..", "..")
+	examplesDir := filepath.Join(repoRoot, "schemas", "examples")
+	entries, err := os.ReadDir(examplesDir)
+	if err != nil {
+		t.Fatalf("read examples dir: %v", err)
+	}
+
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		path := filepath.Join(examplesDir, entry.Name())
+		p, err := Load(path)
+		if err != nil {
+			t.Fatalf("Load(%s): %v", path, err)
+		}
+		if p.Schema == "" {
+			t.Fatalf("%s should include $schema for editor autocomplete", path)
+		}
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+	want := []string{"default.json", "fast.json", "pr-only.json", "thorough.json", "with-entry.json"}
+	if !reflect.DeepEqual(names, want) {
+		t.Fatalf("examples drift: got %v want %v", names, want)
 	}
 }
 

--- a/schemas/examples/default.json
+++ b/schemas/examples/default.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "../pipeline.json",
+  "version": 1,
+  "steps": [
+    {
+      "name": "idea",
+      "agents": ["claude-opus"],
+      "_comment": "Convierte una idea vaga en issue(s) accionables."
+    },
+    {
+      "name": "explore",
+      "agents": ["claude-opus"],
+      "_comment": "Investiga el issue y produce el plan consolidado."
+    },
+    {
+      "name": "validate_issue",
+      "agents": ["plan-reviewer-strict", "plan-reviewer-pragmatic", "claude-opus"],
+      "aggregator": "majority",
+      "_comment": "Valida el plan antes de ejecutar; los reviewers custom pueden pedir [goto: explore]."
+    },
+    {
+      "name": "execute",
+      "agents": ["claude-opus"],
+      "_comment": "Implementa el plan y abre PR draft."
+    },
+    {
+      "name": "validate_pr",
+      "agents": ["code-reviewer-strict", "code-reviewer-security", "claude-opus"],
+      "aggregator": "majority",
+      "_comment": "Valida el PR; los reviewers pueden pedir [goto: execute]."
+    },
+    {
+      "name": "close",
+      "agents": ["claude-opus"],
+      "_comment": "Deja listo el cierre humano del PR."
+    }
+  ]
+}

--- a/schemas/examples/fast.json
+++ b/schemas/examples/fast.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "../pipeline.json",
+  "version": 1,
+  "steps": [
+    {
+      "name": "explore",
+      "agents": ["claude-opus"],
+      "_comment": "Plan corto para cambios de bajo riesgo."
+    },
+    {
+      "name": "execute",
+      "agents": ["claude-opus"],
+      "_comment": "Implementa sin reviewers paralelos."
+    },
+    {
+      "name": "validate_pr",
+      "agents": ["claude-opus"],
+      "_comment": "Sanity check final con un solo agente."
+    }
+  ]
+}

--- a/schemas/examples/pr-only.json
+++ b/schemas/examples/pr-only.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../pipeline.json",
+  "version": 1,
+  "entry": {
+    "agents": ["claude-opus"],
+    "aggregator": "first_blocker"
+  },
+  "steps": [
+    {
+      "name": "review",
+      "agents": ["claude-opus", "claude-opus"],
+      "aggregator": "first_blocker",
+      "_comment": "Revisa PRs existentes; el entry debe emitir [stop] para issues sin PR."
+    },
+    {
+      "name": "fix",
+      "agents": ["claude-opus"],
+      "_comment": "Aplica fixes pedidos por review."
+    },
+    {
+      "name": "recheck",
+      "agents": ["claude-opus", "claude-opus"],
+      "aggregator": "unanimous",
+      "_comment": "Ambos reviewers deben coincidir en [next] antes de cerrar."
+    }
+  ]
+}

--- a/schemas/examples/thorough.json
+++ b/schemas/examples/thorough.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "../pipeline.json",
+  "version": 1,
+  "steps": [
+    {
+      "name": "explore",
+      "agents": ["claude-opus", "claude-opus", "claude-opus"],
+      "aggregator": "majority",
+      "_comment": "Best-of-3 de planificación; empates paran."
+    },
+    {
+      "name": "execute",
+      "agents": ["claude-opus"],
+      "_comment": "Implementación única sobre el plan ganador."
+    },
+    {
+      "name": "security",
+      "agents": ["claude-opus", "claude-opus"],
+      "aggregator": "unanimous",
+      "_comment": "Gate estricto: cualquier divergencia bloquea."
+    },
+    {
+      "name": "validate_pr",
+      "agents": ["claude-opus", "claude-opus", "claude-opus"],
+      "aggregator": "first_blocker",
+      "_comment": "Cualquier reviewer puede mandar [goto: execute] o [stop]."
+    }
+  ]
+}

--- a/schemas/examples/with-entry.json
+++ b/schemas/examples/with-entry.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "../pipeline.json",
+  "version": 1,
+  "entry": {
+    "agents": ["claude-opus"],
+    "aggregator": "first_blocker"
+  },
+  "steps": [
+    {
+      "name": "triage",
+      "agents": ["claude-opus"],
+      "_comment": "El entry puede arrancar acá con [goto: triage] para inputs ambiguos."
+    },
+    {
+      "name": "execute",
+      "agents": ["claude-opus"],
+      "_comment": "El entry puede saltar directo con [goto: execute] si el input ya trae plan."
+    },
+    {
+      "name": "validate_pr",
+      "agents": ["claude-opus"],
+      "_comment": "Validación final."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Document configurable pipelines in the README with quickstart paths and operating rules.
- Add canonical pipeline JSON examples under schemas/examples and ensure `$schema` is accepted by the loader.
- Add e2e coverage for pipeline resolution, `--pipeline`, `--from`, entry stop behavior, agent failure, and wizard JSON generation.

## Tests
- go test ./...

Closes #69