### PR TITLE
chore: cleanup de dead code go

### DIFF
--- a/internal/runner/pause.go
+++ b/internal/runner/pause.go
@@ -16,7 +16,6 @@
 package runner
 
 import (
-	"fmt"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -180,12 +179,3 @@ func viewPauseModal(m RunModel) string {
 	return b.String()
 }
 
-// pauseModalSummaryLine devuelve un string corto que el log pane / footer
-// puede renderear cuando el modal esta abierto. Sirve solo para debug; el
-// render principal lo da viewPauseModal.
-func pauseModalSummaryLine(m RunModel) string {
-	if m.PauseModal == nil {
-		return ""
-	}
-	return fmt.Sprintf("RP · step %d · feedback len=%d", m.PauseModal.StepIdx+1, len(m.PauseModal.LastFeedback))
-}

--- a/internal/wizard/model.go
+++ b/internal/wizard/model.go
@@ -378,21 +378,6 @@ type model struct {
 	width int
 }
 
-// installedCLIs returns the names of the detected CLIs that are installed.
-// Used by S2 to disable pills (B4) — no installed cli == cannot save.
-func (m *model) installedCLIs() []string {
-	if !m.skillsCacheSet {
-		return nil
-	}
-	out := make([]string, 0, len(m.skillsCache))
-	for _, c := range m.skillsCache {
-		if c.Installed {
-			out = append(out, c.Name)
-		}
-	}
-	return out
-}
-
 // skillsForCLI looks up the detected skills for a given cli name. Returns
 // nil if the cli isn't installed or wasn't detected.
 func (m *model) skillsForCLI(name string) []skills.Skill {

--- a/internal/wizard/runhistory.go
+++ b/internal/wizard/runhistory.go
@@ -177,20 +177,6 @@ func ChipForStatus(s RunStatus) string {
 	}
 }
 
-// runDetailReadFile es el helper de la pantalla "Run history" detalle:
-// lee un archivo del run-dir (ej. step-NN.stderr.log). Devuelve "" si
-// no existe — el detalle render-ea "(sin contenido)" en ese caso.
-func runDetailReadFile(runDir, name string) string {
-	if runDir == "" {
-		return ""
-	}
-	data, err := os.ReadFile(filepath.Join(runDir, name))
-	if err != nil {
-		return ""
-	}
-	return string(data)
-}
-
 // formatRunDuration devuelve "1m 23s" / "5s" / "" para una duracion.
 // Mismo estilo que el resumen del runner — duplicado aca por la regla
 // "no importar runner".

--- a/internal/wizard/styles.go
+++ b/internal/wizard/styles.go
@@ -80,7 +80,6 @@ var (
 	errorStyle    = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF5555")).Bold(true)
 	okStyleWizard = lipgloss.NewStyle().Foreground(lipgloss.Color("#50FA7B")).Bold(true)
 	dimStyle     = lipgloss.NewStyle().Foreground(lipgloss.Color("#6272A4"))
-	pendingStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFB86C"))
 	selectedItem = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF79C6")).Bold(true)
 	// selectedOff es la pill "seleccionada pero la fila no tiene foco". Sin
 	// este tono dedicado, mutedItem (#F8F8F2) se confunde con el texto


### PR DESCRIPTION
## Resumen

PR 3/3 del plan en #102. Elimina simbolos go huerfanos detectados por `staticcheck` U1000 tras revisar caso por caso con triple grep (nombre exacto, referencias en repo). Cero cambios de comportamiento — solo deletes de codigo privado sin callers.

## Findings agrupados

### Eliminados (4 simbolos, todos `lowercase` sin uso confirmado)

| Simbolo | Archivo | Razon | Evidencia grep |
|---|---|---|---|
| `pauseModalSummaryLine` | `internal/runner/pause.go:186` | Helper de debug — el propio comentario dice "Sirve solo para debug; el render principal lo da viewPauseModal". Nunca se llama. | `grep -rEn pauseModalSummaryLine --include="*.go" .` → solo la declaracion |
| `(*model).installedCLIs` | `internal/wizard/model.go:383` | Comentario menciona uso por "S2 para deshabilitar pills (B4)" pero no existe caller. Sister methods `skillsForCLI` e `isInstalled` siguen vivas. | `grep -rEn installedCLIs --include="*.go" .` → solo la declaracion |
| `runDetailReadFile` | `internal/wizard/runhistory.go:183` | Helper de la pantalla "Run history" detalle, nunca llamado. | `grep -rEn runDetailReadFile --include="*.go" .` → solo la declaracion |
| `pendingStyle` | `internal/wizard/styles.go:83` | `lipgloss.Style` definido entre otros estilos, sin referencias. | `grep -rEn pendingStyle --include="*.go" .` → solo la declaracion |

Tambien se quita el import de `fmt` en `internal/runner/pause.go` que quedo huerfano.

### Keep con `// keep:` (0)

Ningun finding requirio anotacion — los 4 eran privados, sin sentido semantico como point-of-entry futuro, y con triple grep limpio.

### Skip / follow-up sugerido (2)

| Finding | Razon de skip |
|---|---|
| `e2e/runner_test.go:2566 (SA4010)` — `preArmedNames = append(preArmedNames, name)` cuyo resultado nunca se lee. | Codigo de test, no dead code de runtime. Ortogonal al alcance "dead code go" del PR 3. Realmente la slice se popula pero nunca se compara (el test usa otro mapa `survived` para asserts) — cleanup razonable como follow-up. |
| `internal/runner/validator_test.go:350 (SA4031)` — `if done == nil` nunca true segun staticcheck. | Codigo de test, defensive nil-check antes de derreferenciar. Cambiarlo requiere repensar la salida del loop. Ortogonal al alcance. |

## Verificacion

- `go vet ./...` → ok
- `staticcheck ./...` → 4 U1000 eliminados; los 2 SA quedan (skip-followup, ver arriba)
- `go build ./...` → ok
- `go test ./...` → ok
- `go test ./e2e/...` → ok

## Drift de arquitectura observado (no tocado)

La memoria del proyecto (`project_agent_package.md`, `project_validation_model.md`) menciona `internal/agent/` y `internal/flow/{idea,explore,execute,validate}/`. Post-revamp PR #96 esos paquetes ya no existen — el codigo vive en `internal/runner/` (steps de pipeline con bloque validator) e `internal/wizard/`. Solo reporto, no toco memoria.

## Test plan

- [x] `go vet ./...`
- [x] `staticcheck ./...` (solo quedan 2 SA en tests, documentados como skip)
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `go test ./e2e/...`

Refs #102

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>