### PR TITLE
feat: enriquecer viewport del parser de claude con contexto de tools

### DIFF
--- a/internal/runner/parser/claude.go
+++ b/internal/runner/parser/claude.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 )
 
@@ -34,6 +35,14 @@ type claudeEvent struct {
 	Type    string          `json:"type"`
 	Subtype string          `json:"subtype,omitempty"`
 	Message json.RawMessage `json:"message,omitempty"`
+	// Campos top-level de eventos system task_started / task_progress /
+	// task_notification (subagentes Task/Explore). El shape lo inferimos
+	// observando un run real: description marca el step actual del
+	// subagente; summary aparece en task_notification con el resultado;
+	// status indica completed/failed.
+	Description string `json:"description,omitempty"`
+	Summary     string `json:"summary,omitempty"`
+	Status      string `json:"status,omitempty"`
 }
 
 // claudeMessage representa el envelope de message dentro del evento (los
@@ -52,6 +61,10 @@ type claudeContent struct {
 	Text  string          `json:"text,omitempty"`
 	Name  string          `json:"name,omitempty"`
 	Input json.RawMessage `json:"input,omitempty"`
+	// tool_result (en user echo) — Content puede ser string o array de
+	// bloques; lo guardamos crudo y lo desempacamos en summarizeToolResult.
+	Content json.RawMessage `json:"content,omitempty"`
+	IsError bool            `json:"is_error,omitempty"`
 }
 
 func (claudeParser) Parse(raw string) ([]Line, Event) {
@@ -79,21 +92,14 @@ func (claudeParser) Parse(raw string) ([]Line, Event) {
 func claudeRender(ev claudeEvent) []Line {
 	switch ev.Type {
 	case "system":
-		// system_init / system_error — emit una linea breve si hay subtype.
-		if ev.Subtype == "init" {
-			return []Line{{Text: "· session iniciada"}}
-		}
-		if ev.Subtype != "" {
-			return []Line{{Text: fmt.Sprintf("· system %s", ev.Subtype)}}
-		}
-		return nil
+		return claudeRenderSystem(ev)
 	case "assistant":
 		return claudeRenderMessage(ev.Message, false)
 	case "user":
-		// user es el echo del tool_result que claude se manda a si mismo.
-		// Lo dejamos invisible al viewport por ruido — events.jsonl lo
-		// guarda igual.
-		return nil
+		// user trae el echo del tool_result. Por defecto lo silenciamos
+		// (mucho ruido); solo levantamos los is_error para que el viewport
+		// muestre la falla sin tener que abrir events.jsonl.
+		return claudeRenderUserToolResults(ev.Message)
 	case "result":
 		// result trae stop_reason / usage / cost. Una linea sumaria.
 		return []Line{{Text: "· result"}}
@@ -106,8 +112,69 @@ func claudeRender(ev claudeEvent) []Line {
 	}
 }
 
+// claudeRenderSystem maneja los subtipos de eventos system. Los task_*
+// vienen de subagentes (Task/Explore) y son utiles para el viewport porque
+// muestran el avance del subagente sin tener que abrir events.jsonl.
+func claudeRenderSystem(ev claudeEvent) []Line {
+	switch ev.Subtype {
+	case "init":
+		return []Line{{Text: "· session iniciada"}}
+	case "task_started":
+		if ev.Description != "" {
+			return []Line{{Text: "· task started: " + truncate(ev.Description, 100)}}
+		}
+		return []Line{{Text: "· task started"}}
+	case "task_progress":
+		if ev.Description != "" {
+			return []Line{{Text: "· task: " + truncate(ev.Description, 100)}}
+		}
+		return []Line{{Text: "· task_progress"}}
+	case "task_notification":
+		status := ev.Status
+		if status == "" {
+			status = "done"
+		}
+		if ev.Summary != "" {
+			return []Line{{Text: fmt.Sprintf("· task %s: %s", status, truncate(ev.Summary, 100))}}
+		}
+		return []Line{{Text: "· task " + status}}
+	case "":
+		return nil
+	default:
+		return []Line{{Text: "· system " + ev.Subtype}}
+	}
+}
+
+// claudeRenderUserToolResults extrae solo los tool_result con is_error=true
+// del echo de user. El resto se omite (el output exitoso suele ser data
+// verbosa que no aporta al viewport y events.jsonl lo guarda igual).
+func claudeRenderUserToolResults(raw json.RawMessage) []Line {
+	if len(raw) == 0 {
+		return nil
+	}
+	var msg claudeMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		return nil
+	}
+	var out []Line
+	for _, c := range msg.Content {
+		if c.Type != "tool_result" || !c.IsError {
+			continue
+		}
+		txt := summarizeToolResult(c.Content)
+		if txt == "" {
+			out = append(out, Line{Text: "· tool_result error"})
+		} else {
+			out = append(out, Line{Text: "· tool_result error: " + truncate(txt, 100)})
+		}
+	}
+	return out
+}
+
 // claudeRenderMessage descompone el envelope de message.content[] en lineas
-// humanas. Cada bloque text → "> ..."; cada tool_use → "· tool: name".
+// humanas. Cada bloque text → "> ..."; cada tool_use → "· tool: name [—
+// resumen]"; thinking → "· thinking" (el contenido viene encriptado en
+// stream-json --verbose, solo podemos marcar que ocurrio).
 func claudeRenderMessage(raw json.RawMessage, _ bool) []Line {
 	if len(raw) == 0 {
 		return nil
@@ -139,13 +206,114 @@ func claudeRenderMessage(raw json.RawMessage, _ bool) []Line {
 			if name == "" {
 				name = "(sin nombre)"
 			}
-			out = append(out, Line{Text: "· tool: " + name})
+			line := "· tool: " + name
+			if summary := summarizeToolInput(name, c.Input); summary != "" {
+				line += " — " + summary
+			}
+			out = append(out, Line{Text: line})
+		case "thinking":
+			// El stream emite el `thinking` con la firma encriptada (texto
+			// vacio para consumers externos), asi que solo podemos marcar
+			// que el modelo pensó. Mantiene paridad con el comportamiento
+			// historico cuando este case caia al default.
+			out = append(out, Line{Text: "· thinking"})
 		case "tool_result":
-			// Lo omitimos en el viewport (suele ser data verbosa).
+			// Asistente nunca emite tool_result, pero por las dudas:
+			// silenciamos (los errores se levantan desde el echo user).
 		default:
 			// Bloques desconocidos: marcamos sin volcar contenido.
 			out = append(out, Line{Text: "· " + c.Type})
 		}
 	}
 	return out
+}
+
+// summarizeToolInput devuelve una descripcion corta del input de un
+// tool_use para enriquecer la linea del viewport. Cubre los tools mas
+// frecuentes; el resto cae a "" (sin sufijo). Las claves se observaron
+// directo del stream — Bash usa description+command, Read/Edit/Write usan
+// file_path, Grep/Glob usan pattern, Task usa description.
+func summarizeToolInput(name string, raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var in map[string]any
+	if err := json.Unmarshal(raw, &in); err != nil {
+		return ""
+	}
+	str := func(k string) string {
+		if v, ok := in[k].(string); ok {
+			return strings.TrimSpace(v)
+		}
+		return ""
+	}
+	switch name {
+	case "Bash":
+		if d := str("description"); d != "" {
+			return truncate(d, 80)
+		}
+		if cmd := str("command"); cmd != "" {
+			return "$ " + truncate(strings.ReplaceAll(cmd, "\n", " "), 80)
+		}
+	case "Read", "Edit", "Write", "NotebookEdit":
+		if p := str("file_path"); p != "" {
+			return filepath.Base(p)
+		}
+	case "Grep":
+		if p := str("pattern"); p != "" {
+			return fmt.Sprintf("%q", truncate(p, 60))
+		}
+	case "Glob":
+		if p := str("pattern"); p != "" {
+			return truncate(p, 80)
+		}
+	case "Task":
+		if d := str("description"); d != "" {
+			return truncate(d, 80)
+		}
+	case "WebFetch":
+		if u := str("url"); u != "" {
+			return truncate(u, 80)
+		}
+	case "WebSearch":
+		if q := str("query"); q != "" {
+			return truncate(q, 80)
+		}
+	}
+	return ""
+}
+
+// summarizeToolResult extrae la primera porcion de texto de un tool_result.
+// El campo Content puede venir como string crudo o como array de bloques
+// (cada uno con type=text). Devuelve "" si no hay nada utilizable.
+func summarizeToolResult(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err == nil {
+		return strings.TrimSpace(strings.ReplaceAll(s, "\n", " "))
+	}
+	var blocks []claudeContent
+	if err := json.Unmarshal(raw, &blocks); err == nil {
+		for _, b := range blocks {
+			if b.Type == "text" && strings.TrimSpace(b.Text) != "" {
+				return strings.TrimSpace(strings.ReplaceAll(b.Text, "\n", " "))
+			}
+		}
+	}
+	return ""
+}
+
+// truncate corta s a max runas y agrega "…" si efectivamente se truncó.
+// Cuenta runas (no bytes) para no romper con acentos.
+func truncate(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	return string(r[:max]) + "…"
 }

--- a/internal/runner/parser/claude_test.go
+++ b/internal/runner/parser/claude_test.go
@@ -35,6 +35,114 @@ func TestClaudeToolUse(t *testing.T) {
 	}
 }
 
+// TestClaudeToolUseInputSummary cubre que el render anexa un resumen del
+// input cuando el tool es conocido (Bash/Read/Grep/Edit/etc). Es la rama
+// "punto medio" que enriquece el viewport sin volcar payloads completos.
+func TestClaudeToolUseInputSummary(t *testing.T) {
+	cases := []struct {
+		name     string
+		raw      string
+		expected string
+	}{
+		{
+			name:     "Bash con description",
+			raw:      `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"git status","description":"Show working tree status"}}]}}`,
+			expected: "· tool: Bash — Show working tree status",
+		},
+		{
+			name:     "Bash sin description cae a command",
+			raw:      `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"git log --oneline"}}]}}`,
+			expected: "· tool: Bash — $ git log --oneline",
+		},
+		{
+			name:     "Read muestra basename",
+			raw:      `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"file_path":"/abs/path/to/claude.go"}}]}}`,
+			expected: "· tool: Read — claude.go",
+		},
+		{
+			name:     "Grep muestra pattern",
+			raw:      `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Grep","input":{"pattern":"tool_use","path":"/x"}}]}}`,
+			expected: `· tool: Grep — "tool_use"`,
+		},
+		{
+			name:     "Tool desconocido sin input no agrega sufijo",
+			raw:      `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"CustomTool","input":{"foo":"bar"}}]}}`,
+			expected: "· tool: CustomTool",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			lines, _ := Claude().Parse(tc.raw)
+			if len(lines) != 1 {
+				t.Fatalf("expected 1 line, got %d (%v)", len(lines), lines)
+			}
+			if lines[0].Text != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, lines[0].Text)
+			}
+		})
+	}
+}
+
+// TestClaudeThinking cubre que un bloque thinking emite "· thinking" sin
+// volcar el contenido (que viene encriptado en stream-json --verbose).
+func TestClaudeThinking(t *testing.T) {
+	raw := `{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"","signature":"..."}]}}`
+	lines, _ := Claude().Parse(raw)
+	if len(lines) != 1 || lines[0].Text != "· thinking" {
+		t.Fatalf("expected single '· thinking' line, got %v", lines)
+	}
+}
+
+// TestClaudeSystemTaskProgress cubre que los eventos de subagentes (Task)
+// se renderean con la description, no como "· system task_progress" pelado.
+func TestClaudeSystemTaskProgress(t *testing.T) {
+	raw := `{"type":"system","subtype":"task_progress","description":"Reading docs/vision.html","task_id":"x"}`
+	lines, _ := Claude().Parse(raw)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	if lines[0].Text != "· task: Reading docs/vision.html" {
+		t.Errorf("expected progress with description, got %q", lines[0].Text)
+	}
+}
+
+// TestClaudeSystemTaskNotification cubre que la notificacion final del
+// subagente trae el status + summary.
+func TestClaudeSystemTaskNotification(t *testing.T) {
+	raw := `{"type":"system","subtype":"task_notification","status":"completed","summary":"Compare docs vs code"}`
+	lines, _ := Claude().Parse(raw)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	if lines[0].Text != "· task completed: Compare docs vs code" {
+		t.Errorf("expected status+summary, got %q", lines[0].Text)
+	}
+}
+
+// TestClaudeUserToolResultError cubre que un tool_result con is_error=true
+// sale al viewport con un fragmento del content para que el usuario vea la
+// falla sin abrir events.jsonl. Los success se siguen omitiendo.
+func TestClaudeUserToolResultError(t *testing.T) {
+	raw := `{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"x","is_error":true,"content":"Exit code 1\nfile not found"}]}}`
+	lines, _ := Claude().Parse(raw)
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 line, got %d", len(lines))
+	}
+	if !strings.HasPrefix(lines[0].Text, "· tool_result error:") {
+		t.Errorf("expected error prefix, got %q", lines[0].Text)
+	}
+}
+
+// TestClaudeUserToolResultSuccessSilenced cubre que los tool_result OK
+// siguen invisibles en el viewport (events.jsonl los conserva igual).
+func TestClaudeUserToolResultSuccessSilenced(t *testing.T) {
+	raw := `{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"x","content":"ok output"}]}}`
+	lines, _ := Claude().Parse(raw)
+	if len(lines) != 0 {
+		t.Errorf("expected 0 lines for success tool_result, got %v", lines)
+	}
+}
+
 // TestClaudeNonJSONFallback cubre la rama "linea sin JSON valido". El
 // parser tiene que mostrarla cruda en el viewport y NO appendearla a
 // events.jsonl (event.Empty() == true).


