### PR TITLE
docs: refrescar docs/ y README.md al estado actual + addenda 2026-05

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ La TUI tiene 5 entradas:
 
 | # | Entrada | Qué hace |
 |---|---------|----------|
-| 1 | **My pipelines** | Lista los pipelines en `~/.che/pipelines/`, mezclando ready y drafts, con chip del último run por row. Acciones: <kbd>enter</kbd> reanuda un draft o **ejecuta** un ready (entra al runner R0→R1→R2→R3→R4/RF), <kbd>e</kbd> reedita un ready, <kbd>d</kbd> borra (con confirm), <kbd>y</kbd> abre el YAML en `$EDITOR`, <kbd>r</kbd> abre la sub-screen "Run history" del row. |
+| 1 | **My pipelines** | Lista los pipelines en `~/.che/pipelines/`, mezclando ready y drafts, con chip del último run por row. Incluye el pipeline default `che-funnel` (embebido en el binario, chip `[default]`) que aparece siempre — replica el embudo idea→plan→ejecución→close del che clásico (v0.0.82). Acciones: <kbd>enter</kbd> reanuda un draft o **ejecuta** un ready (entra al runner R0→R1→R2→R3→R4/RF), <kbd>e</kbd> reedita un ready, <kbd>d</kbd> borra (con confirm), <kbd>y</kbd> abre el YAML en `$EDITOR`, <kbd>r</kbd> abre la sub-screen "Run history" del row. |
 | 2 | **Create pipeline** | Wizard que termina en un YAML ready en `~/.che/pipelines/<slug>.yaml`. Persistencia incremental (el archivo es "draft" mientras el wizard no haya cerrado el bloque `status`; se vuelve "ready" al finalizar). Incluye prompt review IA opcional sobre cada step. |
 | 3 | **Crear pipeline con IA** | Genera un pipeline a partir de una descripción libre, lo deja en formato draft listo para revisar en el wizard. |
 | 4 | **See skills** | Detecta los skills instalados en los 4 CLIs (claude / codex / gemini / opencode) y permite abrir cada `SKILL.md` en VS Code. Solo lectura. |

--- a/docs/design.html
+++ b/docs/design.html
@@ -885,7 +885,7 @@
   </section>
 
   <footer>
-    che / parametrizable revamp · design notes · 2026-05-06
+    che / parametrizable revamp · design notes · cierre 2026-05-06 — addendas posteriores en <code>docs/manage-pipelines-flow.html</code> (Addenda 2026-05) y <code>docs/pipeline-execution-flow.html</code> (Addenda post-H10 + Addenda 2026-05). Las decisiones cerradas de este documento siguen vigentes.
   </footer>
 
 </main>

--- a/docs/manage-pipelines-flow.html
+++ b/docs/manage-pipelines-flow.html
@@ -1586,8 +1586,81 @@
 
   </section>
 
+  <hr class="rule">
+
+  <!-- ========== ADDENDA 2026-05 ========== -->
+  <section>
+    <div class="eyebrow">addenda 2026-05</div>
+    <h2>che-funnel embebido como pipeline default</h2>
+    <p>
+      A partir de PR #98 (commit <code>7dc265c</code>), el binario shipea un
+      pipeline default llamado <code>che-funnel</code> embebido en
+      <code>internal/wizard/embedded/che-funnel.yaml</code> via
+      <code>//go:embed</code> y registrado en
+      <code>wizard.Builtins()</code>. <strong>My pipelines</strong> ya no
+      arranca vacío en una instalación nueva — la primera vez que el usuario
+      abre el lister ve el row <code>che-funnel</code> con chip
+      <code>[default]</code> aunque <code>~/.che/pipelines/</code> no exista
+      o esté vacío.
+    </p>
+    <p>
+      El builtin es read-only por default: al ejecutarlo desde el lister
+      arranca con el YAML embebido sin tocar disco. Si el usuario quiere
+      personalizarlo, el lister soporta copy-on-edit — al activar
+      <kbd>e</kbd> o <kbd>y</kbd> sobre el row builtin, el archivo se
+      materializa en <code>~/.che/pipelines/che-funnel.yaml</code> y a
+      partir de ahí el override de disco gana sobre el builtin (mismo
+      mecanismo que cualquier pipeline regular).
+    </p>
+
+    <h3>che-funnel vs v0.0.82 funnel</h3>
+    <p>
+      El pipeline replica el embudo clásico (idea → explore/plan →
+      execute → close) con 4 steps secuenciales sobre <code>claude</code>,
+      delegando la state machine de GitHub (labels <code>che:*</code>,
+      issues, PRs, comments, worktrees) a los prompts vía tool use de
+      <code>gh</code> y <code>git</code>. Diferencias intencionales con la
+      versión vieja:
+    </p>
+    <ul>
+      <li><strong>iterate desaparece como step manual</strong> — cada step
+        tiene un <code>validator</code> con <code>max_loops=3</code>; si el
+        verdict es <code>changes_requested</code> el step se re-corre con
+        feedback hasta converger o agotar el cap (handled por R3 del runner
+        nuevo, no por un step propio).</li>
+      <li><strong>close postea un template de scoring</strong> (1-10 en
+        completitud / fidelidad / alineación) como comment del PR. El
+        humano lo llena fuera del pipeline — no hay gate humano mid-run.</li>
+      <li><strong>Validator cross-CLI</strong> — cada validator usa
+        <code>codex</code> en lugar de <code>claude</code> para reducir
+        groupthink. Si el usuario solo tiene <code>claude</code> instalado,
+        puede editar el YAML (copy-on-edit) o borrar el bloque
+        <code>validator</code> de cada step.</li>
+    </ul>
+
+    <h3>Impacto en el lister</h3>
+    <p>
+      Las acciones existentes funcionan igual sobre el row builtin con dos
+      diferencias:
+    </p>
+    <ul>
+      <li><kbd>d</kbd> sobre el builtin <strong>no abre el modal de
+        confirm</strong>: muestra un toast
+        <code>"default embebido — no se puede borrar"</code> y sigue. Para
+        "ocultar" el default, el usuario tiene que crear un shadow en
+        <code>~/.che/pipelines/che-funnel.yaml</code> (via copy-on-edit) y
+        decidir qué hacer con él.</li>
+      <li><kbd>e</kbd> y <kbd>y</kbd> sobre el builtin
+        <strong>materializan</strong> el YAML en
+        <code>~/.che/pipelines/che-funnel.yaml</code> antes de abrir el
+        editor (copy-on-edit). A partir de ahí el override del FS gana
+        sobre el builtin — el merge en <code>loadListItems</code> dedupea
+        por slug.</li>
+    </ul>
+  </section>
+
   <footer>
