### PR TITLE
fix(runner): wrap del log pane streaming al ancho de terminal en R3

### DIFF
--- a/internal/runner/running.go
+++ b/internal/runner/running.go
@@ -880,6 +880,25 @@ func (m RunModel) effectiveLogViewportLines() int {
 	return avail
 }
 
+// logPaneWidth devuelve el ancho util (en columnas) para wrappear cada linea
+// del log pane segun el terminalWidth del modelo. El pane no tiene border ni
+// padding propio, asi que solo descontamos un margen chico (2 cols) para
+// evitar que el terminal haga su propio wrap en el ultimo char visible —
+// mismo patron que el wizard usa con ContentInnerWidth pero adaptado al
+// pane sin caja. Devuelve 0 cuando todavia no recibimos un WindowSizeMsg
+// (tests headless / antes del primer render) — signal "no wrappear, dejar
+// la linea tal cual" — para preservar el render previo en ese caso.
+func logPaneWidth(termWidth int) int {
+	if termWidth <= 0 {
+		return 0
+	}
+	inner := termWidth - 2
+	if inner < 20 {
+		return 0
+	}
+	return inner
+}
+
 // renderLogPane dibuja el viewport del log pane: header del step en LogFocus
 // + las ultimas N lineas del ring buffer del mismo step (segun StickyBottom
 // / LogScrollOffset). Lineas de stderr en rojo dimmed, intercaladas con