### PR DESCRIPTION
## Summary

El parser de `claude` (stream-json --verbose) estaba proyectando al log pane solo el nombre del tool y el subtipo crudo de los eventos `system`. En sesiones largas — sobre todo cuando el subagente `Task`/`Explore` hace muchos `Bash`/`Read`/`Grep` — el viewport queda como una columna de `· tool: Bash` repetidos sin señal de qué está pasando, mientras `events.jsonl` ya tiene toda la data.

Este PR sube el detalle del viewport a un punto medio: aprovecha los campos que ya vienen en el stream sin volcar payloads completos.

## Cambios

`internal/runner/parser/claude.go`:

- **`tool_use` con resumen del input** por tool conocido:
  - `Bash` → `description` (con fallback a `$ command` truncado)
  - `Read`/`Edit`/`Write`/`NotebookEdit` → basename del `file_path`
  - `Grep` → `pattern` entre comillas
  - `Glob` → `pattern`
  - `Task` → `description`
  - `WebFetch`/`WebSearch` → `url`/`query`
  - Tools desconocidos: comportamiento previo (sin sufijo).
- **Subtipos `system` de subagentes** (`task_started`, `task_progress`, `task_notification`) renderean su `description`/`summary`+`status` en vez de `· system task_progress` pelado.
- **`tool_result` con `is_error=true`** se levanta al viewport con el primer fragmento del `content` para que el usuario vea la falla sin abrir `events.jsonl`. Los OK siguen silenciados.
- **`thinking` blocks** emiten `· thinking` explícito (el contenido viene encriptado en stream-json --verbose, solo se marca que el modelo pensó — verificado contra runs reales).
- Truncado a ~80 chars con elipsis para no inflar el viewport.

`internal/runner/parser/claude_test.go`: tests por cada rama nueva + regresión del comportamiento previo.

## Antes / después

Antes (lo que se ve hoy en exploraciones largas):
```
· tool: Bash
· system task_progress
· tool: Bash
· system task_progress
· tool: Read
· system task_progress
· tool: Grep
```

Después:
```
· tool: Bash — git status
· task: Reading docs/vision.html
· tool: Bash — Run typecheck
· task: Reading internal/runner/parser/claude.go
· tool: Read — claude.go
· task: Searching for "tool_use" in internal/
· tool: Grep — "tool_use"
```

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/...` (todos verdes)
- [x] `go test ./internal/runner/parser/ -run TestClaude -v` (12 subtests OK)
- [ ] Smoke test manual con `che` rebuildeado contra una sesión real de claude (recordar: el `che` del PATH es del brew cask).

🤖 Generated with [Claude Code](https://claude.com/claude-code)