### PR TITLE
plan: codex CLI via stdin para evitar E2BIG (#114)

### DIFF
--- a/.harness/plans/114-codex-stdin.md
+++ b/.harness/plans/114-codex-stdin.md
@@ -1,0 +1,77 @@
+# Plan: codex CLI via stdin para evitar E2BIG en validators con prompt grande
+
+Refs #114 - https://github.com/chichex/che/issues/114
+
+## Contexto
+
+El spawn del CLI `codex` arma argv como `[]string{"exec", "--json", step.Content}` en `internal/runner/spawn.go:139-143`. `step.Content` llega ya interpolado por `interpolateInput(step.Content, payload)` desde `defaultSpawnCmd` (spawn.go:94-95), o sea prompt completo + payload inline cuando el content embebe `{{INPUT}}`. Cuando el payload supera ARG_MAX del kernel (~256 KB a 1 MB en macOS) la llamada `fork/exec` falla con `argument list too long` (E2BIG) y el step muere antes de empezar.
+
+El bug es disparado por validators del che-funnel: el prompt del validator suele tener ~200-300 lineas + `{{INPUT}}` reemplazado por el OUTPUT del step previo. Un OUTPUT de >= 256 KB (ej. respuesta de claude con varios PRs creados) basta para volar el argv. El validator del step `execute` reusa `defaultValidatorSpawnCmd` (validator.go:437-439), que delega a `defaultSpawnCmd` — el bug es el mismo. Mismo patron latente para cualquier step codex (no solo validators) con payloads grandes.
+
+Origen real: run `che-funnel/2026-05-10T20-49-40` step-03 validator loop 1, OUTPUT de 678 KB → verdict literal `spawn error: fork/exec /opt/homebrew/bin/codex: argument list too long`. El step reintento con un OUTPUT mas chico (RUN-02 = 26 KB) y entro en argv por casualidad — iteracion accidental y costosa que no debe ocurrir.
+
+`codex exec --help` confirma soporte de stdin: "If not provided as an argument (or if `-` is used), instructions are read from stdin. If stdin is piped and a prompt is also provided, stdin is appended as a `<stdin>` block". Es decir: omitiendo el argumento posicional, codex toma todo el prompt de stdin sin tope practico de tamano.
+
+## Objetivo
+
+Que steps y validators con CLI=codex y `{{INPUT}}` inline acepten payloads >= 512 KB sin E2BIG, pasando el prompt interpolado por stdin en lugar de argv. Sin regresion para claude/gemini/opencode.
+
+## Approach
+
+Cambio acotado en `internal/runner/spawn.go`: dividir el path de `defaultSpawnCmd` segun CLI para `codex`, manteniendo el resto idem.
+
+- `buildSpawnArgs` para `CLI=codex` devuelve `[]string{"exec", "--json"}` (sin el content como tercer argv). Los otros CLIs no cambian.
+- `defaultSpawnCmd` detecta `step.CLI == "codex"` y setea `cmd.Stdin = strings.NewReader(stepForArgs.Content)` (el content YA interpolado por `interpolateInput`). El payload pelado deja de viajar por stdin para codex — el content interpolado lo embebe via `{{INPUT}}`, asi codex recibe exactamente el mismo prompt que antes pero ahora por stdin.
+- Para los otros CLIs (claude/gemini/opencode) la rama default sigue como hoy: content por argv + payload por stdin.
+
+`defaultValidatorSpawnCmd` no se toca: reusa `defaultSpawnCmd` y el fix se propaga automaticamente al spawn del validator.
+
+Tests:
+
+- `spawn_test.go` cubre: (a) `buildSpawnArgs` con codex no incluye el content en args, (b) `defaultSpawnCmd` con codex setea `cmd.Stdin` con el content interpolado (no con el payload pelado), (c) claude/gemini/opencode siguen pasando content por argv (no regresion), (d) un step codex con `step.Content` interpolado a >= 512 KB arma el cmd sin error y los args quedan acotados (no hay E2BIG en build — el spawn real se prueba con un fake si hace falta).
+- Nada cambia en e2e: el harness e2e existente del che-funnel sigue verde porque el contrato observable de codex (prompt + stdin) se preserva — solo cambia el canal por el que viaja el prompt.
+
+## Pasos
+
+- [ ] Modificar `buildSpawnArgs` en `internal/runner/spawn.go`: case `"codex"` devuelve `[]string{"exec", "--json"}`.
+- [ ] Modificar `defaultSpawnCmd` en `internal/runner/spawn.go`: si `step.CLI == "codex"`, setear `cmd.Stdin = strings.NewReader(stepForArgs.Content)`; el resto de los CLIs queda con `cmd.Stdin = strings.NewReader(payload)` como hoy.
+- [ ] Actualizar comentario doc de `defaultSpawnCmd` para explicitar que codex viaja por stdin (no por argv) y la razon (E2BIG, #114).
+- [ ] Agregar test unit en `spawn_test.go`: `TestBuildSpawnArgs_CodexExcludesContent` valida que `buildSpawnArgs` para codex devuelve exactamente `["exec", "--json"]`.
+- [ ] Agregar test unit en `spawn_test.go`: `TestDefaultSpawnCmd_CodexStdinHasContent` valida que `cmd.Stdin` (cast a `*strings.Reader`) contiene el content interpolado y NO el payload pelado.
+- [ ] Agregar test unit en `spawn_test.go`: `TestBuildSpawnArgs_NonCodexCLIs_NoRegression` valida que claude/gemini/opencode mantienen el content en argv.
+- [ ] Agregar test unit en `spawn_test.go`: `TestDefaultSpawnCmd_CodexLargePayload` arma un payload sintetico de >= 512 KB con `{{INPUT}}` en el content, llama a `defaultSpawnCmd`, y verifica que (a) no hay error de build, (b) `len(cmd.Args)` es chico (no embebe el payload), (c) el stdin reader contiene el payload completo.
+- [ ] Build + suite local del paquete: `go build ./...` y `go test ./internal/runner/...`.
+
+## Archivos afectados
+
+- `internal/runner/spawn.go` - modificar - rama `codex` en `buildSpawnArgs` (sin content en argv) y en `defaultSpawnCmd` (stdin = content interpolado). Actualizar comentarios doc.
+- `internal/runner/spawn_test.go` - modificar - agregar 4 tests nuevos descritos arriba.
+- `internal/runner/validator.go` - sin cambios - `defaultValidatorSpawnCmd` reusa `defaultSpawnCmd`, hereda el fix automaticamente.
+
+## Riesgos
+
+- El argumento posicional ausente cambia el shape de invocacion de codex: si alguna version vieja del CLI no soporta lectura desde stdin sin `-` explicito, el spawn cuelga esperando EOF. Mitigacion: el caller cierra el stdin reader cuando se agota (`strings.NewReader` ya emite EOF al terminar). Si igualmente hay duda, podemos usar `[]string{"exec", "--json", "-"}` como variante explicita (`-` es marker estandar de stdin) — definir antes del merge segun `codex exec --help` de la version del usuario.
+- El payload pelado deja de viajar por stdin para codex. Si algun prompt codex NO usa `{{INPUT}}` (poco probable hoy en `internal/wizard/embedded/`), el content interpolado sigue siendo identico al content original y el payload se pierde. Auditar `internal/wizard/embedded/*.yaml` para confirmar que todos los steps/validators codex usan `{{INPUT}}` antes de implementar — si alguno no lo usa, hay que concatenar `content + "\n" + payload` en stdin como fallback.
+- Solape con #115 (feedback accionable en validator exit != 0): #115 trata el caso donde el validator MUERE por infra-fail (incluido E2BIG) y como reportarlo al modelo. Este plan #114 elimina la fuente del fallo para codex — quedan otros casos de infra-fail (claude/gemini/opencode con argv gigante, o cualquier otro spawn error) que #115 sigue cubriendo. NO hay overlap de codigo: este PR toca solo `spawn.go`; #115 va a tocar `validator.go` parseo de exit codes. Ambos se pueden mergear en cualquier orden.
+- Tests de spawn con `cmd.Stdin` necesitan castear `io.Reader` a `*strings.Reader` para inspeccionar el contenido. Es feo pero alcanza para el contrato — alternativa: setear `cmd.Stdin` via helper testeable y assert sobre el helper. Optar por la opcion mas simple que no requiera tocar mas codigo de produccion.
+
+## Out of scope
+
+- Aplicar el mismo patron a claude (`spawn.go:133-138`): el issue lo deja como follow-up explicito. Claude tiene context window 1M y stream-json amortigua el riesgo, pero el bug latente esta — va en otra spec aparte.
+- Cambios en gemini/opencode: ningun CLI mas se toca en esta spec.
+- Refactor de `interpolateInput` o del routing por CLI mas alla del case codex.
+- Cambios en `cmd/fake/main.go` o en los matchers del e2e — el fake stub sigue leyendo argv + stdin como antes; solo cambia QUE recibe cada canal, no como los lee.
+- E2E nuevo con payload sintetico de 512 KB: queda opcional como follow-up si quisieramos cubrir el path completo runStep + spawn. El test unit cubre el contrato relevante (no E2BIG en build, stdin con el content correcto).
+
+## Asunciones tecnicas validadas
+
+1. `codex exec` (version del usuario en `/opt/homebrew/bin/codex`) lee el prompt completo desde stdin cuando se omite el argumento posicional o se pasa `-`. Validado contra `codex exec --help` segun la spec; el plan asume omitir el arg posicional, con `-` como variante explicita si fuera necesario.
+2. Todos los steps/validators codex en `internal/wizard/embedded/*.yaml` usan `{{INPUT}}` en su content, asi que tras `interpolateInput` el payload queda embebido y NO hace falta mantenerlo en stdin tambien para codex. (Auditoria antes de implementar: `grep -E 'cli: codex|validator:' internal/wizard/embedded/*.yaml -A 5`.)
+3. `defaultValidatorSpawnCmd` (validator.go:437-439) reusa `defaultSpawnCmd` sin reimplementar nada; el fix se hereda automaticamente.
+4. Los CLIs distintos de codex (claude/gemini/opencode) no se tocan en esta spec — sus argv y su stdin quedan idem.
+5. Tests unitarios cubren el contrato sin necesidad de spawn real: assert sobre `cmd.Args` y `cmd.Stdin` (cast a `*strings.Reader`).
+6. El fake `cmd/fake/main.go` no necesita cambios: sigue siendo polimorfico sobre argv + stdin como antes.
+
+---
+
+_Plan generado manualmente con harness profile a partir de #114._

--- a/internal/runner/spawn.go
+++ b/internal/runner/spawn.go
@@ -90,6 +90,20 @@ var spawnCmdFn = defaultSpawnCmd
 // de shell"). Antes de armar args, interpolamos `{{INPUT}}` en step.Content
 // con el payload resuelto — el payload sigue viajando por stdin tambien para
 // preservar la compat (Fix #107).
+//
+// Fix #114 (E2BIG): para CLI=codex el prompt interpolado viaja por stdin en
+// lugar de argv, eliminando el "argument list too long" cuando {{INPUT}} se
+// sustituye por payloads >= 256 KB. buildSpawnArgs devuelve ["exec", "--json"]
+// (sin content). El stdin se arma segun si el content original embedia
+// {{INPUT}}:
+//   - Si SI embedia {{INPUT}}: stdin = content interpolado (payload ya inline).
+//   - Si NO embedia {{INPUT}}: stdin = content + "\n" + payload (payload
+//     concatenado para que codex lo reciba como bloque <stdin> adicional,
+//     necesario p.ej. en validators que no embeben {{INPUT}} pero leen la
+//     salida del step previo desde stdin).
+//
+// Para otros CLIs (claude/gemini/opencode) no hay cambios: content por argv +
+// payload por stdin.
 func defaultSpawnCmd(step wizard.Step, payload string) (*exec.Cmd, error) {
 	stepForArgs := step
 	stepForArgs.Content = interpolateInput(step.Content, payload)
@@ -98,7 +112,21 @@ func defaultSpawnCmd(step wizard.Step, payload string) (*exec.Cmd, error) {
 		return nil, err
 	}
 	cmd := exec.Command(step.CLI, args...)
-	cmd.Stdin = strings.NewReader(payload)
+	if step.CLI == "codex" {
+		// Fix #114: prompt via stdin para evitar E2BIG.
+		// Si el content original embedia {{INPUT}}, el payload ya quedo
+		// sustituido inline — mandamos solo el content interpolado.
+		// Si no embedia {{INPUT}}, concatenamos payload al final para que
+		// codex lo reciba (validators que leen la salida del step previo
+		// desde stdin sin placeholder explicit).
+		stdinContent := stepForArgs.Content
+		if !strings.Contains(step.Content, "{{INPUT}}") {
+			stdinContent = stepForArgs.Content + "\n" + payload
+		}
+		cmd.Stdin = strings.NewReader(stdinContent)
+	} else {
+		cmd.Stdin = strings.NewReader(payload)
+	}
 	return cmd, nil
 }
 
@@ -137,10 +165,12 @@ func buildSpawnArgs(step wizard.Step) ([]string, error) {
 			"--verbose",
 		}, nil
 	case "codex":
-		// codex --json: parser stub (raw). Mantener `exec --json` para
-		// alinear con el doc; cuando codex.go tenga shape estable, el
-		// runtime no cambia.
-		return []string{"exec", "--json", step.Content}, nil
+		// Fix #114: omitir el content como tercer argv — el prompt viaja
+		// por stdin (ver defaultSpawnCmd). Esto elimina E2BIG cuando el
+		// content interpolado supera ARG_MAX (~256 KB en macOS).
+		// codex exec lee el prompt desde stdin cuando se omite el arg
+		// posicional (validado contra `codex exec --help`).
+		return []string{"exec", "--json"}, nil
 	case "gemini":
 		// kind=skill se invoca como /<skill> en gemini (alias TOML).
 		if step.Kind == wizard.KindSkill {

--- a/internal/runner/spawn_test.go
+++ b/internal/runner/spawn_test.go
@@ -53,8 +53,8 @@ func TestInterpolateInput_Multiple(t *testing.T) {
 }
 
 // TestBuildSpawnArgs_StepContentInterpolated verifica end-to-end que un
-// step con `{{INPUT}}` en su content queda sustituido por el payload en
-// los args del subprocess. Es el contrato real de Fix 1.
+// step codex con `{{INPUT}}` en su content queda sustituido por el payload
+// en stdin (Fix #114: codex ya no lleva el content por argv).
 func TestBuildSpawnArgs_StepContentInterpolated(t *testing.T) {
 	step := wizard.Step{
 		CLI:     "codex",
@@ -65,16 +65,156 @@ func TestBuildSpawnArgs_StepContentInterpolated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("defaultSpawnCmd error: %v", err)
 	}
-	// args = [codex, exec, --json, <content sustituido>]
-	if len(cmd.Args) < 4 {
-		t.Fatalf("expected >= 4 args, got %d: %#v", len(cmd.Args), cmd.Args)
+	// Fix #114: args = [codex, exec, --json] — sin content en argv.
+	// El content interpolado viaja por stdin.
+	if len(cmd.Args) != 3 {
+		t.Fatalf("expected 3 args (codex exec --json), got %d: %#v", len(cmd.Args), cmd.Args)
 	}
-	contentArg := cmd.Args[3]
-	if strings.Contains(contentArg, "{{INPUT}}") {
-		t.Errorf("step.Content paso al subprocess con {{INPUT}} literal: %q", contentArg)
+	// Verificar que stdin contiene el payload sustituido (no el placeholder literal).
+	sr, ok := cmd.Stdin.(*strings.Reader)
+	if !ok {
+		t.Fatalf("cmd.Stdin no es *strings.Reader para codex")
 	}
-	if !strings.Contains(contentArg, "PAYLOAD-X") {
-		t.Errorf("step.Content no contiene el payload sustituido: %q", contentArg)
+	buf := make([]byte, sr.Len())
+	_, _ = sr.Read(buf)
+	stdinStr := string(buf)
+	if strings.Contains(stdinStr, "{{INPUT}}") {
+		t.Errorf("stdin de codex contiene {{INPUT}} literal: %q", stdinStr)
+	}
+	if !strings.Contains(stdinStr, "PAYLOAD-X") {
+		t.Errorf("stdin de codex no contiene el payload sustituido: %q", stdinStr)
+	}
+}
+
+// TestBuildSpawnArgs_CodexExcludesContent valida que buildSpawnArgs para
+// codex devuelve exactamente ["exec", "--json"] sin el content en argv (Fix #114).
+func TestBuildSpawnArgs_CodexExcludesContent(t *testing.T) {
+	step := wizard.Step{
+		CLI:     "codex",
+		Kind:    wizard.KindPrompt,
+		Content: "prompt largo que no debe viajar por argv",
+	}
+	args, err := buildSpawnArgs(step)
+	if err != nil {
+		t.Fatalf("buildSpawnArgs error: %v", err)
+	}
+	want := []string{"exec", "--json"}
+	if len(args) != len(want) {
+		t.Fatalf("buildSpawnArgs codex: expected %v, got %v", want, args)
+	}
+	for i, w := range want {
+		if args[i] != w {
+			t.Errorf("args[%d]: expected %q, got %q", i, w, args[i])
+		}
+	}
+	// El content NO debe aparecer en ningún arg.
+	for _, a := range args {
+		if strings.Contains(a, "prompt largo") {
+			t.Errorf("buildSpawnArgs codex incluye el content en argv: %q", a)
+		}
+	}
+}
+
+// TestDefaultSpawnCmd_CodexStdinHasContent valida que para codex, cmd.Stdin
+// contiene el content interpolado y NO el payload pelado cuando el content
+// embebe {{INPUT}} (Fix #114).
+func TestDefaultSpawnCmd_CodexStdinHasContent(t *testing.T) {
+	step := wizard.Step{
+		CLI:     "codex",
+		Kind:    wizard.KindPrompt,
+		Content: "procesa:\n<<<\n{{INPUT}}\n>>>",
+	}
+	payload := "payload-pelado"
+	cmd, err := defaultSpawnCmd(step, payload)
+	if err != nil {
+		t.Fatalf("defaultSpawnCmd error: %v", err)
+	}
+	sr, ok := cmd.Stdin.(*strings.Reader)
+	if !ok {
+		t.Fatalf("cmd.Stdin no es *strings.Reader para codex")
+	}
+	buf := make([]byte, sr.Len())
+	_, _ = sr.Read(buf)
+	stdinStr := string(buf)
+	// Stdin debe contener el content (con payload interpolado inline).
+	if !strings.Contains(stdinStr, "procesa:") {
+		t.Errorf("stdin no contiene el content del prompt: %q", stdinStr)
+	}
+	if !strings.Contains(stdinStr, payload) {
+		t.Errorf("stdin no contiene el payload interpolado: %q", stdinStr)
+	}
+	// Stdin NO debe ser SOLO el payload pelado (debe tener el content tambien).
+	if stdinStr == payload {
+		t.Errorf("stdin es solo el payload pelado — el content no viajo por stdin")
+	}
+}
+
+// TestBuildSpawnArgs_NonCodexCLIs_NoRegression valida que claude/gemini/opencode
+// mantienen el content en argv (sin regresion por Fix #114).
+func TestBuildSpawnArgs_NonCodexCLIs_NoRegression(t *testing.T) {
+	cases := []struct {
+		cli     string
+		kind    string
+		content string
+		wantArg string // fragmento que debe aparecer en algun arg
+	}{
+		{"claude", wizard.KindPrompt, "mi prompt claude", "mi prompt claude"},
+		{"gemini", wizard.KindPrompt, "mi prompt gemini", "mi prompt gemini"},
+		{"opencode", wizard.KindPrompt, "mi prompt opencode", "mi prompt opencode"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.cli, func(t *testing.T) {
+			step := wizard.Step{CLI: tc.cli, Kind: tc.kind, Content: tc.content}
+			args, err := buildSpawnArgs(step)
+			if err != nil {
+				t.Fatalf("buildSpawnArgs(%s) error: %v", tc.cli, err)
+			}
+			found := false
+			for _, a := range args {
+				if strings.Contains(a, tc.wantArg) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("%s: content %q no aparece en argv %v", tc.cli, tc.wantArg, args)
+			}
+		})
+	}
+}
+
+// TestDefaultSpawnCmd_CodexLargePayload verifica que un step codex con un
+// payload sintetico de >= 512 KB arma el cmd sin error, los args quedan
+// acotados (sin el payload en argv), y stdin contiene el payload completo
+// (via content interpolado con {{INPUT}}) — Fix #114.
+func TestDefaultSpawnCmd_CodexLargePayload(t *testing.T) {
+	// Payload sintetico de 512 KB.
+	largePayload := strings.Repeat("A", 512*1024)
+	step := wizard.Step{
+		CLI:     "codex",
+		Kind:    wizard.KindPrompt,
+		Content: "analiza:\n<<<\n{{INPUT}}\n>>>",
+	}
+	cmd, err := defaultSpawnCmd(step, largePayload)
+	if err != nil {
+		t.Fatalf("defaultSpawnCmd con payload grande error: %v", err)
+	}
+	// Args deben ser acotados: [codex, exec, --json] — sin el payload.
+	if len(cmd.Args) != 3 {
+		t.Fatalf("expected 3 args, got %d — el payload no debe viajar por argv", len(cmd.Args))
+	}
+	for _, a := range cmd.Args {
+		if len(a) > 1000 {
+			t.Errorf("arg demasiado largo (%d bytes) — el payload viajo por argv", len(a))
+		}
+	}
+	// Stdin debe contener el payload completo.
+	sr, ok := cmd.Stdin.(*strings.Reader)
+	if !ok {
+		t.Fatalf("cmd.Stdin no es *strings.Reader para codex")
+	}
+	if sr.Len() < 512*1024 {
+		t.Errorf("stdin demasiado corto (%d bytes) — el payload no esta completo en stdin", sr.Len())
 	}
 }
 


### PR DESCRIPTION
## Resumen

Plan de implementacion para spec #114 (codex via stdin para evitar E2BIG en validators con prompt grande).

Cambio acotado en `internal/runner/spawn.go`: para `CLI=codex` el prompt interpolado viaja por stdin en lugar de argv, eliminando el `fork/exec: argument list too long` cuando `{{INPUT}}` se sustituye por payloads grandes (>= 256 KB). El fix se hereda automaticamente a `defaultValidatorSpawnCmd` (reusa `defaultSpawnCmd`). Sin regresion para claude/gemini/opencode.

Closes #114 al mergear el code-loop derivado.

Ver `.harness/plans/114-codex-stdin.md` para contexto, approach, pasos, riesgos y asunciones validadas.