### PR TITLE
fix(runner): unstick che-funnel validators on stream-json output

### DIFF
--- a/internal/runner/validator.go
+++ b/internal/runner/validator.go
@@ -23,6 +23,7 @@
 package runner
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -84,10 +85,22 @@ const (
 // Si nada matchea: devolvemos Verdict{Status: VerdictFail, Feedback: "no
 // verdict block"} (loop equivalente a un fail tolerante).
 //
-// Verdict.Status se normaliza a lower-case y se trimea. Cualquier valor
-// que no sea exactamente "ok" se trata como "fail" (defensivo: un modelo
-// confundido que emite verdict: failed o verdict: KO no engaña al loop).
+// Verdict.Status se normaliza a lower-case + trim y luego se mapea a las
+// dos ramas que entiende el loop (ok|fail). Tokens reconocidos:
+//   - "ok", "approve"                                  → VerdictOk
+//   - "fail", "changes_requested", "needs_human", o
+//     cualquier otro no-vacio (defensivo)              → VerdictFail
+//
+// Cuando un token 3-vias (changes_requested/needs_human) cae a fail sin
+// feedback explicito, parseVerdict guarda el token original en Feedback
+// para que el modal RP / merge-feedback muestre que tipo de fail fue.
 func parseVerdict(stdout string) Verdict {
+	// Si el validator es claude o codex, su stdout es NDJSON stream-json:
+	// el verdict del agente viene anidado en el `text` de un evento, no
+	// como YAML top-level. extractValidatorMessages devuelve solo el
+	// texto del agente concatenado; si nada matchea, devuelve el stdout
+	// tal cual (validators raw como gemini/opencode siguen funcionando).
+	stdout = extractValidatorMessages(stdout)
 	stdout = strings.TrimSpace(stdout)
 	if stdout == "" {
 		return Verdict{Status: VerdictFail, Feedback: "no verdict block"}
@@ -141,22 +154,131 @@ func splitVerdictBlocks(stdout string) []string {
 // (verdict, true) si parseo OK y Status no esta vacio. Cualquier otro caso
 // devuelve (_, false) — el caller sigue con el siguiente candidato.
 //
-// Status se normaliza a lower-case + trim; cualquier valor distinto de "ok"
-// se mapea a "fail" para que el loop tenga solo dos ramas.
+// Status se normaliza a lower-case + trim y luego se canonicaliza via
+// canonicalVerdict (ok/approve → ok; resto → fail).
 func tryParseVerdictBlock(body string) (Verdict, bool) {
 	var v Verdict
 	if err := yaml.Unmarshal([]byte(body), &v); err != nil {
 		return Verdict{}, false
 	}
-	v.Status = strings.ToLower(strings.TrimSpace(v.Status))
-	if v.Status == "" {
+	raw := strings.ToLower(strings.TrimSpace(v.Status))
+	if raw == "" {
 		return Verdict{}, false
 	}
-	if v.Status != VerdictOk {
-		v.Status = VerdictFail
-	}
+	v.Status = canonicalVerdict(raw)
 	v.Feedback = strings.TrimSpace(v.Feedback)
+	// Si un token 3-vias (changes_requested/needs_human, o cualquier valor
+	// raro) cae a fail y el validator no emitio feedback explicito,
+	// guardamos el token original para que el merge-feedback / modal RP
+	// muestre por que fallo y no quede vacio. raw=="fail" se omite porque
+	// "verdict: fail" como feedback no agrega informacion.
+	if v.Status == VerdictFail && v.Feedback == "" && raw != VerdictFail {
+		v.Feedback = "verdict: " + raw
+	}
 	return v, true
+}
+
+// extractValidatorMessages destila el stdout de un validator stream-json
+// (claude o codex) al texto del agente concatenado, descartando metadatos
+// (turn.started, command_execution, usage…) y outputs de tools. Sin esto,
+// `verdict: approve` queda enterrado dentro de `item.text` y yaml.Unmarshal
+// lo lee como un objeto con key "type"/"item", no como un bloque verdict.
+//
+// Shapes reconocidos (cualquier linea que matchee aporta texto al output):
+//
+//	codex  : {"type":"item.completed","item":{"type":"agent_message","text":...}}
+//	claude : {"type":"assistant","message":{"content":[{"type":"text","text":...}, ...]}}
+//
+// Si NINGUNA linea matchea (validator raw — gemini/opencode/text), devuelve
+// el stdout intacto: el parser cae al path tradicional de YAML directo.
+func extractValidatorMessages(stdout string) string {
+	var sb strings.Builder
+	found := false
+	for _, raw := range strings.Split(stdout, "\n") {
+		trim := strings.TrimSpace(raw)
+		if trim == "" || !strings.HasPrefix(trim, "{") {
+			continue
+		}
+		text := tryExtractAgentText(trim)
+		if text == "" {
+			continue
+		}
+		if found {
+			sb.WriteString("\n\n")
+		}
+		sb.WriteString(text)
+		found = true
+	}
+	if !found {
+		return stdout
+	}
+	return sb.String()
+}
+
+// tryExtractAgentText devuelve el texto del agente de una sola linea JSON
+// del stdout del validator. Soporta los dos shapes (claude / codex) y
+// devuelve "" si la linea no es JSON o no calza con ningun shape conocido.
+//
+// Para claude `assistant.message.content[]`, concatena los bloques con
+// type=text separados por newline. Para codex `item.agent_message.text`,
+// devuelve el text plano. Otros tipos (tool_use, command_execution,
+// reasoning, turn.completed, etc) se ignoran — son metadata, no veredicto.
+func tryExtractAgentText(line string) string {
+	var ev struct {
+		Type    string          `json:"type"`
+		Message json.RawMessage `json:"message"`
+		Item    struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"item"`
+	}
+	if err := json.Unmarshal([]byte(line), &ev); err != nil {
+		return ""
+	}
+	if ev.Item.Type == "agent_message" && ev.Item.Text != "" {
+		return ev.Item.Text
+	}
+	if ev.Type == "assistant" && len(ev.Message) > 0 {
+		var msg struct {
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		}
+		if err := json.Unmarshal(ev.Message, &msg); err == nil {
+			var sb strings.Builder
+			first := true
+			for _, c := range msg.Content {
+				if c.Type != "text" || c.Text == "" {
+					continue
+				}
+				if !first {
+					sb.WriteString("\n")
+				}
+				sb.WriteString(c.Text)
+				first = false
+			}
+			if sb.Len() > 0 {
+				return sb.String()
+			}
+		}
+	}
+	return ""
+}
+
+// canonicalVerdict normaliza el token YAML emitido por el validator a las
+// dos ramas que entiende el loop. Acepta los tokens 3-vias usados por
+// pipelines tipo che-funnel (approve/changes_requested/needs_human) y los
+// tokens binarios del contrato base (ok/fail). Cualquier otro valor cae a
+// fail (defensivo: un modelo confundido que emite "approved" o "KO" no
+// debe avanzar el loop).
+func canonicalVerdict(token string) string {
+	switch token {
+	case VerdictOk, "approve":
+		return VerdictOk
+	default:
+		return VerdictFail
+	}
 }
 
 // VerdictRecord es el shape persistido en

--- a/internal/runner/validator_test.go
+++ b/internal/runner/validator_test.go
@@ -133,6 +133,150 @@ verdict: ok
 	}
 }
 
+// TestParseVerdict_ApproveAliasOK cubre el alias 3-vias del che-funnel:
+// `verdict: approve` se canonicaliza a VerdictOk para que el loop avance
+// igual que con `verdict: ok`.
+func TestParseVerdict_ApproveAliasOK(t *testing.T) {
+	stdout := `verdict: approve
+`
+	v := parseVerdict(stdout)
+	if v.Status != VerdictOk {
+		t.Errorf("expected approve to map to ok, got %q", v.Status)
+	}
+	if v.Feedback != "" {
+		t.Errorf("expected empty feedback for ok, got %q", v.Feedback)
+	}
+}
+
+// TestParseVerdict_ChangesRequestedMapsToFail cubre el otro extremo del
+// alias 3-vias: changes_requested cae a fail y, sin feedback explicito,
+// se preserva el token original como Feedback para el modal RP.
+func TestParseVerdict_ChangesRequestedMapsToFail(t *testing.T) {
+	stdout := `verdict: changes_requested
+`
+	v := parseVerdict(stdout)
+	if v.Status != VerdictFail {
+		t.Errorf("expected changes_requested to map to fail, got %q", v.Status)
+	}
+	if v.Feedback != "verdict: changes_requested" {
+		t.Errorf("expected feedback to preserve original token, got %q", v.Feedback)
+	}
+}
+
+// TestParseVerdict_NeedsHumanMapsToFail cubre needs_human del alias
+// 3-vias: tambien fail con el token preservado en feedback. running.go
+// no diferencia needs_human de changes_requested (ambos disparan retry o
+// pause segun on_max_loops); el token ayuda al humano en el modal.
+func TestParseVerdict_NeedsHumanMapsToFail(t *testing.T) {
+	stdout := `verdict: needs_human
+`
+	v := parseVerdict(stdout)
+	if v.Status != VerdictFail {
+		t.Errorf("expected needs_human to map to fail, got %q", v.Status)
+	}
+	if v.Feedback != "verdict: needs_human" {
+		t.Errorf("expected feedback to preserve original token, got %q", v.Feedback)
+	}
+}
+
+// TestParseVerdict_ChangesRequestedKeepsExplicitFeedback cubre que cuando
+// el validator si emitio un feedback explicito, parseVerdict lo respeta
+// y NO sobrescribe con el token original.
+func TestParseVerdict_ChangesRequestedKeepsExplicitFeedback(t *testing.T) {
+	stdout := `verdict: changes_requested
+feedback: |
+  los criterios no son testeables
+`
+	v := parseVerdict(stdout)
+	if v.Status != VerdictFail {
+		t.Errorf("expected fail, got %q", v.Status)
+	}
+	if !strings.Contains(v.Feedback, "los criterios no son testeables") {
+		t.Errorf("expected explicit feedback preserved, got %q", v.Feedback)
+	}
+}
+
+// TestParseVerdict_CodexStreamJSON cubre el shape real de codex --json:
+// el verdict del agente viene enterrado dentro de un agent_message. Sin la
+// extraccion stream-json, parseVerdict devuelve "no verdict block" y el
+// loop nunca avanza (bug observado en el run del 2026-05-10 sobre #99).
+func TestParseVerdict_CodexStreamJSON(t *testing.T) {
+	stdout := `{"type":"thread.started","thread_id":"abc"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"voy a validar el plan"}}
+{"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"gh issue view 99","aggregated_output":"verdict: ok\n","exit_code":0,"status":"completed"}}
+{"type":"item.completed","item":{"id":"item_14","type":"agent_message","text":"verdict: approve"}}
+{"type":"turn.completed","usage":{"input_tokens":1000}}
+`
+	v := parseVerdict(stdout)
+	if v.Status != VerdictOk {
+		t.Errorf("expected approve from codex stream-json to map to ok, got %q (feedback=%q)", v.Status, v.Feedback)
+	}
+}
+
+// TestParseVerdict_CodexStreamJSON_FailWins cubre el caso donde codex
+// emite un agent_message intermedio con verdict: approve pero el final
+// dice changes_requested — gana el ultimo (last-block-wins se preserva
+// despues de extraer texto).
+func TestParseVerdict_CodexStreamJSON_FailWins(t *testing.T) {
+	stdout := `{"type":"item.completed","item":{"type":"agent_message","text":"draft inicial: verdict: approve"}}
+{"type":"item.completed","item":{"type":"agent_message","text":"verdict: changes_requested\nfeedback: |\n  los criterios no son testeables"}}
+`
+	v := parseVerdict(stdout)
+	if v.Status != VerdictFail {
+		t.Errorf("expected last codex agent_message to win, got %q", v.Status)
+	}
+	if !strings.Contains(v.Feedback, "criterios no son testeables") {
+		t.Errorf("expected feedback from last block, got %q", v.Feedback)
+	}
+}
+
+// TestParseVerdict_ClaudeStreamJSON cubre el shape de claude --output-format
+// stream-json --verbose: el verdict viene en assistant.message.content[].text.
+// command_executions y tool_use no deben confundir al parser.
+func TestParseVerdict_ClaudeStreamJSON(t *testing.T) {
+	stdout := `{"type":"system","subtype":"init"}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"reviso el plan"}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Bash","input":{}}]}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"verdict: approve"}]}}
+{"type":"result","subtype":"success"}
+`
+	v := parseVerdict(stdout)
+	if v.Status != VerdictOk {
+		t.Errorf("expected approve from claude stream-json to map to ok, got %q", v.Status)
+	}
+}
+
+// TestParseVerdict_RawStdoutFallback cubre el camino sin stream-json
+// (validator gemini/opencode raw text): si nada parece JSON, parseVerdict
+// debe seguir trabajando sobre el stdout crudo como antes.
+func TestParseVerdict_RawStdoutFallback(t *testing.T) {
+	stdout := `Algun razonamiento del modelo en texto plano.
+
+verdict: ok
+`
+	v := parseVerdict(stdout)
+	if v.Status != VerdictOk {
+		t.Errorf("expected ok from raw text validator, got %q", v.Status)
+	}
+}
+
+// TestParseVerdict_StreamJSONNoVerdict cubre el caso donde el validator
+// emitio JSON correcto pero ningun agent_message contiene verdict — el
+// parser cae a "no verdict block" como antes.
+func TestParseVerdict_StreamJSONNoVerdict(t *testing.T) {
+	stdout := `{"type":"item.completed","item":{"type":"agent_message","text":"olvide emitir el verdict"}}
+{"type":"turn.completed"}
+`
+	v := parseVerdict(stdout)
+	if v.Status != VerdictFail {
+		t.Errorf("expected fail when verdict missing, got %q", v.Status)
+	}
+	if v.Feedback != "no verdict block" {
+		t.Errorf("expected feedback 'no verdict block', got %q", v.Feedback)
+	}
+}
+
 // TestNewValidatorRun_Defaults cubre los defaults del ValidatorRun cuando
 // el yaml omite max_loops / on_max_loops (defensivo — el wizard fuerza
 // valores razonables pero un yaml a mano podria omitirlos).

--- a/internal/wizard/embedded/che-funnel.yaml
+++ b/internal/wizard/embedded/che-funnel.yaml
@@ -360,7 +360,7 @@ steps:
         TODOS los issues (el peor gana: needs_human > changes_requested >
         approve), para que max_loops/on_max_loops decidan continuar:
 
-            VALIDATOR_VERDICT: <approve|changes_requested|needs_human>
+            verdict: <approve|changes_requested|needs_human>
 
         Bloque OUTPUT del explore:
         <<<
@@ -565,7 +565,7 @@ steps:
 
         Devolvé al runner el verdict consolidado (peor gana):
 
-            VALIDATOR_VERDICT: <approve|changes_requested|needs_human>
+            verdict: <approve|changes_requested|needs_human>
 
         Bloque OUTPUT del execute:
         <<<


### PR DESCRIPTION
## Summary

- Los validators de `che-funnel` (codex con `exec --json`) emiten el verdict dentro de `agent_message.text` del NDJSON. `parseVerdict` corria `yaml.Unmarshal` sobre el stream crudo, nunca encontraba `verdict:`, y devolvia `no verdict block` -> el loop agotaba `max_loops` y caia en `on_max_loops: pause` aunque el plan/PR fuera correcto.
- Bug detectado en el run del 2026-05-10 sobre #99: explore y execute hicieron 3/3 loops y exigieron human-override del modal en cada uno (manifest: `final_verdict: human-override`, `last_feedback: no verdict block`).
- Tambien arrastraba un mismatch de token: el pipeline pedia `VALIDATOR_VERDICT: approve|changes_requested|needs_human` pero el parser solo reconocia `verdict: ok|fail`.

## Cambios

- `internal/runner/validator.go`: nuevos helpers `extractValidatorMessages` + `tryExtractAgentText` que destilan el texto del agente de los shapes claude (`assistant.message.content[].text`) y codex (`item.agent_message.text`) antes de pasarselo al YAML parser. Si nada matchea (validators raw como gemini/opencode), el stdout pasa intacto. `canonicalVerdict` ahora mapea `approve` -> ok y `changes_requested`/`needs_human` -> fail; cuando un 3-way fail no trae feedback explicito, se preserva el token original en `Verdict.Feedback` para que el modal RP muestre por que fallo.
- `internal/wizard/embedded/che-funnel.yaml`: el final-line marker pasa de `VALIDATOR_VERDICT: <approve|...>` a `verdict: <approve|...>` en los validators de explore y execute.
- `internal/runner/validator_test.go`: 9 tests nuevos cubriendo (a) los alias 3-way (`approve` -> ok, `changes_requested`/`needs_human` -> fail con token preservado en feedback, feedback explicito gana sobre token), (b) la extraccion stream-json (codex shape, claude shape, last-block-wins entre dos `agent_message`, fallback raw, JSON sin verdict).

Tambien incluye el commit previamente local-only `chore: drop stale EXEC_NOTES.md leftover from PR #83` (99bf38d).

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/runner/... ./internal/wizard/...`
- [x] `go test ./...` (suite completa)
- [ ] Re-correr el funnel default sobre un issue nuevo y confirmar que explore/execute avanzan en loop 1 cuando el validator emite `verdict: approve` (sin caer en el modal pause).

🤖 Generated with [Claude Code](https://claude.com/claude-code)