### PR TITLE
feat(wizard): embed che-funnel default pipeline (port v0.0.82 funnel)

### DIFF
--- a/e2e/tui_test.go
+++ b/e2e/tui_test.go
@@ -54,8 +54,9 @@ func TestTUI_MenuRoutesItem2ToWizard(t *testing.T) {
 }
 
 // TestTUI_MenuItem1OpensMyPipelines valida H9: digit 1 abre la pantalla
-// "My pipelines"; con HOME limpio renderiza el placeholder vacio. q sale
-// con exit 0.
+// "My pipelines". Con HOME limpio el lister muestra al menos el builtin
+// che-funnel con chip [default]; el footer con la ayuda es la senal mas
+// estable para detectar que entramos al lister. q sale con exit 0.
 func TestTUI_MenuItem1OpensMyPipelines(t *testing.T) {
 	t.Parallel()
 	env := harness.New(t)
@@ -70,7 +71,7 @@ func TestTUI_MenuItem1OpensMyPipelines(t *testing.T) {
 	if err := p.Send("1"); err != nil {
 		t.Fatalf("send 1: %v", err)
 	}
-	if !p.WaitForOutputSince(t, mark, "no pipelines yet", 3*time.Second) {
+	if !p.WaitForOutputSince(t, mark, "navegar", 3*time.Second) {
 		t.Fatalf("My pipelines screen never rendered\n%s", p.Since(mark))
 	}
 	if err := p.Send("q"); err != nil {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -23,10 +23,33 @@ import (
 // El caller (cmd/root.go.runMyPipelines) decide como surfacearlo. En H2+ esto
 // se convertira en un toast inline sobre el lister; H1 deja la decision al
 // caller para no inflar el contrato.
-func Run(path string) (exitApp bool, err error) {
-	p, err := wizard.Load(path)
+// loadPipelineForRun resuelve `target` a un Pipeline parseado. Si target
+// tiene el prefijo "builtin:" carga desde wizard.Builtins() (in-memory);
+// caso contrario lee del FS via wizard.Load. Devuelve el error con contexto
+// del target para que el caller lo surface tal cual.
+func loadPipelineForRun(target string) (wizard.Pipeline, error) {
+	if wizard.IsBuiltinTarget(target) {
+		slug := wizard.BuiltinSlugFromTarget(target)
+		b, err := wizard.BuiltinBySlug(slug)
+		if err != nil {
+			return wizard.Pipeline{}, fmt.Errorf("runner: builtin %q: %w", slug, err)
+		}
+		if b == nil {
+			return wizard.Pipeline{}, fmt.Errorf("runner: builtin %q no encontrado", slug)
+		}
+		return b.Pipeline, nil
+	}
+	p, err := wizard.Load(target)
 	if err != nil {
-		return false, fmt.Errorf("runner: load %s: %w", path, err)
+		return wizard.Pipeline{}, fmt.Errorf("runner: load %s: %w", target, err)
+	}
+	return p, nil
+}
+
+func Run(path string) (exitApp bool, err error) {
+	p, err := loadPipelineForRun(path)
+	if err != nil {
+		return false, err
 	}
 	if verr := wizard.IsValid(p); verr != nil {
 		return false, fmt.Errorf("runner: pipeline invalido: %w", verr)

--- a/internal/runner/runner_builtin_test.go
+++ b/internal/runner/runner_builtin_test.go
@@ -1,0 +1,47 @@
+package runner
+
+import (
+	"testing"
+)
+
+// TestLoadPipelineForRun_BuiltinSentinel verifica que loadPipelineForRun
+// resuelve el sentinel "builtin:<slug>" via wizard.BuiltinBySlug en vez
+// de tocar el FS. Cubre el caso por el que el lister devuelve targets
+// builtin para enter sobre rows embedded.
+func TestLoadPipelineForRun_BuiltinSentinel(t *testing.T) {
+	p, err := loadPipelineForRun("builtin:che-funnel")
+	if err != nil {
+		t.Fatalf("loadPipelineForRun(builtin:che-funnel): %v", err)
+	}
+	if p.Name != "che-funnel" {
+		t.Errorf("Name: got %q want che-funnel", p.Name)
+	}
+	if len(p.Steps) == 0 {
+		t.Fatal("Steps vacio")
+	}
+	// Sanity: el primer step del builtin es 'idea'.
+	if p.Steps[0].Name != "idea" {
+		t.Errorf("Steps[0].Name: got %q want idea", p.Steps[0].Name)
+	}
+}
+
+func TestLoadPipelineForRun_UnknownBuiltinError(t *testing.T) {
+	_, err := loadPipelineForRun("builtin:no-existe")
+	if err == nil {
+		t.Fatal("esperaba error para builtin desconocido, got nil")
+	}
+}
+
+func TestLoadPipelineForRun_FilesystemPathDelegatesToWizardLoad(t *testing.T) {
+	// Caso negativo: path inexistente del FS debe devolver el error de
+	// wizard.Load envuelto con prefijo "runner: load". Confirma que el
+	// branch del FS sigue activo.
+	_, err := loadPipelineForRun("/no/existe.yaml")
+	if err == nil {
+		t.Fatal("esperaba error para path inexistente, got nil")
+	}
+}
+
+// IsValid del builtin se cubre en internal/wizard/embedded_test.go
+// (TestBuiltins_IsValidWithMockedCLIs). Aca solo testeamos el branching
+// del runner.

--- a/internal/wizard/embedded.go
+++ b/internal/wizard/embedded.go
@@ -1,0 +1,52 @@
+package wizard
+
+import (
+	_ "embed"
+	"fmt"
+)
+
+// builtinCheFunnelYAML es el pipeline default `che-funnel` shippeado con el
+// binario. Replica el embudo idea -> plan -> ejecucion -> close del che
+// clasico (v0.0.82) usando solo el modelo nuevo (cli + kind + content +
+// validator). Toda la state machine de GitHub la dirigen los prompts via
+// tool use de gh/git.
+//
+//go:embed embedded/che-funnel.yaml
+var builtinCheFunnelYAML []byte
+
+// BuiltinPipeline es un pipeline shippeado con el binario. Aparece siempre
+// en "My pipelines" con chip [default]. Source guarda el YAML serializado
+// para soportar copy-on-edit (escribir el archivo a ~/.che/pipelines/<slug>
+// .yaml cuando el usuario quiere personalizarlo). Pipeline ya viene parseado
+// para evitar re-parsear en cada keystroke del lister.
+type BuiltinPipeline struct {
+	Slug     string
+	Source   []byte
+	Pipeline Pipeline
+}
+
+// Builtins devuelve los pipelines embedded. Si alguno falla al parsear es
+// bug del binario (no del usuario), por eso devolvemos error en vez de
+// skipear: el lister va a surfacearlo como "default invalido — bug del
+// binario, reportar".
+func Builtins() ([]BuiltinPipeline, error) {
+	raw := []struct {
+		slug string
+		data []byte
+	}{
+		{"che-funnel", builtinCheFunnelYAML},
+	}
+	out := make([]BuiltinPipeline, 0, len(raw))
+	for _, r := range raw {
+		p, err := Unmarshal(r.data)
+		if err != nil {
+			return nil, fmt.Errorf("wizard: builtin %s: %w", r.slug, err)
+		}
+		out = append(out, BuiltinPipeline{
+			Slug:     r.slug,
+			Source:   r.data,
+			Pipeline: p,
+		})
+	}
+	return out, nil
+}

--- a/internal/wizard/embedded/che-funnel.yaml
+++ b/internal/wizard/embedded/che-funnel.yaml
@@ -1,0 +1,691 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# che-funnel — pipeline default que replica el che clásico (v0.0.82) sobre
+# el modelo nuevo de pipelines. Toda la state machine de GitHub (labels
+# che:*, issues, PRs, worktrees, comments, scoring) la dirigen los prompts
+# vía tool use de los CLIs (gh/git). El runner del nuevo che no necesita
+# lógica adicional: este archivo es self-contained.
+#
+# Diferencias intencionales con v0.0.82:
+#   1. iterate desaparece como step manual. Cada validator tiene max_loops=3,
+#      así que si el verdict es changes_requested el step se re-corre con
+#      feedback hasta converger o agotar el cap.
+#   2. close postea un template de scoring (1-10 en completitud / fidelidad /
+#      alineación) como comment del PR. El humano lo llena fuera del pipeline.
+#      No hay gate humano en medio del run.
+#   3. El validator de cada step usa codex en lugar de claude para reducir
+#      groupthink (cross-CLI review). Si el usuario solo tiene claude
+#      instalado, puede editar el YAML o borrar el bloque validator.
+#
+# Permisos requeridos por los CLIs invocados:
+#   - gh (issue create / edit / comment / view; pr create / view / diff /
+#     checks / merge / ready)
+#   - git (worktree, add, commit, push, fetch, merge)
+# Asegurate que estén en la allowlist del CLI elegido (claude/codex/gemini/
+# opencode). claude por default los pide en confirm; en pipelines no
+# interactivos hay que correr con permisos pre-aprobados.
+# ─────────────────────────────────────────────────────────────────────────────
+
+name: che-funnel
+description: |
+  Embudo clásico de che (idea → plan → ejecución → close) con state machine
+  en GitHub. Pensado para usuarios que venían del che v0.0.82 y quieren la
+  misma UX sin escribir su propio YAML.
+
+steps:
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # STEP 1 — idea
+  # ───────────────────────────────────────────────────────────────────────────
+  # Input: texto libre del usuario (la "idea cruda").
+  # Acción: clasificar size/type, decidir si splittear en N issues, crear
+  #         issue(s) con `gh issue create` y aplicar labels iniciales.
+  # Output: bloque YAML al final del prompt con los issues creados, que el
+  #         step siguiente parsea para saber sobre qué issue trabajar.
+  - name: idea
+    cli: claude
+    kind: prompt
+    input: text
+    content: |
+      Sos un clasificador de ideas para un backlog de ingeniería en GitHub.
+      Te paso una idea en texto libre. Tu tarea:
+
+      1. Decidí si contiene una idea o varias ideas independientes (split).
+      2. Para cada idea, asigná type y size.
+      3. Armá title, body estructurado y criterios de éxito iniciales.
+      4. Creá UN issue de GitHub por cada idea usando `gh issue create`.
+      5. Aplicá los labels iniciales: che:idea, ct:plan, type:<X>, size:<y>.
+
+      Tipos válidos: feature, fix, mejora, ux.
+      Tamaños válidos: XS (minutos), S (horas), M (1-2 días), L (1 semana),
+      XL (varias semanas). Los labels size:* van en lowercase.
+
+      Antes de crear cualquier issue:
+      - Asegurate que existan los labels en el repo. Para cada label que
+        vayas a usar (che:idea, ct:plan, type:feature/fix/mejora/ux,
+        size:xs/s/m/l/xl), hacé `gh label create <name> --force` con un
+        color razonable. `--force` upsertea sin error si ya existe.
+
+      Body de cada issue (markdown, en este orden exacto):
+
+          ## Idea
+          <idea parafraseada accionable>
+
+          ## Contexto detectado
+          - Archivos/módulos relevantes: <lista o vacío>
+          - Área afectada: <auth/billing/UI/etc o vacío>
+          - Dependencias: <lista o vacío>
+
+          ## Criterios de éxito iniciales
+          - [ ] <criterio 1>
+          - [ ] <criterio 2>
+
+          ## Notas / warnings
+          <warnings, decisiones pendientes, coordinación — opcional>
+
+          ## Clasificación
+          - Type: <type>
+          - Size: <SIZE> — <justificación corta>
+
+      Reglas:
+      - Si la idea cubre varias cosas independientes, creá N issues.
+      - Si es una sola cosa, un único issue.
+      - NUNCA "no crear nada": si no podés clasificar, creá un issue con
+        type=feature size=M y anotá en "Notas" que la idea estaba ambigua.
+      - Cada issue debe tener al menos 1 criterio de éxito.
+      - No inventes archivos o módulos que no aparecen en la idea.
+
+      Para crear cada issue:
+
+          gh issue create \
+            --title "<título imperativo, máx 60 chars>" \
+            --body-file <tmp.md> \
+            --label che:idea \
+            --label ct:plan \
+            --label type:<type> \
+            --label size:<size lowercase>
+
+      `gh issue create` devuelve la URL del issue. Capturá el número (último
+      segmento del path) para reportarlo.
+
+      Al final del prompt, devolvé un bloque exactamente con este formato
+      para que el siguiente step lo parsee:
+
+          OUTPUT:
+          issues:
+            - number: <issue#>
+              url: <url>
+              title: <título>
+              type: <type>
+              size: <SIZE>
+            - number: ...
+
+      Idea cruda del usuario:
+      <<<
+      {{INPUT}}
+      >>>
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # STEP 2 — explore (con validator de plan + iterate via max_loops)
+  # ───────────────────────────────────────────────────────────────────────────
+  # Input: OUTPUT del step idea (lista de issues con número/título/type/size).
+  # Acción: para cada issue, generar plan consolidado, postear comment de
+  #         análisis, reescribir body con "## Plan consolidado", aplicar
+  #         che:planning → che:plan.
+  # Validator (codex): revisa el plan, postea comment de validación, aplica
+  #                    plan-validated:approve|changes-requested|needs-human.
+  #                    Si changes-requested, max_loops=3 re-corre este step
+  #                    para que aplique los fixes (efectivo iterate).
+  - name: explore
+    cli: claude
+    kind: prompt
+    input: previous_output
+    content: |
+      Sos un ingeniero senior haciendo exploración técnica de issues antes
+      de comprometerte a un plan de ejecución.
+
+      INPUT — el bloque OUTPUT del step anterior contiene una lista
+      `issues:` con los issues a explorar. Procesalos en orden.
+
+      Antes de empezar a trabajar en un issue, chequeá su estado:
+
+          gh issue view <N> --json labels,body,comments
+
+      Si tiene label `plan-validated:changes-requested`, significa que ya
+      generaste un plan antes y un validator pidió cambios. En ese caso:
+        1. Leé los comments recientes del issue. El validator dejó un
+           comment con header `<!-- claude-cli: flow=validate ... -->` y
+           un bloque "Findings" con qué corregir.
+        2. Re-generá el plan consolidado APLICANDO esos findings.
+        3. Quitá el label `plan-validated:changes-requested` del issue
+           con `gh issue edit <N> --remove-label plan-validated:changes-requested`.
+
+      Si NO tiene ese label, asumí que es la primera vuelta sobre el issue.
+
+      Para cada issue:
+
+      1. `gh issue edit <N> --add-label che:planning --remove-label che:idea`
+         (transición al estado "planning"; mutex visual mientras trabajás).
+
+      2. Leé el body del issue completo.
+
+      3. Generá el análisis y el plan. Trabajalo mentalmente con esta forma:
+
+         PARTE A — análisis:
+           - summary: paráfrasis accionable del issue (1-2 oraciones).
+           - questions: SOLO ambigüedades de producto irreducibles
+             (kind=product). Las técnicas las decidís vos como assumption.
+           - assumptions: decisiones de ingeniería que tomaste (API shape,
+             refactor order, naming) con justificación corta.
+           - risks: al menos 1, con likelihood/impact (low/medium/high) y
+             mitigation.
+           - paths: al menos 2 caminos distintos con pros/cons/effort
+             (XS-XL). Marcá EXACTAMENTE UNO como recomendado.
+           - next_step: frase accionable de qué tiene que pasar antes de
+             ejecutar.
+
+         PARTE B — plan consolidado (basado en el path recommended):
+           - summary, goal, acceptance_criteria (>=1 observable),
+             approach, steps (>=1 concreto), risks_to_mitigate,
+             out_of_scope.
+           El plan tiene que ser autocontenido: alguien que lea SOLO ese
+           plan tiene que poder arrancar a implementar.
+
+      4. Posteá el análisis (PARTE A) como comment del issue:
+
+             gh issue comment <N> --body-file <tmp.md>
+
+         El comment arranca con esta línea HTML (header tracking):
+
+             <!-- claude-cli: flow=explore iter=1 agent=claude role=executor -->
+
+         Y después en markdown:
+
+             ## [executor:claude · iter:1]
+
+             **Resumen:** <summary>
+
+             ### Decisiones técnicas tomadas
+             - **<assumption.what>** — <assumption.why>
+             ...
+
+             ### Preguntas abiertas
+             - **<q>** — <why>     ← prefijar con "🚧 " si blocker=true
+             (o "_Sin ambigüedades de producto irreducibles._" si vacío)
+
+             ### Riesgos
+             - **<risk>** (likelihood=<x>, impact=<y>) — <mitigation>
+
+             ### Caminos posibles
+             **<title>** (effort=<X>) ⭐ _recomendado_   ← solo el ganador
+             <sketch>
+             - Pros: ...
+             - Cons: ...
+
+             ### Próximo paso
+             <next_step>
+
+      5. Reescribí el BODY del issue con el plan consolidado (PARTE B).
+         Conservá el body original como bloque colapsable y agregá el
+         plan al principio:
+
+             gh issue edit <N> --body-file <tmp-body.md>
+
+         El nuevo body arranca con:
+
+             ## Plan consolidado
+
+             **Resumen:** <summary>
+
+             **Goal:** <goal>
+
+             **Approach:** <approach>
+
+             **Criterios de aceptación:**
+             - [ ] <criterio 1>
+             - [ ] ...
+
+             **Pasos:**
+             1. <paso 1>
+             2. ...
+
+             **Riesgos a mitigar:**
+             - <risk> (likelihood=<x>, impact=<y>) — <mitigation>
+
+             **Fuera de alcance:**
+             - <out_of_scope>
+
+             ---
+
+             <details><summary>Idea original</summary>
+
+             <body original del issue>
+
+             </details>
+
+      6. Transición de label:
+             gh issue edit <N> --add-label che:plan --remove-label che:planning
+
+      Reglas duras:
+      - questions[] solo con kind=product. Técnicas/documentadas son
+        decisiones tuyas.
+      - paths[] >=2 con UNO recomendado.
+      - El plan consolidado NO contiene preguntas ni "a definir": resolvé
+        ambigüedad técnica como assumption.
+      - No inventes archivos.
+
+      Al final del step, devolvé el bloque OUTPUT con la misma lista de
+      issues (preservá number/url/title) para que el siguiente step la use:
+
+          OUTPUT:
+          issues:
+            - number: <N>
+              url: <url>
+              title: <título>
+              plan_committed: true
+            - number: ...
+
+      Issues a procesar:
+      <<<
+      {{INPUT}}
+      >>>
+    validator:
+      cli: codex
+      kind: prompt
+      content: |
+        Sos un validador técnico senior. Otro agente produjo un PLAN DE
+        IMPLEMENTACIÓN para uno o más issues. Tu tarea es revisar el plan
+        ANTES de que se empiece a codear y marcar lo que está flojo — NO
+        reescribir el plan.
+
+        INPUT — el bloque OUTPUT del step explore contiene la lista de
+        issues con `plan_committed: true`. Para CADA issue:
+
+        1. `gh issue view <N> --json body,labels` y extraé la sección
+           "## Plan consolidado" del body.
+
+        2. Chequeá específicamente:
+           a. ¿goal y summary son consistentes con el título del issue?
+           b. ¿Los criterios son observables y testeables? (Evitá "funciona
+              bien".)
+           c. ¿Los pasos son concretos y accionables, end-to-end?
+           d. ¿El effort implícito es razonable?
+           e. ¿Faltan riesgos obvios que el plan no menciona?
+           f. ¿Hay asunciones del plan que no son correctas (dep que no
+              existe, API distinta)?
+           g. ¿El approach descartó alternativas razonables sin justificar?
+           h. ¿Hay ambigüedad de producto irreducible que el plan resolvió
+              arbitrariamente y debería escalarse al humano?
+
+        3. Decidí verdict global del issue:
+           - approve: plan listo para ejecutar.
+           - changes_requested: gaps técnicos a corregir antes de ejecutar.
+           - needs_human: ambigüedad de producto irreducible.
+
+        4. Posteá un comment en el issue con header tracking:
+
+               <!-- claude-cli: flow=validate iter=1 agent=codex role=validator -->
+               ## [validator:codex · iter:1] — verdict: <verdict>
+
+               **Resumen:** <tu opinión global, 1-2 oraciones>
+
+               ### Findings
+               - **[<severity>] <area> @ <where>**: <issue>
+                 _Sugerencia:_ <suggestion>
+                 (kind=<technical|product|documented>, needs_human=<bool>)
+               ...
+
+           where puede referenciar steps[3], approach, acceptance_criteria,
+           etc. — no hay paths de archivo todavía.
+
+           gh issue comment <N> --body-file <tmp.md>
+
+        5. Aplicá el label correspondiente, removiendo cualquier
+           plan-validated:* previo (mutex):
+
+               gh issue edit <N> \
+                 --remove-label plan-validated:approve \
+                 --remove-label plan-validated:changes-requested \
+                 --remove-label plan-validated:needs-human \
+                 --add-label plan-validated:<verdict-en-kebab>
+
+           Si los labels no existen, primero `gh label create
+           plan-validated:<verdict> --force`.
+
+        Reglas:
+        - Si todo OK, verdict=approve y findings=[].
+        - needs_human requiere kind=product Y decisión del dueño.
+        - No inventes faltantes.
+
+        Devolvé al runner UNA SOLA línea con el verdict consolidado de
+        TODOS los issues (el peor gana: needs_human > changes_requested >
+        approve), para que max_loops/on_max_loops decidan continuar:
+
+            VALIDATOR_VERDICT: <approve|changes_requested|needs_human>
+
+        Bloque OUTPUT del explore:
+        <<<
+        {{INPUT}}
+        >>>
+    max_loops: 3
+    on_max_loops: pause
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # STEP 3 — execute (con validator de PR + iterate via max_loops)
+  # ───────────────────────────────────────────────────────────────────────────
+  # Input: OUTPUT del step explore (issues con plan validado).
+  # Acción: por cada issue, parsear el plan del body, crear worktree,
+  #         implementar, commit + push, abrir PR draft contra main, aplicar
+  #         che:executing → che:executed.
+  # Validator (codex): revisar el diff del PR, postear comment, aplicar
+  #                    validated:*. Si changes_requested → max_loops=3
+  #                    re-corre execute con feedback (iterate).
+  - name: execute
+    cli: claude
+    kind: prompt
+    input: previous_output
+    content: |
+      Sos un ingeniero senior ejecutando planes ya consolidados. Tenés
+      acceso al filesystem, a git y a gh.
+
+      INPUT — el bloque OUTPUT del step explore contiene la lista de
+      issues con plan validado. Procesalos en orden.
+
+      Para cada issue:
+
+      1. Pre-check de estado del issue:
+             gh issue view <N> --json labels,body,comments
+
+         Si el label es `validated:changes-requested` (label del PR previo
+         propagado al issue), o si el PR asociado tiene ese label, este
+         es un re-run para aplicar feedback. En ese caso:
+           - Encontrá el PR asociado: `gh pr list --search "<N> in:body" --json number,headRefName --state open`
+             o seguí el branch convention `exec/<N>-<slug>`.
+           - Hacé checkout del worktree existente en `.worktrees/issue-<N>`.
+           - Leé el comment de validate más reciente del PR (header
+             flow=validate role=validator) para los findings.
+           - Aplicá los fixes en los archivos.
+           - Commit + push (NO abrir PR nuevo, ya existe).
+           - Quitá `validated:changes-requested` del PR:
+                 gh pr edit <PR#> --remove-label validated:changes-requested
+           - Saltá al paso 9.
+
+         Si no, primera vuelta — seguí desde el paso 2.
+
+      2. Parsear el plan del body del issue (sección "## Plan consolidado").
+         Extraé summary, goal, acceptance_criteria, approach, steps,
+         out_of_scope.
+
+      3. Transición:
+             gh issue edit <N> --add-label che:executing --remove-label che:plan
+
+      4. Crear worktree y branch:
+             slug=$(echo "<título-del-issue>" | tr 'A-Z' 'a-z' | tr -c 'a-z0-9' '-' | sed 's/--*/-/g;s/^-//;s/-$//' | cut -c1-40)
+             branch="exec/<N>-${slug}"
+             git worktree add -b "${branch}" ".worktrees/issue-<N>" main
+
+      5. Implementar el plan dentro del worktree (cwd=`.worktrees/issue-<N>`).
+         Usá Read/Write/Edit. Trabajá SOLO en el scope del plan; no toques
+         out_of_scope.
+
+         Si un paso no se puede completar (falta info, dep bloqueada),
+         dejá un archivo `EXEC_NOTES.md` en el worktree con lo que quedó
+         pendiente — esa info va al body del PR.
+
+      6. Verificá localmente cuando sea barato (ej. `go test ./...` si es
+         Go, `npm test` si Node) antes de commitear. Si los tests fallan
+         por algo del scope, arreglalo. Si fallan por algo no relacionado,
+         anotalo en EXEC_NOTES.md y seguí.
+
+      7. Commit + push:
+             cd .worktrees/issue-<N>
+             git add -A
+             git commit -m "feat: <descripción accionable, primera línea del título del issue>
+
+             Closes #<N>"
+             git push -u origin "${branch}"
+
+      8. Crear PR draft:
+             gh pr create \
+               --draft \
+               --base main \
+               --head "${branch}" \
+               --title "<título del issue>" \
+               --body-file <pr-body.md>
+
+         Body del PR:
+
+             ## Resumen
+             <summary del plan>
+
+             ## Cambios
+             <2-4 bullets de qué tocaste>
+
+             ## Criterios cubiertos
+             - [x] <criterio 1>
+             - [x] <criterio 2>
+
+             ## Notas de ejecución
+             <contenido de EXEC_NOTES.md si existe, o "—">
+
+             Closes #<N>
+
+      9. Transición:
+             gh issue edit <N> --add-label che:executed --remove-label che:executing
+
+      10. Posteá comment en el issue linkeando al PR:
+              gh issue comment <N> --body "PR draft abierto: <PR-URL>"
+
+      Reglas duras:
+      - No commitees secretos ni archivos de config sensibles.
+      - No hagas force-push que pise commits ajenos.
+      - No abras PRs nuevos en re-runs: actualizá el existente.
+      - Si el fix es imposible sin decisión humana, NO commitees nada,
+        explicá por qué en EXEC_NOTES.md, dejá el issue en che:executing.
+        El humano decide.
+
+      Al final, devolvé al runner el bloque OUTPUT con la lista de PRs:
+
+          OUTPUT:
+          prs:
+            - issue: <N>
+              pr: <PR#>
+              url: <PR-URL>
+              branch: exec/<N>-<slug>
+              has_exec_notes: <bool>
+            - ...
+
+      Issues a ejecutar:
+      <<<
+      {{INPUT}}
+      >>>
+    validator:
+      cli: codex
+      kind: prompt
+      content: |
+        Sos un validador técnico senior. Otro agente implementó cambios en
+        uno o más PRs. Tu tarea es leer el DIFF y marcar lo que falta o
+        está mal — NO reimplementar nada.
+
+        INPUT — el bloque OUTPUT del step execute contiene una lista `prs:`
+        con el número de cada PR. Para CADA PR:
+
+        1. Leé el diff:
+               gh pr diff <PR#>
+           y el body:
+               gh pr view <PR#> --json title,body,files
+
+        2. Chequeá específicamente:
+           a. ¿El diff hace lo que el título del PR dice?
+           b. ¿Hay regresiones obvias (tests rotos, edge cases sin cubrir,
+              lógica incorrecta)?
+           c. ¿Hay code smells o problemas de diseño que merezcan
+              escalarse?
+           d. ¿Los tests cubren los cambios o hay gaps importantes?
+           e. ¿Hay problemas de seguridad (input validation, auth, inj)?
+           f. ¿Los criterios de aceptación del plan original están todos
+              cubiertos por el diff?
+
+        3. Decidí verdict:
+           - approve: diff correcto y suficiente.
+           - changes_requested: hay cosas técnicas a corregir.
+           - needs_human: ambigüedad de producto irreducible.
+
+        4. Posteá comment en el PR con header tracking:
+
+               <!-- claude-cli: flow=validate iter=1 agent=codex role=validator -->
+               ## [validator:codex · iter:1] — verdict: <verdict>
+
+               **Resumen:** <opinión global>
+
+               ### Findings
+               - **[<severity>] <area> @ <where>**: <issue>
+                 _Sugerencia:_ <suggestion>
+                 (kind=<technical|product|documented>, needs_human=<bool>)
+
+           where = path/file.go:line o función.
+
+               gh pr comment <PR#> --body-file <tmp.md>
+
+        5. Label mutex en el PR:
+
+               gh pr edit <PR#> \
+                 --remove-label validated:approve \
+                 --remove-label validated:changes-requested \
+                 --remove-label validated:needs-human \
+                 --add-label validated:<verdict-en-kebab>
+
+           Crear labels con `gh label create validated:<v> --force` si no
+           existen.
+
+        Reglas:
+        - Si el diff cubre algo aunque sea brevemente, NO marcarlo como
+          gap.
+        - needs_human requiere kind=product Y decisión del dueño.
+        - approve = findings vacío.
+
+        Devolvé al runner el verdict consolidado (peor gana):
+
+            VALIDATOR_VERDICT: <approve|changes_requested|needs_human>
+
+        Bloque OUTPUT del execute:
+        <<<
+        {{INPUT}}
+        >>>
+    max_loops: 3
+    on_max_loops: pause
+
+  # ───────────────────────────────────────────────────────────────────────────
+  # STEP 4 — close
+  # ───────────────────────────────────────────────────────────────────────────
+  # Input: OUTPUT del step execute (PRs validados).
+  # Acción: marcar PR ready, esperar CI, fix loop si conflict/CI rojo (≤3),
+  #         mergear, borrar branch, cerrar issues asociados, postear
+  #         comment template de scoring 1-10 (NO gating; el humano lo
+  #         llena después), aplicar che:closing → che:closed.
+  - name: close
+    cli: claude
+    kind: prompt
+    input: previous_output
+    content: |
+      Sos un ingeniero senior cerrando PRs. Tu objetivo es dejarlos
+      mergeados y limpios; el scoring humano lo hace el usuario después
+      via comment template.
+
+      INPUT — el bloque OUTPUT del step execute contiene una lista `prs:`
+      con número, branch e issue asociado. Procesá cada PR:
+
+      1. Leé estado del PR:
+             gh pr view <PR#> --json state,mergeable,isDraft,statusCheckRollup,closingIssuesReferences
+
+         Si state=MERGED, saltá este PR (ya cerró).
+         Si state=CLOSED y no MERGED, NO toques: el humano lo cerró aparte.
+         Si isDraft=true, marcalo ready:
+             gh pr ready <PR#>
+
+      2. Aplicá transición al issue asociado:
+             issue=$(gh pr view <PR#> --json closingIssuesReferences -q '.closingIssuesReferences[0].number')
+             gh issue edit "$issue" --add-label che:closing --remove-label che:executed
+
+      3. Fix loop (≤3 intentos): si mergeable=CONFLICTING o el rollup tiene
+         checks failing, invocá el fix:
+
+             cd .worktrees/issue-<issue>      # reusá worktree existente
+             git fetch origin main
+             git merge origin/main            # resolvé conflictos si los hay
+             # corré tests locales si es barato
+             # si CI fallaba, leé `gh run view --log-failed <run-id>` y
+             # arreglá el código real (no parches que tapen síntomas)
+             git add -A
+             git commit -m "fix: <descripción del arreglo>"
+             git push
+
+         Después del push, esperá CI:
+             gh pr checks <PR#> --watch
+
+         Si después de 3 intentos sigue rojo o conflictivo, NO mergees.
+         Posteá comment explicando qué bloquea y dejá el PR en
+         che:closing — el humano decide.
+
+      4. Mergear con merge commit (NO squash, preservamos historia):
+             gh pr merge <PR#> --merge --delete-branch
+
+         `--delete-branch` borra branch remota y local. Después borrá el
+         worktree:
+             git worktree remove --force .worktrees/issue-<issue> 2>/dev/null || true
+
+      5. Cerrar issue(s) asociado(s) — el `Closes #N` del body del PR ya
+         los cierra al mergear, pero aplicamos la transición de label:
+
+             gh issue edit "$issue" --add-label che:closed --remove-label che:closing
+
+         Quitá labels bloqueantes residuales:
+
+             gh issue edit "$issue" \
+               --remove-label plan-validated:changes-requested \
+               --remove-label plan-validated:needs-human || true
+             gh pr edit <PR#> \
+               --remove-label validated:changes-requested \
+               --remove-label validated:needs-human || true
+
+      6. Postear comment de scoring template en el PR (sin gate):
+
+             gh pr comment <PR#> --body-file <scoring-template.md>
+
+         Template:
+
+             <!-- claude-cli: flow=close iter=1 agent=claude role=scoring-template -->
+             ## Scoring del cierre
+
+             Para que el humano puntúe del 1 al 10 cuando tenga 5 minutos.
+
+             - **Completitud** (cuánto del plan se cumplió): __/10
+             - **Fidelidad** (qué tan bien se siguió el approach): __/10
+             - **Alineación** (qué tan en línea quedó con la idea original): __/10
+
+             **Notas libres:**
+             > <reemplazar con notas, friction points, lecciones>
+
+             _El embudo no usa este score como gate; vive como historia
+             del PR. Si querés tracking, usá `gh pr list --json comments`
+             y filtrá por este header._
+
+      Reglas duras:
+      - Si CI nunca pasa después de 3 intentos, NO mergees. Dejá el PR
+        en che:closing y el issue también, postea comment explicando.
+      - No cambies la base del PR ni abras PRs nuevos.
+      - No force-push.
+
+      Al final devolvé el resumen:
+
+          OUTPUT:
+          closed:
+            - issue: <N>
+              pr: <PR#>
+              merged: <bool>
+              reason_if_not_merged: <opcional>
+            - ...
+
+      PRs a cerrar:
+      <<<
+      {{INPUT}}
+      >>>

--- a/internal/wizard/embedded_test.go
+++ b/internal/wizard/embedded_test.go
@@ -1,0 +1,132 @@
+package wizard
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestBuiltins_ParseAndStructure verifica que cada builtin parsea y tiene
+// la forma minima esperada. No corremos IsValid aca porque depende de la
+// deteccion de CLIs (el harness de tests no instala claude/codex/gemini).
+// IsValid se cubre con TestBuiltins_IsValidWithMockedCLIs abajo.
+func TestBuiltins_ParseAndStructure(t *testing.T) {
+	bs, err := Builtins()
+	if err != nil {
+		t.Fatalf("Builtins() error: %v", err)
+	}
+	if len(bs) == 0 {
+		t.Fatal("Builtins() devolvio vacio — esperabamos al menos che-funnel")
+	}
+
+	wantSlugs := map[string]bool{"che-funnel": true}
+	for _, b := range bs {
+		if !wantSlugs[b.Slug] {
+			t.Errorf("slug inesperado: %q", b.Slug)
+		}
+		if len(b.Source) == 0 {
+			t.Errorf("%s: Source vacio", b.Slug)
+		}
+		if b.Pipeline.Name == "" {
+			t.Errorf("%s: Pipeline.Name vacio", b.Slug)
+		}
+		if len(b.Pipeline.Steps) == 0 {
+			t.Errorf("%s: Pipeline.Steps vacio", b.Slug)
+		}
+	}
+}
+
+func TestBuiltins_CheFunnelShape(t *testing.T) {
+	bs, err := Builtins()
+	if err != nil {
+		t.Fatalf("Builtins() error: %v", err)
+	}
+	var cf *BuiltinPipeline
+	for i := range bs {
+		if bs[i].Slug == "che-funnel" {
+			cf = &bs[i]
+			break
+		}
+	}
+	if cf == nil {
+		t.Fatal("che-funnel no encontrado en builtins")
+	}
+
+	wantSteps := []string{"idea", "explore", "execute", "close"}
+	if got := len(cf.Pipeline.Steps); got != len(wantSteps) {
+		t.Fatalf("steps len: got %d want %d", got, len(wantSteps))
+	}
+	for i, want := range wantSteps {
+		if got := cf.Pipeline.Steps[i].Name; got != want {
+			t.Errorf("step[%d].Name: got %q want %q", i, got, want)
+		}
+	}
+
+	// explore y execute deben tener validator (la "iteracion" del che
+	// clasico vive ahi via max_loops).
+	for _, idx := range []int{1, 2} {
+		s := cf.Pipeline.Steps[idx]
+		if s.Validator == nil {
+			t.Errorf("step[%d] (%s): validator esperado no nil", idx, s.Name)
+			continue
+		}
+		if s.MaxLoops <= 0 {
+			t.Errorf("step[%d] (%s): max_loops esperado > 0, got %d", idx, s.Name, s.MaxLoops)
+		}
+	}
+
+	// idea es el primer step y NO puede usar previous_output.
+	if cf.Pipeline.Steps[0].Input == InputPreviousOutput {
+		t.Errorf("step[0] (idea): input=previous_output no es valido en step 0")
+	}
+}
+
+func TestBuiltins_IsValidWithMockedCLIs(t *testing.T) {
+	prev := detectInstalledCLIs
+	t.Cleanup(func() { detectInstalledCLIs = prev })
+	detectInstalledCLIs = func() []string { return []string{"claude", "codex", "gemini", "opencode"} }
+
+	bs, err := Builtins()
+	if err != nil {
+		t.Fatalf("Builtins() error: %v", err)
+	}
+	for _, b := range bs {
+		if err := IsValid(b.Pipeline); err != nil {
+			t.Errorf("%s: IsValid error: %v", b.Slug, err)
+		}
+	}
+}
+
+// TestBuiltins_SourceIsRoundtripParseable garantiza que Source es el YAML
+// crudo y no una serializacion derivada (necesario para copy-on-edit:
+// cuando escribimos el archivo al FS, el usuario tiene que ver el mismo
+// contenido que ve el binario).
+func TestBuiltins_SourceIsRoundtripParseable(t *testing.T) {
+	bs, err := Builtins()
+	if err != nil {
+		t.Fatalf("Builtins() error: %v", err)
+	}
+	for _, b := range bs {
+		p, err := Unmarshal(b.Source)
+		if err != nil {
+			t.Errorf("%s: re-Unmarshal del Source fallo: %v", b.Slug, err)
+			continue
+		}
+		if p.Name != b.Pipeline.Name {
+			t.Errorf("%s: roundtrip Name mismatch: %q vs %q", b.Slug, p.Name, b.Pipeline.Name)
+		}
+		if len(p.Steps) != len(b.Pipeline.Steps) {
+			t.Errorf("%s: roundtrip Steps len mismatch: %d vs %d", b.Slug, len(p.Steps), len(b.Pipeline.Steps))
+		}
+	}
+
+	// Sanity: el header del YAML va a empezar con un comentario "che-funnel".
+	// Si rompemos el orden o lo regeneramos perderiamos el comment block.
+	for _, b := range bs {
+		if b.Slug == "che-funnel" {
+			head := string(b.Source)
+			if !strings.Contains(head, "che-funnel") {
+				t.Errorf("che-funnel: Source no contiene el slug en el header")
+			}
+		}
+	}
+}

--- a/internal/wizard/list.go
+++ b/internal/wizard/list.go
@@ -60,6 +60,13 @@ type listItem struct {
 	// el render — el flag persiste el "este pipeline asume repo" sin
 	// re-parsear los steps por keystroke).
 	needsRepo bool
+	// isBuiltin = pipeline shippeado embedded en el binario (ver Builtins()).
+	// Aparece siempre en la lista con chip [default]; no tiene path en el FS
+	// hasta que el usuario lo personaliza (copy-on-edit). Enter ejecuta usando
+	// el target sentinel "builtin:<slug>"; e / y disparan copy-on-edit a
+	// ~/.che/pipelines/<slug>.yaml; d se rechaza con toast.
+	isBuiltin     bool
+	builtinSource []byte // YAML crudo del builtin para copy-on-edit
 }
 
 // listModel es el bubbletea model del lister "My pipelines".
@@ -134,23 +141,58 @@ func loadListItemsCmd(home string) tea.Cmd {
 // activo, asi que reusar editorFinishedMsg directamente es seguro. El
 // wrapper queda comentado por si en el futuro hay UI compartida.
 
-// loadListItems lee ~/.che/pipelines/*.yaml, parsea cada uno, y devuelve la
-// lista ordenada por when desc (mas reciente primero). Archivos ilegibles o
-// con YAML invalido se skipean en silencio (decision: pipelines corruptos no
-// deben volar el lister; al hacer enter sobre uno tampoco habria como
-// reanudarlo). Si el dir no existe, devuelve lista vacia (caso "primer uso").
+// loadListItems lee ~/.che/pipelines/*.yaml, mergea con los builtins
+// embedded del binario, y devuelve la lista ordenada por when desc (mas
+// reciente primero). Si el usuario tiene un archivo cuyo slug coincide con
+// un builtin (ej. ~/.che/pipelines/che-funnel.yaml), su override gana y el
+// builtin queda hidden — semantica de shadow file.
+//
+// Archivos ilegibles o con YAML invalido del FS se skipean en silencio
+// (pipelines corruptos no deben volar el lister; al hacer enter sobre uno
+// tampoco habria como reanudarlo). Builtins que no parsean SI rompen el
+// load — eso es bug del binario, no del usuario, y queremos verlo.
+//
+// Si el dir no existe, devolvemos solo los builtins (caso "primer uso").
 func loadListItems(homeDir string) ([]listItem, error) {
 	dir, err := PipelinesDir(homeDir)
 	if err != nil {
 		return nil, err
 	}
+	fsItems, fsSlugs, err := loadFSItems(dir, homeDir)
+	if err != nil {
+		return nil, err
+	}
+	builtins, err := Builtins()
+	if err != nil {
+		// El binario tiene un builtin invalido — abortamos el load para que
+		// el caller surface el error en vez de ocultarlo.
+		return nil, err
+	}
+	items := fsItems
+	for _, b := range builtins {
+		if fsSlugs[b.Slug] {
+			// Override del FS gana: el builtin queda hidden.
+			continue
+		}
+		items = append(items, builtinToListItem(b))
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		return items[i].when.After(items[j].when)
+	})
+	return items, nil
+}
+
+// loadFSItems lee los pipelines del FS. Devuelve los items + el set de
+// slugs presentes (para el dedupe de builtins en loadListItems).
+func loadFSItems(dir, homeDir string) ([]listItem, map[string]bool, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil, map[string]bool{}, nil
 		}
-		return nil, err
+		return nil, nil, err
 	}
+	slugs := map[string]bool{}
 	var items []listItem
 	for _, ent := range entries {
 		if ent.IsDir() {
@@ -203,12 +245,88 @@ func loadListItems(homeDir string) ([]listItem, error) {
 		// chip pasa por repoctx.Detect() en el render — el flag de aca solo
 		// dice "este pipeline asume repo".
 		item.needsRepo = PipelineNeedsRepo(p)
+		slugs[item.slug] = true
 		items = append(items, item)
 	}
-	sort.SliceStable(items, func(i, j int) bool {
-		return items[i].when.After(items[j].when)
-	})
-	return items, nil
+	return items, slugs, nil
+}
+
+// builtinToListItem proyecta un BuiltinPipeline al shape que el lister
+// renderea. when = epoch zero para que el sort por when desc lo deje al
+// final (los items del FS siempre son mas recientes); en la practica con
+// solo un builtin esto no se nota, pero deja la semantica consistente
+// si en el futuro shipeamos varios.
+func builtinToListItem(b BuiltinPipeline) listItem {
+	return listItem{
+		path:          "",
+		name:          b.Pipeline.Name,
+		description:   b.Pipeline.Description,
+		nSteps:        len(b.Pipeline.Steps),
+		when:          time.Time{}, // sort: queda al final
+		slug:          b.Slug,
+		needsRepo:     PipelineNeedsRepo(b.Pipeline),
+		isBuiltin:     true,
+		builtinSource: b.Source,
+	}
+}
+
+// builtinTargetPrefix es el sentinel que el lister usa al devolver
+// ListActionRun sobre un builtin. El runner detecta el prefijo y carga el
+// pipeline via wizard.Builtins() en vez de tocar el FS.
+const builtinTargetPrefix = "builtin:"
+
+// IsBuiltinTarget devuelve true si target tiene el prefijo de builtin.
+// El runner lo usa para ramificar entre Load(path) y BuiltinBySlug.
+func IsBuiltinTarget(target string) bool {
+	return strings.HasPrefix(target, builtinTargetPrefix)
+}
+
+// BuiltinSlugFromTarget extrae el slug de un target sentinel. Si target
+// no tiene el prefijo, devuelve "" — el caller debe haber chequeado con
+// IsBuiltinTarget primero.
+func BuiltinSlugFromTarget(target string) string {
+	if !IsBuiltinTarget(target) {
+		return ""
+	}
+	return strings.TrimPrefix(target, builtinTargetPrefix)
+}
+
+// BuiltinBySlug busca un builtin por slug. Devuelve (nil, nil) si no existe;
+// (nil, err) si Builtins() falla (bug del binario).
+func BuiltinBySlug(slug string) (*BuiltinPipeline, error) {
+	bs, err := Builtins()
+	if err != nil {
+		return nil, err
+	}
+	for i := range bs {
+		if bs[i].Slug == slug {
+			return &bs[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// copyBuiltinToFS escribe el YAML crudo del builtin a ~/.che/pipelines/<slug>
+// .yaml y devuelve el path. Si el archivo ya existe (porque el usuario ya
+// hizo copy-on-edit antes pero no aparece en la lista por algun race), no
+// lo pisa — devolvemos el path existente. La proxima loadListItems va a
+// detectar el shadow y ocultar al builtin.
+func copyBuiltinToFS(homeDir, slug string, source []byte) (string, error) {
+	dir, err := EnsureDir(homeDir)
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, slug+".yaml")
+	if _, err := os.Stat(path); err == nil {
+		// Ya existe — no pisamos para evitar perder ediciones del usuario.
+		return path, nil
+	} else if !os.IsNotExist(err) {
+		return "", err
+	}
+	if err := os.WriteFile(path, source, 0o600); err != nil {
+		return "", err
+	}
+	return path, nil
 }
 
 // RunList levanta el lister "My pipelines" usando $HOME real.
@@ -329,8 +447,15 @@ func (m listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// ready: H1 del flow de runner — enter dispara la screen del
 		// runner skeleton. El caller (cmd/root.go.runMyPipelines) rutea
 		// ListActionRun a runner.Run(target).
+		// Builtins se identifican con el sentinel "builtin:<slug>" — el
+		// runner detecta el prefijo y carga el pipeline desde memoria via
+		// wizard.Builtins() en vez de leer del FS.
 		m.action = ListActionRun
-		m.target = sel.path
+		if sel.isBuiltin {
+			m.target = builtinTargetPrefix + sel.slug
+		} else {
+			m.target = sel.path
+		}
 		return m, tea.Quit
 	case "e":
 		if len(m.items) == 0 {
@@ -344,11 +469,37 @@ func (m listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.target = sel.path
 			return m, tea.Quit
 		}
+		if sel.isBuiltin {
+			// Copy-on-edit: el builtin no es editable in-place porque vive
+			// embedded en el binario. Lo escribimos al FS del usuario y
+			// abrimos el wizard como ready edit sobre la copia. La proxima
+			// vez que el lister cargue, el shadow del FS oculta al builtin
+			// (la copia queda como su override personal).
+			path, err := copyBuiltinToFS(m.homeDir, sel.slug, sel.builtinSource)
+			if err != nil {
+				m.toast = "no pude copiar el default: " + err.Error()
+				m.toastOK = false
+				return m, nil
+			}
+			m.action = ListActionEditReady
+			m.target = path
+			return m, tea.Quit
+		}
 		m.action = ListActionEditReady
 		m.target = sel.path
 		return m, tea.Quit
 	case "d":
 		if len(m.items) == 0 {
+			return m, nil
+		}
+		sel := m.items[m.cursor]
+		if sel.isBuiltin {
+			// Builtins no se borran. Si el usuario quiere "ocultarlo",
+			// puede crear un shadow en ~/.che/pipelines/ y borrarlo cuando
+			// quiera — pero sacar el default mismo del binario seria
+			// confuso (volveria al primer load).
+			m.toast = "default embebido — no se puede borrar"
+			m.toastOK = false
 			return m, nil
 		}
 		m.delConfirm = true
@@ -359,6 +510,20 @@ func (m listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		sel := m.items[m.cursor]
+		if sel.isBuiltin {
+			// Mismo principio que `e`: el builtin no tiene path en el FS.
+			// Copy-on-edit primero, despues el editor abre la copia. El
+			// usuario edita y guarda como cualquier otro pipeline.
+			path, err := copyBuiltinToFS(m.homeDir, sel.slug, sel.builtinSource)
+			if err != nil {
+				m.toast = "no pude copiar el default: " + err.Error()
+				m.toastOK = false
+				return m, nil
+			}
+			m.toast = "copia creada en ~/.che/pipelines/" + sel.slug + ".yaml"
+			m.toastOK = true
+			return m, openEditorCmd(path)
+		}
 		return m, openEditorCmd(sel.path)
 	case "r":
 		// H10: r abre la pantalla "Run history" del row seleccionado.
@@ -500,6 +665,9 @@ func (m listModel) applyDelete() (tea.Model, tea.Cmd) {
 var (
 	chipReadyStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#50FA7B")).Bold(true)
 	chipDraftStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#F1FA8C")).Bold(true)
+	// chipDefaultStyle marca builtin pipelines (cyan dracula). Va junto al
+	// chip [ready] para distinguir lo embedded de lo creado por el usuario.
+	chipDefaultStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#8BE9FD")).Bold(true)
 	// chipFailStyle / chipWarnStyle / chipInfoStyle son los chips del
 	// "last run" por status (H10). Rojo para failed, amarillo para
 	// cancelled, gris para interrupted/never. Done reusa chipReadyStyle
@@ -583,6 +751,12 @@ func renderListRow(it listItem) string {
 	chip := chipReadyStyle.Render("[ready]")
 	if it.isDraft {
 		chip = chipDraftStyle.Render("[draft]")
+	}
+	if it.isBuiltin {
+		// Builtins son ready por construccion (no hay drafts embedded). El
+		// chip [default] reemplaza el "X ago" de when para no mentir con un
+		// timestamp ficticio (when=zero en builtins).
+		chip = chipDefaultStyle.Render("[default]") + "  " + chipReadyStyle.Render("[ready]")
 	}
 
 	when := relTime(it.when)

--- a/internal/wizard/list_test.go
+++ b/internal/wizard/list_test.go
@@ -1,0 +1,230 @@
+package wizard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// helperFakeAllCLIs hace que IsValid trate como instalados a los 4 CLIs v1.
+// Necesario para que loadListItems no rebote al cargar el builtin che-funnel
+// que invoca claude + codex.
+func helperFakeAllCLIs(t *testing.T) {
+	t.Helper()
+	prev := detectInstalledCLIs
+	t.Cleanup(func() { detectInstalledCLIs = prev })
+	detectInstalledCLIs = func() []string { return []string{"claude", "codex", "gemini", "opencode"} }
+}
+
+func TestLoadListItems_EmptyDirReturnsOnlyBuiltins(t *testing.T) {
+	helperFakeAllCLIs(t)
+	home := t.TempDir()
+
+	items, err := loadListItems(home)
+	if err != nil {
+		t.Fatalf("loadListItems: %v", err)
+	}
+	if len(items) == 0 {
+		t.Fatal("esperabamos al menos un builtin, got 0 items")
+	}
+	for _, it := range items {
+		if !it.isBuiltin {
+			t.Errorf("item %q no esperaba (no builtin) en dir vacio", it.name)
+		}
+	}
+	// Sanity: che-funnel tiene que estar.
+	found := false
+	for _, it := range items {
+		if it.slug == "che-funnel" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("che-funnel no aparecio entre los builtins")
+	}
+}
+
+func TestLoadListItems_FSItemsCoexistWithBuiltins(t *testing.T) {
+	helperFakeAllCLIs(t)
+	home := t.TempDir()
+	dir, err := EnsureDir(home)
+	if err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	// Pipeline ready del usuario, slug distinto al builtin.
+	user := Pipeline{
+		Name: "mi-flujo",
+		Steps: []Step{
+			{Name: "uno", CLI: "claude", Kind: "prompt", Content: "hola", Input: "text"},
+		},
+	}
+	if err := Save(filepath.Join(dir, "mi-flujo.yaml"), user); err != nil {
+		t.Fatalf("Save user: %v", err)
+	}
+
+	items, err := loadListItems(home)
+	if err != nil {
+		t.Fatalf("loadListItems: %v", err)
+	}
+
+	var sawUser, sawBuiltin bool
+	for _, it := range items {
+		switch it.slug {
+		case "mi-flujo":
+			sawUser = true
+			if it.isBuiltin {
+				t.Error("mi-flujo no deberia ser builtin")
+			}
+		case "che-funnel":
+			sawBuiltin = true
+			if !it.isBuiltin {
+				t.Error("che-funnel deberia ser builtin")
+			}
+		}
+	}
+	if !sawUser {
+		t.Error("mi-flujo no aparecio en la lista")
+	}
+	if !sawBuiltin {
+		t.Error("che-funnel no aparecio en la lista")
+	}
+}
+
+func TestLoadListItems_ShadowOverridesBuiltin(t *testing.T) {
+	helperFakeAllCLIs(t)
+	home := t.TempDir()
+	dir, err := EnsureDir(home)
+	if err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	// Shadow: archivo del usuario con el mismo slug que el builtin.
+	shadow := Pipeline{
+		Name: "che-funnel", // slug = "che-funnel"
+		Steps: []Step{
+			{Name: "custom", CLI: "claude", Kind: "prompt", Content: "x", Input: "text"},
+		},
+	}
+	if err := Save(filepath.Join(dir, "che-funnel.yaml"), shadow); err != nil {
+		t.Fatalf("Save shadow: %v", err)
+	}
+
+	items, err := loadListItems(home)
+	if err != nil {
+		t.Fatalf("loadListItems: %v", err)
+	}
+
+	var count int
+	var found listItem
+	for _, it := range items {
+		if it.slug == "che-funnel" {
+			count++
+			found = it
+		}
+	}
+	if count != 1 {
+		t.Errorf("esperaba 1 che-funnel (shadow gana), got %d", count)
+	}
+	if found.isBuiltin {
+		t.Error("el shadow deberia ganar — esperaba isBuiltin=false")
+	}
+	if found.path == "" {
+		t.Error("el shadow deberia tener path del FS")
+	}
+	if found.nSteps != 1 {
+		t.Errorf("nSteps del shadow: got %d want 1", found.nSteps)
+	}
+}
+
+func TestBuiltinTargetSentinel(t *testing.T) {
+	cases := []struct {
+		target  string
+		wantHit bool
+		wantSlug string
+	}{
+		{"builtin:che-funnel", true, "che-funnel"},
+		{"builtin:foo", true, "foo"},
+		{"/abs/path.yaml", false, ""},
+		{"", false, ""},
+		{"builtin:", true, ""}, // prefijo solo: hit pero slug vacio
+	}
+	for _, tc := range cases {
+		t.Run(tc.target, func(t *testing.T) {
+			if got := IsBuiltinTarget(tc.target); got != tc.wantHit {
+				t.Errorf("IsBuiltinTarget(%q): got %v want %v", tc.target, got, tc.wantHit)
+			}
+			if got := BuiltinSlugFromTarget(tc.target); got != tc.wantSlug {
+				t.Errorf("BuiltinSlugFromTarget(%q): got %q want %q", tc.target, got, tc.wantSlug)
+			}
+		})
+	}
+}
+
+func TestBuiltinBySlug(t *testing.T) {
+	b, err := BuiltinBySlug("che-funnel")
+	if err != nil {
+		t.Fatalf("BuiltinBySlug: %v", err)
+	}
+	if b == nil {
+		t.Fatal("che-funnel no encontrado")
+	}
+	if b.Slug != "che-funnel" {
+		t.Errorf("Slug: got %q want che-funnel", b.Slug)
+	}
+
+	b2, err := BuiltinBySlug("no-existe")
+	if err != nil {
+		t.Fatalf("BuiltinBySlug no-existe: %v", err)
+	}
+	if b2 != nil {
+		t.Errorf("esperaba nil para slug inexistente, got %+v", b2)
+	}
+}
+
+func TestCopyBuiltinToFS_WritesFile(t *testing.T) {
+	home := t.TempDir()
+	source := []byte("name: che-funnel\nsteps:\n  - name: x\n    cli: claude\n    kind: prompt\n    content: y\n    input: text\n")
+	path, err := copyBuiltinToFS(home, "che-funnel", source)
+	if err != nil {
+		t.Fatalf("copyBuiltinToFS: %v", err)
+	}
+	want := filepath.Join(home, ".che/pipelines/che-funnel.yaml")
+	if path != want {
+		t.Errorf("path: got %q want %q", path, want)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(got), "che-funnel") {
+		t.Errorf("contenido no contiene slug: got %q", string(got))
+	}
+}
+
+func TestCopyBuiltinToFS_DoesNotOverwriteExisting(t *testing.T) {
+	home := t.TempDir()
+	dir, err := EnsureDir(home)
+	if err != nil {
+		t.Fatalf("EnsureDir: %v", err)
+	}
+	existing := []byte("# editado por el usuario\nname: che-funnel\n")
+	path := filepath.Join(dir, "che-funnel.yaml")
+	if err := os.WriteFile(path, existing, 0o600); err != nil {
+		t.Fatalf("WriteFile setup: %v", err)
+	}
+
+	// Intentar copy-on-edit no deberia pisar.
+	source := []byte("# del binario (no me copies encima)\nname: che-funnel\n")
+	got, err := copyBuiltinToFS(home, "che-funnel", source)
+	if err != nil {
+		t.Fatalf("copyBuiltinToFS: %v", err)
+	}
+	if got != path {
+		t.Errorf("path: got %q want %q", got, path)
+	}
+	content, _ := os.ReadFile(path)
+	if !strings.Contains(string(content), "editado por el usuario") {
+		t.Errorf("contenido fue pisado: got %q", string(content))
+	}
+}


### PR DESCRIPTION
## Summary

Reintroduce el embudo clasico de v0.0.82 (`idea → explore → execute → close`) como pipeline **default shippeado con el binario**, para que usuarios que venian del che pre-revamp lo encuentren out-of-the-box sin tener que escribir su propio YAML. Toda la state machine de GitHub (labels `che:*`, issues, PRs, worktrees, comments, scoring) la dirigen los prompts mismos via tool use de `gh`/`git` — el runner del nuevo che no necesita logica adicional, el archivo es self-contained.

### Diferencias intencionales con v0.0.82

- **`iterate` desaparece como step manual**: cada validator tiene `max_loops=3`, asi que `changes_requested` re-corre el step con feedback hasta converger o agotar el cap.
- **`close` postea un comment template de scoring** (1-10 × 3 ejes) **sin gate humano**. El usuario lo llena post-merge.
- **Validator cross-CLI**: cada step usa `codex` como validator (mientras `claude` implementa) para reducir groupthink. Si solo hay claude, hay que editar el YAML — esta documentado en el header del archivo.

### UX en "My pipelines"

- El builtin aparece **siempre** con chip `[default]` (cyan dracula) al lado de `[ready]`.
- **Shadow override**: si el usuario tiene `~/.che/pipelines/che-funnel.yaml`, ese archivo gana y el builtin queda hidden.
- **Copy-on-edit**: `e` y `y` sobre el builtin escriben el YAML a `~/.che/pipelines/che-funnel.yaml` (sin pisar si ya existe) y abren el wizard / editor sobre la copia.
- **Delete bloqueado**: `d` sobre el builtin muestra toast `"default embebido — no se puede borrar"`.
- **Run**: enter sobre el builtin devuelve target sentinel `"builtin:<slug>"` que el runner resuelve via `wizard.BuiltinBySlug` en vez de tocar el FS.

## Files

- `internal/wizard/embedded/che-funnel.yaml` (~700 lineas) — el pipeline. Prompts portados de los 5 flows de v0.0.82, traducidos a tool use sobre `gh`/`git`.
- `internal/wizard/embedded.go` — `//go:embed`, `Builtins()`, `BuiltinBySlug()`.
- `internal/wizard/list.go` — merge de builtins en `loadListItems`, chip `[default]`, handlers de `e`/`d`/`y`/`enter` con branching por `isBuiltin`.
- `internal/runner/runner.go` — `loadPipelineForRun` ramifica entre sentinel `builtin:` y `wizard.Load`.
- `e2e/tui_test.go` — ajuste de `TestTUI_MenuItem1OpensMyPipelines`: con builtin embedded el dir vacio ya no muestra "no pipelines yet"; cambio el matcher al footer `"navegar"`.

## Test plan

- [x] `go test ./...` verde end-to-end (e2e + wizard + runner).
- [ ] Manual smoke: `make build && ./bin/che` → menu → 1 → ver `che-funnel  [default]  [ready]  4 steps` en la lista.
- [ ] Manual smoke: cursor sobre che-funnel + `d` → toast `"default embebido — no se puede borrar"`.
- [ ] Manual smoke: cursor sobre che-funnel + `e` → copia automatica a `~/.che/pipelines/che-funnel.yaml` + wizard abre en mode=edit.
- [ ] Manual smoke: con shadow en `~/.che/pipelines/che-funnel.yaml` el builtin desaparece de la lista.
- [ ] Manual smoke (opcional, requiere CLIs reales): enter sobre che-funnel → R1 (input texto) → primer step. Si claude o codex no estan instalados, `IsValid` rebota con mensaje claro antes de entrar al runner.

## Caveats / known gaps vs v0.0.82

Listados en el header del YAML para visibilidad del usuario:

- Sin validacion JSON-strict del output (en v0.0.82 codigo Go rechazaba responses sin `paths>=2`, criterios, etc). Aca depende del prompt; los validators cubren gaps.
- Sin selector de validadores multiples (1-3 en paralelo) — eso pertenece al modelo aspiracional (`agents` + `aggregator`) que aun no esta vivo.
- Sin rollback transactional en `idea` (si falla el Nth issue, en v0.0.82 cerraban los anteriores; aca depende del agente).
- `che eliminar` (descartar idea en cualquier estado) no portado; seria un step / subcomando aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)