@@ -933,12 +952,14 @@ func renderLogPane(m RunModel) string {
 	// dinamico (H10: resize via WindowSizeMsg). LogScrollOffset corre la
 	// ventana hacia atras cuando el usuario scrollea arriba.
 	visible := windowLines(snap, m.effectiveLogViewportLines(), m.LogScrollOffset)
+	wrapW := logPaneWidth(m.terminalWidth)
 	for _, line := range visible {
+		text := wizard.WrapText(line.Text, wrapW)
 		switch line.Kind {
 		case LogLineStderr:
-			b.WriteString(stderrStyle.Render(line.Text))
+			b.WriteString(stderrStyle.Render(text))
 		default:
-			b.WriteString(line.Text)
+			b.WriteString(text)
 		}
 		b.WriteString("\n")
 	}

--- a/internal/runner/running_test.go
+++ b/internal/runner/running_test.go
@@ -1,0 +1,87 @@
+package runner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/chichex/che/internal/wizard"
+)
+
+// TestRenderLogPane_WrapsLongLineAtTerminalWidth verifica que las lineas del
+// log pane (viewport del subprocess en R3) se wrappean al ancho del terminal
+// cuando el modelo conoce un terminalWidth > 0 — antes del fix, una linea
+// larga del stream del agente (ej. un text block de claude sin newlines
+// internos) se cortaba contra el borde derecho del terminal.
+//
+// Con terminalWidth=0 (tests headless / antes del primer WindowSizeMsg) el
+// render queda intacto — backward-compat con el comportamiento previo.
+func TestRenderLogPane_WrapsLongLineAtTerminalWidth(t *testing.T) {
+	long := "> " + strings.Repeat("palabra ", 30) + "fin"
+	build := func(termWidth int) RunModel {
+		rb := NewRingBuffer(10)
+		rb.Append(LogLineStdout, long)
+		return RunModel{
+			Pipeline: wizard.Pipeline{
+				Name:  "test",
+				Steps: []wizard.Step{{Name: "step1", CLI: "claude", Kind: "prompt"}},
+			},
+			Steps:         []StepRun{{Idx: 1, Name: "step1", Status: StepStatusRunning}},
+			Active:        0,
+			LogFocus:      0,
+			LogBuffers:    []*RingBuffer{rb},
+			StickyBottom:  true,
+			terminalWidth: termWidth,
+		}
+	}
+
+	noWrap := renderLogPane(build(0))
+	wrapped := renderLogPane(build(40))
+
+	if strings.Count(wrapped, "\n") <= strings.Count(noWrap, "\n") {
+		t.Fatalf("expected wrapped log pane to have extra newlines vs no-wrap; got noWrap=%d wrapped=%d\n--- noWrap ---\n%s\n--- wrapped ---\n%s",
+			strings.Count(noWrap, "\n"), strings.Count(wrapped, "\n"), noWrap, wrapped)
+	}
+
+	// Ninguna linea del output wrappeado debe exceder el ancho util
+	// (terminalWidth - margen de seguridad). Asi confirmamos que el wrap
+	// efectivamente cortó la linea larga, no solo agregó newlines en otro
+	// lugar.
+	want := logPaneWidth(40)
+	if want <= 0 {
+		t.Fatalf("logPaneWidth(40) devolvio %d, esperaba > 0", want)
+	}
+	for _, line := range strings.Split(wrapped, "\n") {
+		// Ignoramos las lineas que tienen ANSI (header con labelStyle): el
+		// chequeo aplica al cuerpo del log donde el texto va raw.
+		if strings.Contains(line, "\x1b[") {
+			continue
+		}
+		if n := len([]rune(line)); n > want {
+			t.Errorf("linea del log pane excede el ancho util (%d > %d): %q", n, want, line)
+		}
+	}
+}
+
+// TestLogPaneWidth_ZeroPreservesLegacyBehavior fija el contrato del helper:
+// termWidth <= 0 devuelve 0 (signal "no wrappear"); termWidth chico (< 22)
+// tambien devuelve 0 porque inner < 20 — preserva render legible en splits
+// muy finos en lugar de hacer hard-break char-a-char.
+func TestLogPaneWidth_ZeroPreservesLegacyBehavior(t *testing.T) {
+	cases := []struct {
+		termWidth int
+		want      int
+	}{
+		{0, 0},
+		{-1, 0},
+		{10, 0},
+		{21, 0},
+		{22, 20},
+		{80, 78},
+	}
+	for _, c := range cases {
+		got := logPaneWidth(c.termWidth)
+		if got != c.want {
+			t.Errorf("logPaneWidth(%d) = %d, want %d", c.termWidth, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- En R3, `renderLogPane` escribia cada `line.Text` del ring buffer sin aplicar `Width()`, asi que lineas largas de un text block del agente (ej. claude stream-json sin newlines internos) se cortaban contra el borde derecho del terminal en lugar de wrappear.
- Aplica `wizard.WrapText` con un helper local `logPaneWidth(termWidth)` (devuelve `termWidth - 2`, piso `inner >= 20`, `0 = no wrappear`) — mismo patron que el fix del prompt stdin de R1 (PR #100 / `ContentInnerWidth`) pero adaptado al pane que no tiene border ni padding propio.
- `terminalWidth = 0` preserva el render previo (backward-compat con tests headless / antes del primer `WindowSizeMsg`).

## Diagnostico

Archivo/funcion: `internal/runner/running.go::renderLogPane` (loop sobre `visible []LogLine`).
Lineas culpables (pre-fix):

```go
for _, line := range visible {
    switch line.Kind {
    case LogLineStderr:
        b.WriteString(stderrStyle.Render(line.Text))
    default:
        b.WriteString(line.Text)
    }
    b.WriteString("\n")
}
```

`stderrStyle` y el render raw de stdout no fijan `Width`, asi que lipgloss no wrappea — la linea sale entera y el terminal la trunca/oculta a partir del char N donde N = ancho de la terminal.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/runner/` (todo el paquete pasa, incluido el `running_test.go` nuevo con 2 tests: `TestRenderLogPane_WrapsLongLineAtTerminalWidth` + `TestLogPaneWidth_ZeroPreservesLegacyBehavior`)
- [ ] Smoke manual en TUI con un step que dispare claude stream-json y texto largo en un text block (terminal ~80-120 cols).
- [ ] Verificar que el indicador `(scroll · N lineas mas abajo)` sigue funcionando cuando una linea wrappeada empuja el viewport.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>