### PR TITLE
Plan for #121: Exponer runs históricos de che dash

### DIFF
--- a/.harness/plans/121-exponer-runs-historicos-de-che-dash.md
+++ b/.harness/plans/121-exponer-runs-historicos-de-che-dash.md
@@ -1,0 +1,103 @@
+# Plan: Exponer runs históricos de che dash (tabla + run detail read-only)
+
+Refs #121 · https://github.com/chichex/che/issues/121
+
+## Contexto
+
+Spec 2 del dashboard. La tabla de runs del pipeline detail y el nuevo run detail screen consumen 3 endpoints HTTP nuevos que leen `~/.che/runs/<slug>/<run-id>/manifest.yaml` + archivos `step-NN.stdout.log`. Read-only. Builds sobre `hs-plan/119` (PR #120).
+
+## Objetivo
+
+Exponer 3 endpoints HTTP para (a) listar runs históricos de un pipeline, (b) leer el manifest completo de un run, y (c) servir el stdout crudo por step. Wirear la tabla de runs y el run detail del HTML embebido a esos endpoints. El server sigue sin escribir nada ni shellear a `gh`.
+
+## Approach
+
+Agregar `internal/dash/runs.go` con tres handlers (`handleListRuns`, `handleGetRun`, `handleGetStepStdout`), parametrizados por `runsDir`. Reusar el parsing del manifest existente (`internal/runner.Manifest`) y, si está disponible, los helpers `wizard.RunHistoryFor` para listing. Refactor de la ruta `/api/pipelines/` en `internal/dash/dash.go` a un dispatcher interno que parsea path segments y delega a la lógica correspondiente (la `http.ServeMux` no soporta routing con múltiples vars). Frontend: reemplazar `RUNS_INIT[slug]` por fetch real en pipeline detail; agregar la run detail screen con state local + lazy fetch del stdout cuando se selecciona un step; tabs `output`/`definition`/`validator?` con visibilidad/disabled según las asunciones del spec.
+
+## Pasos
+
+- [ ] Crear `internal/dash/runs.go` con `handleListRuns(runsDir string) http.HandlerFunc`, `handleGetRun(runsDir string) http.HandlerFunc`, `handleGetStepStdout(runsDir string) http.HandlerFunc`.
+- [ ] Listing reusa `wizard.RunHistoryFor(home, slug)` si está disponible; si no, walker propio que parsea `~/.che/runs/<slug>/<runId>/manifest.yaml` con `yaml.Unmarshal` a `runner.Manifest`. Orden desc por `started_at`. Corrupt skippeado + log a stderr con prefijo `[dash]`.
+- [ ] Detail parsea `manifest.yaml` con la struct `runner.Manifest`. Si no existe loader público en `internal/runner`, agregar uno mínimo en `internal/dash/runs.go` (sin modificar `internal/runner`). Corrupt → 500 + JSON `{"error":"manifest corrupt"}`.
+- [ ] Stdout endpoint sirve `~/.che/runs/<slug>/<runId>/step-NN.stdout.log` (NN = `fmt.Sprintf("%02d", idx+1)`) con `http.ServeFile` y Content-Type `text/plain; charset=utf-8`. 404 + JSON `{"error":"stdout not found"}` si no existe.
+- [ ] Refactor del routing en `internal/dash/dash.go`: el handler de `/api/pipelines/` se vuelve dispatcher por segments.
+  - `[slug]` → pipeline detail (spec 1, sin cambios)
+  - `[slug, "runs"]` → list runs
+  - `[slug, "runs", runId]` → get run
+  - `[slug, "runs", runId, "steps", idx, "stdout"]` → get stdout
+  - Cualquier otra cosa → 404.
+- [ ] Mover la lógica del actual `handleGetPipeline` (spec 1) a una función helper invocable desde el dispatcher.
+- [ ] `Serve()` resuelve `runsDir = filepath.Join(home, ".che", "runs")` (al lado del existente `pipelinesDir`).
+- [ ] Frontend HTML — tabla de runs del pipeline detail:
+  - Reemplazar lookup en `RUNS_INIT[slug]` por `useEffect` que fetch `/api/pipelines/:slug/runs` cuando cambia el slug seleccionado.
+  - Render row: id (slice 0-6 chars), status chip (reusar el componente existente), started_at relativo (tooltip absoluto al hover), duración compacta o "—" si está corriendo.
+  - Click handler en row → setea `selectedRunId` y abre run detail.
+- [ ] Frontend HTML — run detail screen (state local, sin URL routing):
+  - Cuando `selectedRunId` cambia, fetch `/api/pipelines/:slug/runs/:runId` → setea `runDetail`.
+  - Columna izquierda: steps del manifest (dot status + nombre + duración).
+  - Selección inicial: primer step (idx 0).
+  - Tab default: `output`.
+  - Tabs `output` / `definition` / `validator?`. `validator` aparece solo si `step.validator` no nil. `output` y `validator` deshabilitadas si `step.status == "pending"`. `definition` siempre disponible.
+  - Tab `output`: lazy fetch a `/api/pipelines/:slug/runs/:runId/steps/:idx/stdout` cuando se selecciona el step. Empty → copy literal `sin stdout registrado`. Si `step.error` no vacío, renderizarlo arriba del stdout.
+  - Tab `definition`: render del step desde el manifest. Si `content` vacío → copy literal `definición no persistida — ver YAML del pipeline`.
+  - Tab `validator`: render de `loops_run/max_loops`, `final_verdict`, `last_feedback` en `<pre class="mono whitespace-pre-wrap">`.
+  - AbortController por effect para evitar race al cambiar selección rápido.
+- [ ] Helpers JS inline (sin deps): `formatDuration(ms)` → "12.4s" / "1m 23s" / "1h 12m"; `formatRelative(date)` → "hace 5 min" / "hace 1 h" / fecha absoluta si > 7 días.
+- [ ] Empty state `sin runs registrados — corré el pipeline desde la TUI` aparece solo cuando el fetch devuelve `[]`.
+- [ ] Botones Run / Cancel / Resume siguen disabled (sin cambios respecto a spec 1).
+- [ ] Tests `internal/dash/runs_test.go`: listing (empty dir → `[]`, una run, múltiples ordenadas desc, una corrupta skippeada con log); detail (200 con todos los campos, 404 si run no existe, 500 si corrupt); stdout (200 con bytes, 404 si falta). Validator omitido si nil.
+- [ ] Routing tests: tabla `{path, expectedStatus, expectedBodySubstring}` en `dash_test.go` o `runs_test.go` para validar el dispatcher.
+- [ ] Smoke test manual en el PR body: `go build && ./che dash --no-open --port 17878` + curls a los 3 endpoints con un fixture plantado en `~/.che/runs/`.
+
+## Archivos afectados
+
+- `internal/dash/runs.go` — crear — 3 handlers + helpers de listing/detail/stdout
+- `internal/dash/runs_test.go` — crear — coverage de listing/detail/stdout + routing dispatcher
+- `internal/dash/dash.go` — modificar — refactor del routing a dispatcher + resolver `runsDir`
+- `internal/dash/pipelines.go` — modificar — el handler actual de `/api/pipelines/:slug` pasa a ser invocado desde el dispatcher (función helper sin cambios de comportamiento)
+- `internal/dash/assets/dash.html` — modificar — fetch real para tabla de runs + run detail screen + tabs + helpers JS
+
+## Riesgos
+
+- Refactor del routing: si rompo el matching del dispatcher, `/api/pipelines/:slug` (spec 1) deja de andar. Mitigación: tabla de tests del dispatcher antes de tocar el frontend, incluyendo todos los paths de spec 1 + spec 2.
+- Manifest yaml puede tener campos que no espero o tags `yaml:"..."` que no documenté. Mitigación: usar exactamente la struct `runner.Manifest` ya definida, no redefinir; tests con fixture real.
+- `step-NN.stdout.log` puede ser muy grande (no hay cap del runner). `http.ServeFile` hace streaming nativo, así que la memoria del server queda OK — el riesgo se traslada al browser. Aceptado.
+- Lazy fetch del stdout flapeando si el usuario cambia rápido entre steps: AbortController por effect.
+- Naming del archivo de stdout (`step-NN`, 1-indexed, 2-pad): si el runner cambió el formato sin actualizar la doc, los tests fallarán inmediatamente y resolvemos.
+- Helper `wizard.RunHistoryFor` puede no estar exportado o no devolver todos los campos necesarios. Fallback: walker propio + parse YAML inline.
+
+## Out of scope
+
+- SSE live para runs vivos (spec 3) — los runs `running` se sirven como snapshot.
+- SSE global del rail (spec 4).
+- Lanzar / cancelar / resume (write API, eventual spec futuro).
+- Stderr endpoint (queda como follow-up si hace falta).
+- Routing real con URLs del browser (`history.pushState`).
+- Paginación / truncado del stdout.
+- Cambios al package `internal/runner` o `internal/wizard` salvo agregar accessor mínimo si no hay loader público.
+
+## Asunciones tecnicas validadas
+
+1. Stack: Go puro, sin deps nuevas. Reuse de `encoding/json` (stdlib), `internal/runner` (struct `Manifest`), `internal/wizard` (helper `RunHistoryFor` o similar) y `gopkg.in/yaml.v3` (ya usado por wizard/runner).
+2. Ubicación: `internal/dash/runs.go` + `internal/dash/runs_test.go`. Sin sub-paquete nuevo.
+3. Listing: preferimos `wizard.RunHistoryFor(home, slug)` si está exportado y devuelve la shape adecuada. Si no, walker propio que parsea `~/.che/runs/<slug>/<runId>/manifest.yaml` con `yaml.Unmarshal` a `runner.Manifest`.
+4. Detail: parsear `manifest.yaml` con la struct `runner.Manifest` ya existente. Si no hay loader público (`runner.LoadManifest`), agregar uno mínimo en `internal/dash/runs.go` sin modificar `internal/runner`.
+5. Routing: refactor del handler `/api/pipelines/` a un **dispatcher manual por segments**. Path post-prefix se splittea por `/`; el largo + nombre del segmento determina qué handler corre. No usar libs de routing — stdlib only.
+6. JSON shape de listing: `[{id, status, started_at, finished_at?, input_kind, input_value}]`. snake_case (consistente con spec 1).
+7. JSON shape de detail: `{id, slug, status, started_at, finished_at?, input_kind, input_value, steps: [...]}`. Step: `{idx, name, cli, kind, status, exit_code, started_at?, finished_at?, error?, validator?}`. Validator: `{cli, loops_run, max_loops, on_max_loops, final_verdict, last_feedback}`. Fields con `omitempty` cuando aplique.
+8. Timestamps: `time.RFC3339` para emit. Parsing en el frontend con `new Date()`.
+9. Stdout: servir con `http.ServeFile`. 404 + JSON `{"error":"stdout not found"}` si no existe. Content-Type forzado a `text/plain; charset=utf-8`.
+10. Inyección de dependencias: handlers se construyen con factory `func(runsDir string) http.HandlerFunc`. Tests pasan `t.TempDir()`.
+11. Detección de manifest corrupto en listing: try parse; on error → `log.Printf("[dash] manifest corrupt: %s: %v", path, err)` + skip. Los demás runs siguen siendo serializados.
+12. Stdout file naming: `step-NN.stdout.log` con `NN = fmt.Sprintf("%02d", idx+1)` (1-indexed, 2 dígitos).
+13. Frontend: dos nuevos `useEffect` en el componente App. (a) `selectedSlug` → fetch a `/api/pipelines/:slug/runs` y setea `runs`. (b) `selectedRunId` → fetch a `/api/pipelines/:slug/runs/:runId` y setea `runDetail`. Stdout es lazy en el tab `output` con su propio `useEffect`.
+14. AbortController: instanciar uno por effect; cancelar al cleanup. Evita race entre selección anterior y nueva.
+15. Helpers JS: `formatDuration(ms)` y `formatRelative(date)` implementados inline (~30 LOC cada uno). Sin libs externas (moment/dayjs/etc).
+16. Render del feedback del validator: `<pre class="mono whitespace-pre-wrap">` con el contenido crudo. Sin highlighting.
+17. Tests: `httptest.NewRecorder` + `t.TempDir()`. Plantar fixtures en disco simulando la estructura `~/.che/runs/<slug>/<runId>/manifest.yaml` + `step-01.stdout.log`. Cleanup automático del temp dir.
+18. Routing tests: tabla `{path, expectedStatus, expectedBodySubstring}` para validar el dispatcher cubriendo paths de spec 1 + spec 2.
+19. Smoke test manual incluido en el PR body: `go build && ./che dash --no-open --port 17878` + 3 curls.
+
+---
+
+_Plan generado por `/hs-plan` a partir de #121._

--- a/internal/dash/assets/dash.html
+++ b/internal/dash/assets/dash.html
@@ -646,28 +646,73 @@ const PipelineDetail = ({ pipeline, runs, onOpenRun, onRequestRun, onResumeDraft
 // Run detail (live + frozen share the same view)
 // ─────────────────────────────────────────────────────────────────────
 
-const RunDetail = ({ pipeline, run, stream, onBack, onCancel, onResume, onSelectStep, selectedStepIdx }) => {
-  const streamRef = useRef(null);
+const RunDetail = ({ pipeline, run, slug, runId, stream, onBack, onCancel, onResume, onSelectStep, selectedStepIdx }) => {
   const [paneView, setPaneView] = useState("output");
-  const selectedHasValidator = run.steps[selectedStepIdx]?.validator;
+  const [stdoutText, setStdoutText] = useState(null); // null=not fetched, ""=empty, str=content
+  const [stdoutLoading, setStdoutLoading] = useState(false);
+
+  // run may be null while the detail fetch is in flight — guard defensively
+  const steps = run?.steps || [];
+  const selectedStep = steps[selectedStepIdx] || null;
+  const selectedHasValidator = selectedStep?.validator || null;
+
+  // if we switched to a step without validator while on validator tab, fall back
   useEffect(() => {
-    // if we switched to a step without validator while on the validator tab, fall back
     if (paneView === "validator" && !selectedHasValidator) setPaneView("output");
   }, [selectedStepIdx, selectedHasValidator]);
+
+  // reset stdout cache when step or run changes
   useEffect(() => {
-    const el = streamRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, [stream]);
+    setStdoutText(null);
+    setStdoutLoading(false);
+  }, [selectedStepIdx, runId]);
+
+  // lazy fetch stdout when tab is "output" and not yet loaded
+  useEffect(() => {
+    if (paneView !== "output") return;
+    if (stdoutText !== null) return; // already fetched or loading
+    if (!slug || !runId || selectedStep == null) return;
+    if (selectedStep.status === "pending") return;
+
+    setStdoutLoading(true);
+    const ctrl = new AbortController();
+    fetch('/api/pipelines/' + slug + '/runs/' + runId + '/steps/' + selectedStepIdx + '/stdout', { signal: ctrl.signal })
+      .then(r => {
+        if (r.status === 404) return '';
+        return r.text();
+      })
+      .then(text => {
+        setStdoutText(text || '');
+        setStdoutLoading(false);
+      })
+      .catch(err => {
+        if (err.name !== 'AbortError') {
+          console.error('[dash] fetch stdout:', err);
+          setStdoutText('');
+          setStdoutLoading(false);
+        }
+      });
+    return () => ctrl.abort();
+  }, [paneView, selectedStepIdx, runId, slug, stdoutText]);
+
+  if (!run) {
+    return (
+      <div className="flex flex-col h-full items-center justify-center">
+        <div className="ink-3 text-[13px] mono">cargando run…</div>
+      </div>
+    );
+  }
 
   const isLive = run.status === "running";
   const dur = run.finished_at && run.started_at
     ? new Date(run.finished_at).getTime() - new Date(run.started_at).getTime()
     : run.started_at ? Date.now() - new Date(run.started_at).getTime() : null;
 
-  const selectedStep = run.steps[selectedStepIdx];
-
-  // filter stream for selected step (in the simulator we just show all; in real impl, server tags by step idx)
-  const filtered = stream;
+  // step duration from manifest: finished_at - started_at in ms
+  const stepDuration = (s) => {
+    if (!s || !s.finished_at || !s.started_at) return null;
+    return new Date(s.finished_at).getTime() - new Date(s.started_at).getTime();
+  };
 
   return (
     <div className="flex flex-col h-full" data-screen-label={"run · " + run.id}>
@@ -701,32 +746,28 @@ const RunDetail = ({ pipeline, run, stream, onBack, onCancel, onResume, onSelect
                 title="v1 read-only — usar TUI para lanzar"
               >Cancel run</button>
             )}
-            {!isLive && run.status === "failed" && (
-              <button className="btn">Re-run</button>
-            )}
           </div>
         </div>
         <div className="flex items-center gap-5 mono text-[12px] ink-3 ml-8">
           <span>started <span className="ink-2">{fmtClock(run.started_at)}</span> · {fmtAgo(run.started_at)}</span>
           <span>{isLive ? "live" : "duration"} <span className="ink-2">{fmtDuration(dur)}</span></span>
-          {run.input && <span>input <span className="ink-2">{run.input}</span></span>}
-          <span className="ml-auto">{run.steps.filter(s=>s.status==="done").length}/{run.steps.length} steps</span>
+          {run.input_value && <span>input <span className="ink-2">{run.input_value}</span></span>}
+          <span className="ml-auto">{steps.filter(s=>s.status==="done").length}/{steps.length} steps</span>
         </div>
       </div>
 
-      {/* steps + stream */}
+      {/* steps + detail pane */}
       <div className="flex flex-1 min-h-0">
         {/* steps timeline */}
         <div className="w-[380px] shrink-0 border-r hairline overflow-y-auto scroll-thin">
           <div className="px-4 pt-4 pb-2 text-[11px] uppercase tracking-wider ink-3 font-semibold">steps</div>
           <div className="pb-4">
-            {run.steps.map((s, i) => {
+            {steps.map((s, i) => {
               const sel = i === selectedStepIdx;
-              const stepDef = pipeline.steps[i];
-              const hasValidator = stepDef && stepDef.validator;
+              const dur_ms = stepDuration(s);
               return (
                 <button
-                  key={s.name}
+                  key={s.name + i}
                   onClick={() => onSelectStep(i)}
                   className={"step-row w-full text-left px-4 py-3 border-b hairline-2 " + (sel ? "selected" : "")}
                 >
@@ -734,9 +775,9 @@ const RunDetail = ({ pipeline, run, stream, onBack, onCancel, onResume, onSelect
                     <span className="mono text-[10.5px] ink-3 w-5">{(i+1).toString().padStart(2,"0")}</span>
                     <StatusDot status={s.status} />
                     <span className="mono text-[13px] ink">{s.name}</span>
-                    <span className="mono text-[10.5px] ink-3 ml-1">{stepDef?.cli}</span>
+                    <span className="mono text-[10.5px] ink-3 ml-1">{s.cli}</span>
                     <span className="ml-auto mono text-[11px] ink-3">
-                      {s.status === "running" ? "running" : fmtDuration(s.duration_ms)}
+                      {s.status === "running" ? "running" : fmtDuration(dur_ms)}
                     </span>
                   </div>
                   {s.error && (
@@ -744,7 +785,7 @@ const RunDetail = ({ pipeline, run, stream, onBack, onCancel, onResume, onSelect
                       {s.error}
                     </div>
                   )}
-                  {hasValidator && s.validator && (
+                  {s.validator && (
                     <div className="mt-2 ml-7 panel rounded-md p-2 border hairline" style={{background:"rgba(0,0,0,0.015)"}}>
                       <div className="flex items-center gap-2 mb-1">
                         <span className="text-[10.5px] uppercase tracking-wider ink-3 font-semibold">validator</span>
@@ -771,17 +812,20 @@ const RunDetail = ({ pipeline, run, stream, onBack, onCancel, onResume, onSelect
           </div>
         </div>
 
-        {/* stream panel */}
+        {/* detail pane */}
         <div className="flex-1 flex flex-col min-w-0">
           <div className="flex items-center justify-between px-4 py-0 border-b hairline">
             <div className="flex items-center gap-0">
+              {/* output tab: disabled if step is pending */}
               <button
-                onClick={() => setPaneView("output")}
-                className={"px-3 py-3 text-[12px] mono border-b-2 transition-colors " + (paneView === "output" ? "ink font-semibold" : "ink-3 hover:ink-2")}
+                onClick={() => selectedStep?.status !== "pending" && setPaneView("output")}
+                disabled={selectedStep?.status === "pending"}
+                className={"px-3 py-3 text-[12px] mono border-b-2 transition-colors " + (paneView === "output" ? "ink font-semibold" : "ink-3 hover:ink-2") + (selectedStep?.status === "pending" ? " opacity-40 cursor-not-allowed" : "")}
                 style={{borderColor: paneView === "output" ? "var(--ink)" : "transparent", marginBottom: "-1px"}}
               >
                 output
               </button>
+              {/* definition tab: always available */}
               <button
                 onClick={() => setPaneView("definition")}
                 className={"px-3 py-3 text-[12px] mono border-b-2 transition-colors " + (paneView === "definition" ? "ink font-semibold" : "ink-3 hover:ink-2")}
@@ -789,10 +833,12 @@ const RunDetail = ({ pipeline, run, stream, onBack, onCancel, onResume, onSelect
               >
                 definition
               </button>
+              {/* validator tab: only if step has validator, disabled if pending */}
               {selectedHasValidator && (
                 <button
-                  onClick={() => setPaneView("validator")}
-                  className={"px-3 py-3 text-[12px] mono border-b-2 transition-colors " + (paneView === "validator" ? "ink font-semibold" : "ink-3 hover:ink-2")}
+                  onClick={() => selectedStep?.status !== "pending" && setPaneView("validator")}
+                  disabled={selectedStep?.status === "pending"}
+                  className={"px-3 py-3 text-[12px] mono border-b-2 transition-colors " + (paneView === "validator" ? "ink font-semibold" : "ink-3 hover:ink-2") + (selectedStep?.status === "pending" ? " opacity-40 cursor-not-allowed" : "")}
                   style={{borderColor: paneView === "validator" ? "var(--ink)" : "transparent", marginBottom: "-1px"}}
                 >
                   validator <span className="ink-3">{selectedHasValidator.loops_run}/{selectedHasValidator.max_loops}</span>
@@ -806,41 +852,75 @@ const RunDetail = ({ pipeline, run, stream, onBack, onCancel, onResume, onSelect
               )}
             </div>
             <div className="flex items-center gap-2 mono text-[10.5px] ink-3">
-              {paneView === "output" ? <span>{stream.length} lines</span>
-                : paneView === "definition" ? <span>step {(selectedStepIdx+1).toString().padStart(2,"0")} / {run.steps.length.toString().padStart(2,"0")}</span>
-                : <span>{selectedHasValidator?.loops_run || 0} loop{(selectedHasValidator?.loops_run || 0) === 1 ? "" : "s"}</span>}
+              {paneView === "definition"
+                ? <span>step {(selectedStepIdx+1).toString().padStart(2,"00")} / {steps.length.toString().padStart(2,"00")}</span>
+                : paneView === "validator"
+                ? <span>{selectedHasValidator?.loops_run || 0} loop{(selectedHasValidator?.loops_run || 0) === 1 ? "" : "s"}</span>
+                : null}
             </div>
           </div>
+
           {paneView === "output" ? (
-            <div ref={streamRef} className="stream flex-1 overflow-y-auto scroll-thin px-4 py-3">
-              {filtered.map((line, idx) => (
-                <div key={idx} className="flex gap-3">
-                  <span className="l-ts shrink-0 select-none">{line.tStr}</span>
-                  <span className={"shrink-0 select-none " + (line.kind === "err" ? "l-err" : line.kind === "sys" ? "l-sys" : "l-ts")}>
-                    {line.kind === "err" ? "ERR" : line.kind === "sys" ? "SYS" : "out"}
-                  </span>
-                  <span className={line.kind === "err" ? "l-err" : line.kind === "sys" ? "l-sys" : "l-out"}>
-                    {line.text}
-                  </span>
-                </div>
-              ))}
-              {isLive && <div className="caret mt-1" />}
+            <div className="stream flex-1 overflow-y-auto scroll-thin px-4 py-3">
+              {selectedStep?.status === "pending" ? (
+                <div className="ink-3 text-[12.5px]">step pendiente — aún no corrió</div>
+              ) : stdoutLoading ? (
+                <div className="ink-3 text-[12.5px]">cargando…</div>
+              ) : stdoutText === null ? null : stdoutText === '' ? (
+                <div className="ink-3 text-[12.5px]">sin stdout registrado</div>
+              ) : (
+                <>
+                  {selectedStep?.error && (
+                    <div className="mb-3 px-3 py-2 rounded text-[12px] mono" style={{background:"rgba(var(--failed-rgb,220,38,38),0.08)",color:"var(--failed)"}}>
+                      {selectedStep.error}
+                    </div>
+                  )}
+                  <pre className="mono text-[12px] ink whitespace-pre-wrap">{stdoutText}</pre>
+                </>
+              )}
             </div>
           ) : paneView === "definition" ? (
             <div className="flex-1 overflow-y-auto scroll-thin px-6 py-5">
-              <StepDefinition
-                step={pipeline.steps[selectedStepIdx]}
-                idx={selectedStepIdx}
-                total={run.steps.length}
-                runStep={run.steps[selectedStepIdx]}
-              />
+              {selectedStep ? (
+                <div>
+                  <div className="flex items-center gap-2 mb-4">
+                    <span className="mono text-[13px] font-semibold ink">{selectedStep.name}</span>
+                    {selectedStep.cli && <span className="badge mono">{selectedStep.cli}</span>}
+                    {selectedStep.kind && <span className="badge mono">{selectedStep.kind}</span>}
+                  </div>
+                  {selectedStep.content ? (
+                    <pre className="mono text-[12px] ink-2 whitespace-pre-wrap bg-[var(--bg)] rounded border hairline px-4 py-3">{selectedStep.content}</pre>
+                  ) : (
+                    <div className="ink-3 text-[12.5px]">definición no persistida — ver YAML del pipeline</div>
+                  )}
+                </div>
+              ) : (
+                <div className="ink-3 text-[12.5px]">seleccioná un step</div>
+              )}
             </div>
           ) : (
-            <ValidatorHistory
-              validator={selectedHasValidator}
-              step={pipeline.steps[selectedStepIdx]}
-              runStep={run.steps[selectedStepIdx]}
-            />
+            /* validator tab */
+            <div className="flex-1 overflow-y-auto scroll-thin px-6 py-5">
+              {selectedHasValidator ? (
+                <div>
+                  <div className="flex items-center gap-3 mb-4">
+                    <span className="mono text-[12px] ink-3">loops_run</span>
+                    <span className="mono text-[13px] ink">{selectedHasValidator.loops_run} / {selectedHasValidator.max_loops}</span>
+                    {selectedHasValidator.final_verdict && (
+                      <span className={"badge " + verdictBadgeClass(selectedHasValidator.final_verdict)}>{selectedHasValidator.final_verdict}</span>
+                    )}
+                  </div>
+                  {selectedHasValidator.last_feedback && (
+                    <div className="mb-3">
+                      <div className="text-[11px] uppercase tracking-wider ink-3 font-semibold mb-1">last feedback</div>
+                      <pre className="mono text-[12px] ink-2 whitespace-pre-wrap bg-[var(--bg)] rounded border hairline px-4 py-3">{selectedHasValidator.last_feedback}</pre>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className="ink-3 text-[12.5px]">sin validator en este step</div>
+              )}
+            </div>
           )}
         </div>
       </div>
@@ -1095,6 +1175,7 @@ const App = () => {
   const [runs, setRuns] = useState(RUNS_INIT);
   const [selectedSlug, setSelectedSlug] = useState(null);
   const [openRunId, setOpenRunId] = useState(null);
+  const [runDetail, setRunDetail] = useState(null);
   const [selectedStepIdx, setSelectedStepIdx] = useState(0);
   const [modalOpen, setModalOpen] = useState(false);
   const [toast, setToast] = useState(null);
@@ -1134,6 +1215,33 @@ const App = () => {
       })
       .catch(err => console.error('[dash] fetch pipeline detail:', err));
   }, [selectedSlug]);
+
+  // ── fetch runs list when selected slug changes ────────────────────
+  useEffect(() => {
+    if (!selectedSlug) return;
+    const ctrl = new AbortController();
+    fetch('/api/pipelines/' + selectedSlug + '/runs', { signal: ctrl.signal })
+      .then(r => r.json())
+      .then(data => {
+        setRuns(prev => ({ ...prev, [selectedSlug]: data }));
+      })
+      .catch(err => { if (err.name !== 'AbortError') console.error('[dash] fetch runs:', err); });
+    return () => ctrl.abort();
+  }, [selectedSlug]);
+
+  // ── fetch run detail when openRunId changes ───────────────────────
+  useEffect(() => {
+    if (!openRunId || !selectedSlug) {
+      setRunDetail(null);
+      return;
+    }
+    const ctrl = new AbortController();
+    fetch('/api/pipelines/' + selectedSlug + '/runs/' + openRunId, { signal: ctrl.signal })
+      .then(r => r.json())
+      .then(data => setRunDetail(data))
+      .catch(err => { if (err.name !== 'AbortError') console.error('[dash] fetch run detail:', err); });
+    return () => ctrl.abort();
+  }, [openRunId, selectedSlug]);
 
   const selectedPipeline = pipelines.find(p => p.slug === selectedSlug);
   const openRun = openRunId
@@ -1299,6 +1407,7 @@ const App = () => {
   const onSelectPipeline = (slug) => {
     setSelectedSlug(slug);
     setOpenRunId(null);
+    setRunDetail(null);
   };
 
   return (
@@ -1318,14 +1427,16 @@ const App = () => {
                 ? "no pipelines yet — corré che y entrá a Create pipeline"
                 : "seleccioná un pipeline del rail"}
             </div>
-          ) : openRun ? (
+          ) : openRunId ? (
             <RunDetail
               pipeline={selectedPipeline}
-              run={openRun}
+              run={runDetail || openRun}
+              slug={selectedSlug}
+              runId={openRunId}
               stream={streamLines}
               selectedStepIdx={selectedStepIdx}
               onSelectStep={setSelectedStepIdx}
-              onBack={() => setOpenRunId(null)}
+              onBack={() => { setOpenRunId(null); setRunDetail(null); }}
               onCancel={cancelRun}
               onResume={resumeRun}
             />
@@ -1333,7 +1444,7 @@ const App = () => {
             <PipelineDetail
               pipeline={selectedPipeline}
               runs={runs}
-              onOpenRun={(id) => { setOpenRunId(id); setSelectedStepIdx(0); }}
+              onOpenRun={(id) => { setOpenRunId(id); setSelectedStepIdx(0); setRunDetail(null); }}
               onRequestRun={requestRun}
               onResumeDraft={() => alert("Prototype: would run `che new --resume " + selectedPipeline.slug + "` in the user's terminal.")}
             />

--- a/internal/dash/assets/dash.html
+++ b/internal/dash/assets/dash.html
@@ -608,7 +608,6 @@ const PipelineDetail = ({ pipeline, runs, onOpenRun, onRequestRun, onResumeDraft
                 <th className="text-left font-medium px-4 py-2.5">input</th>
                 <th className="text-left font-medium px-4 py-2.5 w-[110px]">started</th>
                 <th className="text-left font-medium px-4 py-2.5 w-[100px]">duration</th>
-                <th className="text-left font-medium px-4 py-2.5 w-[160px]">steps</th>
               </tr>
             </thead>
             <tbody>
@@ -616,8 +615,6 @@ const PipelineDetail = ({ pipeline, runs, onOpenRun, onRequestRun, onResumeDraft
                 const dur = r.finished_at && r.started_at
                   ? new Date(r.finished_at).getTime() - new Date(r.started_at).getTime()
                   : null;
-                const totalSteps = r.steps.length;
-                const doneSteps = r.steps.filter(s => s.status === "done").length;
                 return (
                   <tr
                     key={r.id}
@@ -625,12 +622,11 @@ const PipelineDetail = ({ pipeline, runs, onOpenRun, onRequestRun, onResumeDraft
                     className="border-t hairline-2 cursor-pointer hover:bg-[var(--hover)]"
                   >
                     <td className="px-4 py-3"><StatusDot status={r.status} /></td>
-                    <td className="px-4 py-3 mono ink">{r.id}</td>
+                    <td className="px-4 py-3 mono ink">{r.id.slice(0, 6)}</td>
                     <td className="px-4 py-3 mono ink-2">{statusLabel[r.status]}</td>
-                    <td className="px-4 py-3 mono ink-2 truncate">{r.input || <span className="ink-3">—</span>}</td>
-                    <td className="px-4 py-3 ink-2">{fmtAgo(r.started_at)}</td>
+                    <td className="px-4 py-3 mono ink-2 truncate">{r.input_value || <span className="ink-3">—</span>}</td>
+                    <td className="px-4 py-3 ink-2" title={fmtClock(r.started_at)}>{fmtAgo(r.started_at)}</td>
                     <td className="px-4 py-3 mono ink-2">{r.status === "running" ? <span className="ink">live</span> : fmtDuration(dur)}</td>
-                    <td className="px-4 py-3 mono ink-2">{doneSteps}/{totalSteps}</td>
                   </tr>
                 );
               })}

--- a/internal/dash/dash.go
+++ b/internal/dash/dash.go
@@ -49,17 +49,19 @@ func Serve(ctx context.Context, opts Options) error {
 		return err
 	}
 
-	// Resolve pipelines directory: ~/.che/pipelines. On failure use ""
-	// so handlers return empty list / 404 instead of crashing.
+	// Resolve pipelines and runs directories. On failure use "" so handlers
+	// return empty list / 404 instead of crashing.
 	pipelinesDir := ""
+	runsDir := ""
 	if home, err := os.UserHomeDir(); err == nil {
 		pipelinesDir = filepath.Join(home, ".che", "pipelines")
+		runsDir = filepath.Join(home, ".che", "runs")
 	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", handleIndex)
 	mux.HandleFunc("/api/pipelines", handleListPipelines(pipelinesDir))
-	mux.HandleFunc("/api/pipelines/", handleGetPipeline(pipelinesDir))
+	mux.HandleFunc("/api/pipelines/", dispatchPipelinesPrefix(pipelinesDir, runsDir))
 
 	srv := &http.Server{
 		Handler:           mux,

--- a/internal/dash/pipelines.go
+++ b/internal/dash/pipelines.go
@@ -140,48 +140,58 @@ func handleListPipelines(dir string) http.HandlerFunc {
 // It extracts the slug from the URL path, loads the matching YAML, and
 // returns the full pipeline detail including steps. Returns 404 JSON if
 // the slug does not exist, 500 on systemic errors.
+//
+// Deprecated: prefer calling getPipelineDetail directly from the dispatcher.
+// This function is kept for backward compatibility with tests.
 func handleGetPipeline(dir string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		slug := strings.TrimPrefix(r.URL.Path, "/api/pipelines/")
+		slug = strings.TrimSuffix(slug, "/")
 		if slug == "" || strings.ContainsAny(slug, "/\\") {
 			http.Error(w, `{"error":"pipeline not found"}`, http.StatusNotFound)
 			return
 		}
+		getPipelineDetail(dir, slug, w, r)
+	}
+}
 
-		if dir == "" {
+// getPipelineDetail is the helper that loads a pipeline by slug from dir and
+// writes the JSON detail response. Used by both handleGetPipeline and the
+// dispatcher in dispatchPipelinesPrefix.
+func getPipelineDetail(dir, slug string, w http.ResponseWriter, r *http.Request) {
+	if dir == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"pipeline not found"}`))
+		return
+	}
+
+	path := filepath.Join(dir, slug+".yaml")
+	p, err := wizard.Load(path)
+	if err != nil {
+		if os.IsNotExist(err) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = w.Write([]byte(`{"error":"pipeline not found"}`))
 			return
 		}
-
-		path := filepath.Join(dir, slug+".yaml")
-		p, err := wizard.Load(path)
-		if err != nil {
-			if os.IsNotExist(err) {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusNotFound)
-				_, _ = w.Write([]byte(`{"error":"pipeline not found"}`))
-				return
-			}
-			log.Printf("[dash] load %s: %v", path, err)
-			http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
-			return
-		}
-
-		steps := make([]stepJSON, 0, len(p.Steps))
-		for _, s := range p.Steps {
-			steps = append(steps, toStepJSON(s))
-		}
-
-		detail := pipelineDetailJSON{
-			Slug:        slug,
-			Name:        p.Name,
-			Description: p.Description,
-			Status:      pipelineStatus(p),
-			Steps:       steps,
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(detail)
+		log.Printf("[dash] load %s: %v", path, err)
+		http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
+		return
 	}
+
+	steps := make([]stepJSON, 0, len(p.Steps))
+	for _, s := range p.Steps {
+		steps = append(steps, toStepJSON(s))
+	}
+
+	detail := pipelineDetailJSON{
+		Slug:        slug,
+		Name:        p.Name,
+		Description: p.Description,
+		Status:      pipelineStatus(p),
+		Steps:       steps,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(detail)
 }

--- a/internal/dash/runs.go
+++ b/internal/dash/runs.go
@@ -1,0 +1,402 @@
+package dash
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/chichex/che/internal/runner"
+	"gopkg.in/yaml.v3"
+)
+
+// ── JSON wire shapes ───────────────────────────────────────────────────
+
+// runListItemJSON is the wire shape for a single item in GET /api/pipelines/:slug/runs.
+type runListItemJSON struct {
+	ID         string  `json:"id"`
+	Status     string  `json:"status"`
+	StartedAt  string  `json:"started_at"`
+	FinishedAt *string `json:"finished_at,omitempty"`
+	InputKind  string  `json:"input_kind,omitempty"`
+	InputValue string  `json:"input_value,omitempty"`
+}
+
+// runDetailJSON is the wire shape for GET /api/pipelines/:slug/runs/:runId.
+type runDetailJSON struct {
+	ID         string         `json:"id"`
+	Slug       string         `json:"slug"`
+	Status     string         `json:"status"`
+	StartedAt  string         `json:"started_at"`
+	FinishedAt *string        `json:"finished_at,omitempty"`
+	InputKind  string         `json:"input_kind,omitempty"`
+	InputValue string         `json:"input_value,omitempty"`
+	Steps      []runStepJSON  `json:"steps"`
+}
+
+// runStepJSON is the wire shape for a step in a run detail.
+type runStepJSON struct {
+	Idx        int                  `json:"idx"`
+	Name       string               `json:"name"`
+	CLI        string               `json:"cli,omitempty"`
+	Kind       string               `json:"kind,omitempty"`
+	Status     string               `json:"status"`
+	ExitCode   int                  `json:"exit_code"`
+	StartedAt  *string              `json:"started_at,omitempty"`
+	FinishedAt *string              `json:"finished_at,omitempty"`
+	Error      string               `json:"error,omitempty"`
+	Validator  *runValidatorJSON    `json:"validator,omitempty"`
+}
+
+// runValidatorJSON is the wire shape for an optional step validator in run detail.
+type runValidatorJSON struct {
+	CLI          string `json:"cli,omitempty"`
+	LoopsRun     int    `json:"loops_run"`
+	MaxLoops     int    `json:"max_loops"`
+	OnMaxLoops   string `json:"on_max_loops,omitempty"`
+	FinalVerdict string `json:"final_verdict,omitempty"`
+	LastFeedback string `json:"last_feedback,omitempty"`
+}
+
+// ── manifest loading ───────────────────────────────────────────────────
+
+// loadManifest parses a manifest.yaml file at path into a runner.Manifest.
+func loadManifest(path string) (runner.Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return runner.Manifest{}, err
+	}
+	var m runner.Manifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return runner.Manifest{}, err
+	}
+	return m, nil
+}
+
+// fmtTime returns a RFC3339 string pointer if t is non-zero, nil otherwise.
+func fmtTime(t time.Time) *string {
+	if t.IsZero() {
+		return nil
+	}
+	s := t.Format(time.RFC3339)
+	return &s
+}
+
+// manifestToRunDetail converts a runner.Manifest + slug to the wire detail shape.
+func manifestToRunDetail(m runner.Manifest, slug string) runDetailJSON {
+	steps := make([]runStepJSON, 0, len(m.Steps))
+	for _, s := range m.Steps {
+		sj := runStepJSON{
+			Idx:        s.Idx,
+			Name:       s.Name,
+			CLI:        s.CLI,
+			Kind:       s.Kind,
+			Status:     s.Status,
+			ExitCode:   s.ExitCode,
+			StartedAt:  fmtTime(s.StartedAt),
+			FinishedAt: fmtTime(s.FinishedAt),
+			Error:      s.Error,
+		}
+		if s.Validator != nil {
+			sj.Validator = &runValidatorJSON{
+				CLI:          s.Validator.CLI,
+				LoopsRun:     s.Validator.LoopsRun,
+				MaxLoops:     s.Validator.MaxLoops,
+				OnMaxLoops:   s.Validator.OnMaxLoops,
+				FinalVerdict: s.Validator.FinalVerdict,
+				LastFeedback: s.Validator.LastFeedback,
+			}
+		}
+		steps = append(steps, sj)
+	}
+
+	runID := m.RunID
+	if runID == "" {
+		runID = filepath.Base(filepath.Dir(m.PipelinePath))
+	}
+
+	return runDetailJSON{
+		ID:         runID,
+		Slug:       slug,
+		Status:     m.Status,
+		StartedAt:  m.StartedAt.Format(time.RFC3339),
+		FinishedAt: fmtTime(m.FinishedAt),
+		InputKind:  m.InputKind,
+		InputValue: m.InputValue,
+		Steps:      steps,
+	}
+}
+
+// ── listing ────────────────────────────────────────────────────────────
+
+// listRuns returns all runs for a slug under runsDir, ordered desc by started_at.
+// Corrupt manifests are logged and skipped.
+func listRuns(runsDir, slug string) []runListItemJSON {
+	if runsDir == "" || slug == "" {
+		return []runListItemJSON{}
+	}
+	slugDir := filepath.Join(runsDir, slug)
+	entries, err := os.ReadDir(slugDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Printf("[dash] readdir %s: %v", slugDir, err)
+		}
+		return []runListItemJSON{}
+	}
+
+	type runWithTime struct {
+		item      runListItemJSON
+		startedAt time.Time
+	}
+
+	var runs []runWithTime
+	for _, ent := range entries {
+		if !ent.IsDir() {
+			continue
+		}
+		mPath := filepath.Join(slugDir, ent.Name(), "manifest.yaml")
+		m, err := loadManifest(mPath)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				log.Printf("[dash] manifest corrupt: %s: %v", mPath, err)
+			}
+			continue
+		}
+		runID := m.RunID
+		if runID == "" {
+			runID = ent.Name()
+		}
+		item := runListItemJSON{
+			ID:         runID,
+			Status:     m.Status,
+			StartedAt:  m.StartedAt.Format(time.RFC3339),
+			FinishedAt: fmtTime(m.FinishedAt),
+			InputKind:  m.InputKind,
+			InputValue: m.InputValue,
+		}
+		runs = append(runs, runWithTime{item: item, startedAt: m.StartedAt})
+	}
+
+	// Sort desc by started_at; tie-break by ID desc for stability.
+	sort.SliceStable(runs, func(i, j int) bool {
+		if !runs[i].startedAt.Equal(runs[j].startedAt) {
+			return runs[i].startedAt.After(runs[j].startedAt)
+		}
+		return runs[i].item.ID > runs[j].item.ID
+	})
+
+	result := make([]runListItemJSON, len(runs))
+	for i, r := range runs {
+		result[i] = r.item
+	}
+	return result
+}
+
+// ── handlers ──────────────────────────────────────────────────────────
+
+// handleListRuns returns an http.HandlerFunc for GET /api/pipelines/:slug/runs.
+// It reads all runs from runsDir/<slug>/, skipping corrupt manifests.
+// Returns JSON array (empty if no runs or dir missing).
+func handleListRuns(runsDir string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// slug is extracted by the dispatcher from the URL path
+		slug := extractSlug(r)
+		list := listRuns(runsDir, slug)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(list)
+	}
+}
+
+// handleGetRun returns an http.HandlerFunc for GET /api/pipelines/:slug/runs/:runId.
+// It parses the manifest.yaml and returns the full run detail.
+// Returns 404 if not found, 500 if corrupt.
+func handleGetRun(runsDir string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		slug, runID := extractSlugAndRunID(r)
+		if slug == "" || runID == "" {
+			writeJSONError(w, http.StatusNotFound, "run not found")
+			return
+		}
+
+		mPath := filepath.Join(runsDir, slug, runID, "manifest.yaml")
+		m, err := loadManifest(mPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				writeJSONError(w, http.StatusNotFound, "run not found")
+				return
+			}
+			log.Printf("[dash] manifest corrupt: %s: %v", mPath, err)
+			writeJSONError(w, http.StatusInternalServerError, "manifest corrupt")
+			return
+		}
+
+		detail := manifestToRunDetail(m, slug)
+		// Ensure RunID reflects the directory name if manifest didn't set it
+		if detail.ID == "" || detail.ID == slug {
+			detail.ID = runID
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(detail)
+	}
+}
+
+// handleGetStepStdout returns an http.HandlerFunc for
+// GET /api/pipelines/:slug/runs/:runId/steps/:idx/stdout.
+// Serves the step-NN.stdout.log file (NN = 1-indexed, 2-padded).
+// Returns 404 JSON if missing.
+func handleGetStepStdout(runsDir string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		slug, runID, stepIdx := extractSlugRunIDAndStepIdx(r)
+		if slug == "" || runID == "" || stepIdx < 0 {
+			writeJSONError(w, http.StatusNotFound, "stdout not found")
+			return
+		}
+
+		// NN is 1-indexed, 2-padded
+		nn := fmt.Sprintf("%02d", stepIdx+1)
+		logPath := filepath.Join(runsDir, slug, runID, "step-"+nn+".stdout.log")
+
+		if _, err := os.Stat(logPath); os.IsNotExist(err) {
+			writeJSONError(w, http.StatusNotFound, "stdout not found")
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		http.ServeFile(w, r, logPath)
+	}
+}
+
+// ── URL extraction helpers ─────────────────────────────────────────────
+
+// These helpers extract path parameters from the URL. The dispatcher sets
+// them via query params for simplicity, since http.ServeMux doesn't support
+// path params. Instead, the dispatcher injects slug/runId into r.URL.Path
+// context by routing to closures that already have the segments.
+//
+// Actually: the dispatcher in dash.go calls these handlers with the full
+// request, so we store the extracted values in a custom header set by the
+// dispatcher before calling the handler.
+
+const (
+	hdrSlug   = "X-Dash-Slug"
+	hdrRunID  = "X-Dash-RunID"
+	hdrStepIdx = "X-Dash-StepIdx"
+)
+
+func extractSlug(r *http.Request) string {
+	return r.Header.Get(hdrSlug)
+}
+
+func extractSlugAndRunID(r *http.Request) (slug, runID string) {
+	return r.Header.Get(hdrSlug), r.Header.Get(hdrRunID)
+}
+
+func extractSlugRunIDAndStepIdx(r *http.Request) (slug, runID string, stepIdx int) {
+	slug = r.Header.Get(hdrSlug)
+	runID = r.Header.Get(hdrRunID)
+	idxStr := r.Header.Get(hdrStepIdx)
+	if idxStr == "" {
+		return slug, runID, -1
+	}
+	idx, err := strconv.Atoi(idxStr)
+	if err != nil || idx < 0 {
+		return slug, runID, -1
+	}
+	return slug, runID, idx
+}
+
+// writeJSONError writes a JSON error response.
+func writeJSONError(w http.ResponseWriter, code int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	body, _ := json.Marshal(map[string]string{"error": msg})
+	_, _ = w.Write(body)
+}
+
+// ── dispatcher ────────────────────────────────────────────────────────
+
+// dispatchPipelinesPrefix is the handler for /api/pipelines/ that dispatches
+// to sub-handlers based on path segments.
+//
+// Supported routes:
+//   /api/pipelines/<slug>                              → pipeline detail (spec 1)
+//   /api/pipelines/<slug>/runs                         → list runs
+//   /api/pipelines/<slug>/runs/<runId>                 → get run
+//   /api/pipelines/<slug>/runs/<runId>/steps/<idx>/stdout → get step stdout
+//
+// Any other pattern returns 404.
+func dispatchPipelinesPrefix(pipelinesDir, runsDir string) http.HandlerFunc {
+	listRunsH := handleListRuns(runsDir)
+	getRunH := handleGetRun(runsDir)
+	getStdoutH := handleGetStepStdout(runsDir)
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Strip the /api/pipelines/ prefix and split into segments.
+		trimmed := strings.TrimPrefix(r.URL.Path, "/api/pipelines/")
+		trimmed = strings.Trim(trimmed, "/")
+		if trimmed == "" {
+			writeJSONError(w, http.StatusNotFound, "pipeline not found")
+			return
+		}
+		segs := strings.Split(trimmed, "/")
+
+		switch len(segs) {
+		case 1:
+			// /api/pipelines/<slug>
+			slug := segs[0]
+			if slug == "" {
+				writeJSONError(w, http.StatusNotFound, "pipeline not found")
+				return
+			}
+			getPipelineDetail(pipelinesDir, slug, w, r)
+
+		case 2:
+			// /api/pipelines/<slug>/runs
+			slug, sub := segs[0], segs[1]
+			if sub != "runs" {
+				writeJSONError(w, http.StatusNotFound, "not found")
+				return
+			}
+			r2 := requestWithHeaders(r, map[string]string{hdrSlug: slug})
+			listRunsH(w, r2)
+
+		case 3:
+			// /api/pipelines/<slug>/runs/<runId>
+			slug, sub, runID := segs[0], segs[1], segs[2]
+			if sub != "runs" {
+				writeJSONError(w, http.StatusNotFound, "not found")
+				return
+			}
+			r2 := requestWithHeaders(r, map[string]string{hdrSlug: slug, hdrRunID: runID})
+			getRunH(w, r2)
+
+		case 6:
+			// /api/pipelines/<slug>/runs/<runId>/steps/<idx>/stdout
+			slug, sub1, runID, sub2, idxStr, sub3 := segs[0], segs[1], segs[2], segs[3], segs[4], segs[5]
+			if sub1 != "runs" || sub2 != "steps" || sub3 != "stdout" {
+				writeJSONError(w, http.StatusNotFound, "not found")
+				return
+			}
+			r2 := requestWithHeaders(r, map[string]string{hdrSlug: slug, hdrRunID: runID, hdrStepIdx: idxStr})
+			getStdoutH(w, r2)
+
+		default:
+			writeJSONError(w, http.StatusNotFound, "not found")
+		}
+	}
+}
+
+// requestWithHeaders returns a shallow copy of r with additional headers set.
+func requestWithHeaders(r *http.Request, headers map[string]string) *http.Request {
+	r2 := r.Clone(r.Context())
+	for k, v := range headers {
+		r2.Header.Set(k, v)
+	}
+	return r2
+}

--- a/internal/dash/runs_test.go
+++ b/internal/dash/runs_test.go
@@ -1,0 +1,381 @@
+package dash
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chichex/che/internal/runner"
+	"github.com/chichex/che/internal/wizard"
+	"gopkg.in/yaml.v3"
+)
+
+// ── test helpers ───────────────────────────────────────────────────────
+
+// plantManifest writes a runner.Manifest to runsDir/<slug>/<runID>/manifest.yaml.
+func plantManifest(t *testing.T, runsDir, slug, runID string, m runner.Manifest) {
+	t.Helper()
+	dir := filepath.Join(runsDir, slug, runID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	data, err := yaml.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.yaml"), data, 0o600); err != nil {
+		t.Fatalf("WriteFile manifest: %v", err)
+	}
+}
+
+// plantCorruptManifest writes invalid YAML to simulate a corrupt manifest.
+func plantCorruptManifest(t *testing.T, runsDir, slug, runID string) {
+	t.Helper()
+	dir := filepath.Join(runsDir, slug, runID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.yaml"), []byte("{\nnot valid yaml: ["), 0o600); err != nil {
+		t.Fatalf("WriteFile corrupt: %v", err)
+	}
+}
+
+// plantStdoutLog writes a fake stdout log file for a given step idx (0-indexed).
+func plantStdoutLog(t *testing.T, runsDir, slug, runID string, idx int, content string) {
+	t.Helper()
+	dir := filepath.Join(runsDir, slug, runID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	fname := fmt.Sprintf("step-%02d.stdout.log", idx+1)
+	if err := os.WriteFile(filepath.Join(dir, fname), []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile stdout: %v", err)
+	}
+}
+
+func callHandler(t *testing.T, h http.HandlerFunc, method, path string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	return rr
+}
+
+// ── listing tests ──────────────────────────────────────────────────────
+
+func TestListRunsEmpty(t *testing.T) {
+	runsDir := t.TempDir()
+	h := handleListRuns(runsDir)
+	rr := callHandler(t, h, http.MethodGet, "/api/pipelines/mypipe/runs", map[string]string{hdrSlug: "mypipe"})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+	var list []runListItemJSON
+	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
+		t.Fatalf("unmarshal: %v\nbody: %s", err, rr.Body.String())
+	}
+	if len(list) != 0 {
+		t.Fatalf("want empty list, got %d items", len(list))
+	}
+}
+
+func TestListRunsOneRun(t *testing.T) {
+	runsDir := t.TempDir()
+	now := time.Now().Truncate(time.Second)
+	m := runner.Manifest{
+		RunID:     "abc123",
+		Pipeline:  "mypipe",
+		StartedAt: now,
+		Status:    "done",
+	}
+	plantManifest(t, runsDir, "mypipe", "abc123", m)
+
+	h := handleListRuns(runsDir)
+	rr := callHandler(t, h, http.MethodGet, "/api/pipelines/mypipe/runs", map[string]string{hdrSlug: "mypipe"})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+	var list []runListItemJSON
+	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("want 1 run, got %d", len(list))
+	}
+	if list[0].ID != "abc123" {
+		t.Errorf("want id=abc123, got %q", list[0].ID)
+	}
+	if list[0].Status != "done" {
+		t.Errorf("want status=done, got %q", list[0].Status)
+	}
+}
+
+func TestListRunsMultipleDescOrder(t *testing.T) {
+	runsDir := t.TempDir()
+	now := time.Now().Truncate(time.Second)
+
+	plantManifest(t, runsDir, "mypipe", "run-newer", runner.Manifest{
+		RunID:     "run-newer",
+		StartedAt: now,
+		Status:    "done",
+	})
+	plantManifest(t, runsDir, "mypipe", "run-older", runner.Manifest{
+		RunID:     "run-older",
+		StartedAt: now.Add(-1 * time.Hour),
+		Status:    "failed",
+	})
+
+	h := handleListRuns(runsDir)
+	rr := callHandler(t, h, http.MethodGet, "/api/pipelines/mypipe/runs", map[string]string{hdrSlug: "mypipe"})
+
+	var list []runListItemJSON
+	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("want 2 runs, got %d", len(list))
+	}
+	if list[0].ID != "run-newer" {
+		t.Errorf("first run should be newer, got %q", list[0].ID)
+	}
+	if list[1].ID != "run-older" {
+		t.Errorf("second run should be older, got %q", list[1].ID)
+	}
+}
+
+func TestListRunsCorruptSkipped(t *testing.T) {
+	runsDir := t.TempDir()
+	now := time.Now().Truncate(time.Second)
+
+	plantManifest(t, runsDir, "mypipe", "good-run", runner.Manifest{
+		RunID:     "good-run",
+		StartedAt: now,
+		Status:    "done",
+	})
+	plantCorruptManifest(t, runsDir, "mypipe", "bad-run")
+
+	h := handleListRuns(runsDir)
+	rr := callHandler(t, h, http.MethodGet, "/api/pipelines/mypipe/runs", map[string]string{hdrSlug: "mypipe"})
+
+	var list []runListItemJSON
+	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("want 1 run (corrupt skipped), got %d", len(list))
+	}
+	if list[0].ID != "good-run" {
+		t.Errorf("want good-run, got %q", list[0].ID)
+	}
+}
+
+// ── detail tests ───────────────────────────────────────────────────────
+
+func TestGetRunFound(t *testing.T) {
+	runsDir := t.TempDir()
+	now := time.Now().Truncate(time.Second)
+	m := runner.Manifest{
+		RunID:     "xyz789",
+		Pipeline:  "mypipe",
+		StartedAt: now,
+		Status:    "done",
+		Steps: []runner.ManifestStep{
+			{Idx: 0, Name: "plan", CLI: "claude", Kind: "prompt", Status: "done", ExitCode: 0},
+			{
+				Idx:    1,
+				Name:   "review",
+				CLI:    "gemini",
+				Kind:   "prompt",
+				Status: "done",
+				Validator: &runner.ManifestValidator{
+					CLI:          "gemini",
+					LoopsRun:     2,
+					MaxLoops:     3,
+					FinalVerdict: "accepted",
+					LastFeedback: "looks good",
+				},
+			},
+		},
+	}
+	plantManifest(t, runsDir, "mypipe", "xyz789", m)
+
+	h := handleGetRun(runsDir)
+	rr := callHandler(t, h, http.MethodGet, "/api/pipelines/mypipe/runs/xyz789", map[string]string{
+		hdrSlug:  "mypipe",
+		hdrRunID: "xyz789",
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var detail runDetailJSON
+	if err := json.Unmarshal(rr.Body.Bytes(), &detail); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if detail.ID != "xyz789" {
+		t.Errorf("want id=xyz789, got %q", detail.ID)
+	}
+	if detail.Slug != "mypipe" {
+		t.Errorf("want slug=mypipe, got %q", detail.Slug)
+	}
+	if len(detail.Steps) != 2 {
+		t.Fatalf("want 2 steps, got %d", len(detail.Steps))
+	}
+	if detail.Steps[0].Validator != nil {
+		t.Errorf("step[0] should have nil validator")
+	}
+	if detail.Steps[1].Validator == nil {
+		t.Fatalf("step[1] should have validator")
+	}
+	if detail.Steps[1].Validator.FinalVerdict != "accepted" {
+		t.Errorf("want final_verdict=accepted, got %q", detail.Steps[1].Validator.FinalVerdict)
+	}
+}
+
+func TestGetRunNotFound(t *testing.T) {
+	runsDir := t.TempDir()
+	h := handleGetRun(runsDir)
+	rr := callHandler(t, h, http.MethodGet, "/api/pipelines/mypipe/runs/nonexistent", map[string]string{
+		hdrSlug:  "mypipe",
+		hdrRunID: "nonexistent",
+	})
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "not found") {
+		t.Errorf("want 'not found' in body, got %q", rr.Body.String())
+	}
+}
+
+func TestGetRunCorrupt(t *testing.T) {
+	runsDir := t.TempDir()
+	plantCorruptManifest(t, runsDir, "mypipe", "bad-run")
+
+	h := handleGetRun(runsDir)
+	rr := callHandler(t, h, http.MethodGet, "/api/pipelines/mypipe/runs/bad-run", map[string]string{
+		hdrSlug:  "mypipe",
+		hdrRunID: "bad-run",
+	})
+
+	if rr.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %d", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "corrupt") {
+		t.Errorf("want 'corrupt' in body, got %q", rr.Body.String())
+	}
+}
+
+// ── stdout tests ───────────────────────────────────────────────────────
+
+func TestGetStdoutFound(t *testing.T) {
+	runsDir := t.TempDir()
+	content := "hello from step 1\n"
+	plantStdoutLog(t, runsDir, "mypipe", "run1", 0, content)
+
+	h := handleGetStepStdout(runsDir)
+	rr := callHandler(t, h, http.MethodGet, "/api/pipelines/mypipe/runs/run1/steps/0/stdout", map[string]string{
+		hdrSlug:    "mypipe",
+		hdrRunID:   "run1",
+		hdrStepIdx: "0",
+	})
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if !strings.Contains(rr.Body.String(), "hello from step 1") {
+		t.Errorf("want content in body, got %q", rr.Body.String())
+	}
+}
+
+func TestGetStdoutNotFound(t *testing.T) {
+	runsDir := t.TempDir()
+	h := handleGetStepStdout(runsDir)
+	rr := callHandler(t, h, http.MethodGet, "/api/pipelines/mypipe/runs/run1/steps/0/stdout", map[string]string{
+		hdrSlug:    "mypipe",
+		hdrRunID:   "run1",
+		hdrStepIdx: "0",
+	})
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "not found") {
+		t.Errorf("want 'not found' in body, got %q", rr.Body.String())
+	}
+}
+
+// ── dispatcher routing tests ───────────────────────────────────────────
+
+func TestDispatcherRouting(t *testing.T) {
+	pipelinesDir := t.TempDir()
+	runsDir := t.TempDir()
+
+	// Plant a pipeline for spec 1 paths
+	writeYAML(t, pipelinesDir, "my-pipe", wizard.Pipeline{
+		Name:  "My Pipe",
+		Steps: []wizard.Step{{Name: "step1", CLI: "claude", Kind: "prompt"}},
+	})
+
+	// Plant a run for spec 2 paths
+	now := time.Now().Truncate(time.Second)
+	plantManifest(t, runsDir, "my-pipe", "run1", runner.Manifest{
+		RunID:     "run1",
+		Pipeline:  "my-pipe",
+		StartedAt: now,
+		Status:    "done",
+		Steps:     []runner.ManifestStep{{Idx: 0, Name: "step1", Status: "done"}},
+	})
+
+	// Plant stdout for step 0
+	plantStdoutLog(t, runsDir, "my-pipe", "run1", 0, "stdout content")
+
+	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir)
+
+	cases := []struct {
+		path           string
+		wantStatus     int
+		wantBodySubstr string
+	}{
+		// spec 1 paths
+		{"/api/pipelines/my-pipe", 200, "my-pipe"},
+		{"/api/pipelines/nonexistent", 404, "not found"},
+		{"/api/pipelines/", 404, "not found"},
+		// spec 2: list runs
+		{"/api/pipelines/my-pipe/runs", 200, "run1"},
+		// spec 2: get run detail
+		{"/api/pipelines/my-pipe/runs/run1", 200, "run1"},
+		{"/api/pipelines/my-pipe/runs/nonexistent", 404, "not found"},
+		// spec 2: get stdout
+		{"/api/pipelines/my-pipe/runs/run1/steps/0/stdout", 200, "stdout content"},
+		{"/api/pipelines/my-pipe/runs/run1/steps/99/stdout", 404, "not found"},
+		// bad paths → 404
+		{"/api/pipelines/my-pipe/something", 404, "not found"},
+		{"/api/pipelines/my-pipe/runs/run1/steps/0/stderr", 404, "not found"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			rr := httptest.NewRecorder()
+			dispatcher(rr, req)
+			if rr.Code != tc.wantStatus {
+				t.Errorf("want status %d, got %d (body: %s)", tc.wantStatus, rr.Code, rr.Body.String())
+			}
+			if tc.wantBodySubstr != "" && !strings.Contains(rr.Body.String(), tc.wantBodySubstr) {
+				t.Errorf("want %q in body, got %q", tc.wantBodySubstr, rr.Body.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #121

Plan de implementación para #121: **Exponer runs históricos de che dash (tabla + run detail read-only)**.

Archivo: `.harness/plans/121-exponer-runs-historicos-de-che-dash.md`

Este PR construye sobre `hs-plan/119` (#120, spec 1) — los PRs de implementación referenciarán este plan.

---

_PR generado por `/hs-plan`._