-    che / parametrizable revamp · manage pipelines flow · 2026-05-07
+    che / parametrizable revamp · manage pipelines flow · 2026-05-07 · addenda 2026-05-10
   </footer>
 
 </main>

--- a/docs/pipeline-execution-flow.html
+++ b/docs/pipeline-execution-flow.html
@@ -2131,8 +2131,94 @@ enter / esc volver al menu · r retry · l abrir log · q / ctrl+c salir</div>
 
   </section>
 
+  <hr class="rule">
+
+  <!-- ========== ADDENDA 2026-05 ========== -->
+  <section>
+    <div class="eyebrow">addenda 2026-05</div>
+    <h2>Fixes y polish post-2026-05-09</h2>
+    <p>
+      Lote chico de fixes sobre R1 y R3 que aparecieron al usar el runner
+      en corridas reales del <code>che-funnel</code> embebido. Ninguno
+      cambia el state diagram; son fixes de presentación y de robustez del
+      streaming.
+    </p>
+
+    <h3>1 · R1 — wrap del prompt stdin al ancho de terminal</h3>
+    <p>
+      Commit <code>5696e5d</code>. El textarea de R1 (kind=<code>text</code>)
+      no envolvía: textos largos quedaban en una sola línea que se cortaba
+      contra el borde derecho del alt-screen y el caret salía del viewport.
+      Fix: aplicar wrap soft al width visible del runner.
+    </p>
+
+    <h3>2 · R3 — wrap del log pane streaming al ancho de terminal</h3>
+    <p>
+      Commit <code>443860a</code>. El log pane viviente (sticky-bottom +
+      ring buffer) recibía líneas crudas del subprocess; cuando el CLI
+      shippeaba payloads largos sin <code>\n</code> intermedio, la línea
+      tapaba el borde derecho y el footer. Fix: wrap por terminal width
+      antes de imprimir.
+    </p>
+
+    <h3>3 · R3 — unstick del validator sobre stream-json</h3>
+    <p>
+      Commit <code>92a6f52</code>. El validator del <code>che-funnel</code>
+      (codex con <code>stream-json --verbose</code>) podía quedar trabado
+      esperando un EOF que nunca llegaba si el último evento del stream no
+      cerraba un bloque <code>verdict:</code> reconocible — el parser caía
+      a "no verdict block" pero el reader del subprocess seguía abierto.
+      Fix: liberar el reader explícitamente al detectar fin de stream sin
+      verdict, dejando que <code>parseVerdict</code> emita el fallback
+      <code>fail</code> con el feedback raw.
+    </p>
+
+    <h3>4 · R3 — stream del output del validator al log pane</h3>
+    <p>
+      Commit <code>03de057</code>. Antes el output del validator solo
+      aparecía en <code>events.jsonl</code> y en el feedback re-payload,
+      no en la UI viviente — el usuario veía "validating…" hasta el
+      verdict. Fix: el validator usa el mismo log pane que el step,
+      con prefijo distintivo, así el usuario ve qué está haciendo el
+      cross-CLI review en tiempo real.
+    </p>
+
+    <h3>5 · Bug chain del runner del che-funnel (PR #107)</h3>
+    <p>
+      Commit <code>04fe67b</code>. Cinco fixes encadenados que aparecieron
+      al correr el <code>che-funnel</code> embebido y son ortogonales al
+      state diagram:
+    </p>
+    <ul>
+      <li><strong>Fix 1 (raíz)</strong>: interpolar <code>{{INPUT}}</code>
+        en <code>step.Content</code> y <code>step.Validator.Content</code>
+        antes de armar args. Helper <code>interpolateInput</code> invocado
+        desde <code>defaultSpawnCmd</code> y <code>runValidator</code>. El
+        payload sigue viajando por stdin (compat).</li>
+      <li><strong>Fix 2</strong>: <code>splitVerdictBlocks</code> reconoce
+        fences markdown (<code>```yaml</code> / <code>```yml</code> /
+        <code>```</code> sin info-string) como candidatos adicionales.
+        Antes, verdicts envueltos en un fence dentro de prosa caían al
+        fallback "no verdict block".</li>
+      <li><strong>Fix 3</strong>: nuevo flag
+        <code>Verdict.RawFeedbackOnly</code> +
+        <code>ValidatorRun.LastFeedbackRawOnly</code>. Si el feedback es
+        sólo el fallback raw <code>"verdict: &lt;token&gt;"</code>,
+        <code>rerunStepWithFeedback</code> suprime el feedback al payload
+        (no re-prompt con ruido). Defensa adicional vía
+        <code>isRawVerdictFallback</code> en
+        <code>mergeFeedbackIntoPayload</code>.</li>
+      <li><strong>Fix 4</strong>: rotación de <code>events.jsonl</code>
+        por corrida. <code>StepRun.EventsRun</code> (1-based) se incrementa
+        en <code>startStep</code> y <code>rerunStepWithFeedback</code>. El
+        archivo se escribe como
+        <code>step-NN.events.RUN-K.jsonl</code> — los reruns por validator
+        ya no pisan el log original.</li>
+    </ul>
+  </section>
+
   <footer>
-    che / parametrizable revamp · pipeline execution flow · estado post-H10 · 2026-05-09
+    che / parametrizable revamp · pipeline execution flow · estado post-H10 · 2026-05-09 · addenda 2026-05-10
   </footer>
 
 </main>


### PR DESCRIPTION
## Resumen

Pasada de verificación + addenda sobre `docs/*.html` y `README.md` para alinear la documentación con el estado actual del código. Drift mínimo: solo `che-funnel` embebido como pipeline default (PR #98) introduce concepto nuevo no documentado; el resto son fixes 2026-05 documentados como addenda.

## Cambios

- **`README.md`**: bullet en "My pipelines" mencionando `che-funnel` embebido como pipeline default (chip `[default]`, PR #98).
- **`docs/manage-pipelines-flow.html`**: primera addenda del archivo ("Addenda 2026-05") con la semántica del builtin `che-funnel` — copy-on-edit, override del FS, comportamiento de `d`/`e`/`y` sobre el row builtin.
- **`docs/pipeline-execution-flow.html`**: nueva addenda ("Addenda 2026-05") con los fixes posteriores a 2026-05-09: wrap R1 (`5696e5d`), wrap R3 (`443860a`), unstick validator stream-json (`92a6f52`), stream validator al log pane (`03de057`), bug chain del che-funnel PR #107 (`04fe67b`).
- **`docs/design.html`**: nota al pie indicando cierre 2026-05-06 y dónde viven las addendas posteriores. Sin tocar el cuerpo (las decisiones cerradas siguen vigentes).
- **`docs/vision.html`**: revisado, modelo "Premisa A → Pipeline → Entregable B" sigue vigente, no se tocó.

## Criterios cubiertos

- [x] Cada subcomando mencionado en `README.md` existe en `cmd/*.go` (`doctor`, `upgrade`, `root`).
- [x] Cada paquete listado bajo "Layout" en `README.md` existe en `internal/` (wizard, tui, runner, runner/parser, skills, output, aiprompt, repoctx, clipboard).
- [x] Cada estado del wizard (S1–S4, SC) y del runner (R0–R4, RF, RC, RP) referenciado en los flows tiene contraparte en `internal/wizard/` o `internal/runner/`.
- [x] Cada clave YAML (`cli`, `kind`, `content`, `input`, `validator`, `max_loops`, `on_max_loops`) y enum (`text`, `file`, `url`, `pr`, `issue`, `none`, `previous_output`, `prompt`, `skill`, `fail`, `continue`, `pause`) existe en `internal/wizard/model.go` + `internal/runner/manifest.go`.
- [x] Los 4 HTML preservan balance de `<section>` y cierre de `</html>`.
- [x] `che-funnel` embebido como default pipeline documentado en README ("My pipelines") + Addenda 2026-05 en `manage-pipelines-flow.html`.
- [x] Diff acotado: solo `docs/*.html` + `README.md`; sin tocar código Go.
- [x] `make build` ok (no cambia código).

## Notas de ejecución

—

Closes #111
