### PR TITLE
Plan for #123: Streamear runs vivos de che dash via SSE

### DIFF
--- a/.harness/plans/123-streamear-runs-vivos-de-che-dash-via-sse.md
+++ b/.harness/plans/123-streamear-runs-vivos-de-che-dash-via-sse.md
@@ -1,0 +1,114 @@
+# Plan: Streamear runs vivos de che dash via SSE (per-run events)
+
+Refs #123 · https://github.com/chichex/che/issues/123
+
+## Contexto
+
+Spec 3 del dashboard. Cuando el usuario abre un run con `status=running` desde el dash, el panel derecho debe mostrar stdout línea por línea conforme el step lo emite, los step states pasando de pending → running → done/failed, y los validator loops iterando en tiempo real. Sin refresh manual. Builds sobre `hs-plan/121` (PR #122).
+
+**Resolución del gap del spec**: el spec menciona "event bus in-process" + "el runner publica al bus", pero `che` (TUI/runner) y `che dash` corren en procesos separados. Un bus de canales Go directo entre runner y dash no es viable sin fusionar procesos (gran cambio de UX/arquitectura). Resolución: el "bus" vive ENTERAMENTE dentro del proceso `che dash`, alimentado por un **disk-watcher** que observa `~/.che/runs/<slug>/<runId>/manifest.yaml` y `step-NN.stdout.log`. La behavior visible para el usuario es idéntica a lo descrito en el spec.
+
+## Objetivo
+
+Servir `GET /api/pipelines/:slug/runs/:runId/events` como Server-Sent Events emitiendo `run:status`, `step:start`, `step:end`, `step:stdout`, `validator:loop` en vivo, con heartbeat 15s y replay completo al conectar. Wirear el frontend a EventSource para que el tab output streamee, los dots de step se actualicen, los validator loops aparezcan en vivo, y el badge "live" refleje el estado de conexión. Cuando el run termina, conmutar a modo frozen.
+
+## Approach
+
+Implementar el bus + watcher + handler SSE íntegramente dentro de `internal/dash/`, sin tocar `internal/runner`. El watcher polling-based (`os.Stat` cada 250ms) lee deltas en `manifest.yaml` (atomic rename via `.tmp`) y `step-NN.stdout.log` (append-only), y los traduce a eventos del bus. El bus es ref-counted: el primer subscriber para un (slug, runId) inicia el watcher; el último que se va lo detiene. El handler SSE subscribe primero, hace snapshot del disco después, drain del buffer del bus, y entra en tail loop con heartbeats cada 15s. El frontend abre `EventSource` cuando el run está `running|paused`, dedup por keys explícitos, badge "live" pulsante, auto-scroll con threshold 50px.
+
+## Pasos
+
+- [ ] `internal/dash/bus.go`: `Bus.Subscribe(runId) (<-chan Event, cancel)`, `Bus.Publish(Event)`. Buffer 256 por suscriptor. Slow → close + drop.
+- [ ] `internal/dash/watcher.go`: watcher por (slug, runId). Polling 250ms con `os.Stat`. State: último `manifest mtime+size`, último `stdout size por step`. En cada tick lee diffs y publica al bus.
+- [ ] Lifecycle integrado al bus: ref-counted. Primer subscriber inicia watcher; último que se va halt.
+- [ ] `internal/dash/sse.go`: `handleEvents(runsDir, bus)`. Subscribe primero, leer snapshot del disco, drain del buffer del bus, después entrar en tail. Headers `Content-Type: text/event-stream`, `Cache-Control: no-cache`, `Connection: keep-alive`, `X-Accel-Buffering: no`. `http.Flusher` post cada chunk. Ticker 15s para heartbeat. Cleanup en `r.Context().Done()`.
+- [ ] Replay desde disco: emit `run:status=<actual>`, `step:start`/`step:end` por step del manifest con timestamps, `step:stdout` línea-por-línea del `step-NN.stdout.log` del running step (con ordinal incrementing), `validator:loop` históricos del manifest. Termina con suscripción al tail.
+- [ ] Detección de fin de run en watcher: cuando manifest transitions de `running` a terminal (`done|failed|cancelled|interrupted`), emit `run:status=<terminal>` + halt watcher después de drain stdout pending. Estado `paused` mantiene watcher activo.
+- [ ] Routing: extender dispatcher en `dash.go` para match `[slug, "runs", runId, "events"]` → `handleEvents`.
+- [ ] `Serve()` inicializa instancia singleton del bus y la inyecta al handler.
+- [ ] Frontend HTML — EventSource lifecycle:
+  - useEffect en run detail: cuando `runDetail.status in ["running", "paused"]`, `new EventSource("/api/pipelines/:slug/runs/:runId/events")`. Cleanup cierra.
+  - `addEventListener` para cada tipo: `run:status`, `step:start`, `step:end`, `step:stdout`, `validator:loop`.
+  - Cuando llega `run:status` terminal != paused: close EventSource + refetch `/api/pipelines/:slug/runs/:runId` para reconciliar.
+- [ ] Frontend HTML — dedup:
+  - `Set<string>` con keys `step:<idx>:start`, `step:<idx>:end`, `validator:<idx>:<loop>` para transitions.
+  - Contador `nextLineOrdinal[idx]` por step; eventos con `ordinal < nextLineOrdinal` descartados.
+- [ ] Frontend HTML — tab output streaming:
+  - Cada `step:stdout` agrega línea al state local del step (`stdoutLines[idx]`).
+  - Auto-scroll: state `autoScrollEnabled` (init `true`). Listener `onscroll` desactiva si user scrollea arriba >50px del bottom; reactiva si vuelve al bottom. Si activo, `scrollTop = scrollHeight` después de cada nueva línea.
+- [ ] Frontend HTML — columna de steps:
+  - Cada `step:start` setea `step.status = "running"` y `started_at`.
+  - Cada `step:end` setea `step.status`, `exit_code`, `finished_at`, `error?`.
+- [ ] Frontend HTML — tab validator:
+  - Cada `validator:loop` push al array `step.validator.loops`.
+- [ ] Frontend HTML — badge "live":
+  - 4 states: `live` (pulsing green dot), `reconnecting…` (yellow dot, mientras `onerror` con readyState=CONNECTING), `disconnected` (red dot + botón retry, después de 10s sin reconnect exitoso), hidden (run frozen).
+  - Timer de 10s arranca en `onerror`, se cancela en `onopen` exitoso.
+- [ ] Tests:
+  - `bus_test.go`: subscribe/publish básico, multiple subs fanout, slow-sub overflow → drop, unsubscribe libera.
+  - `watcher_test.go`: con `t.TempDir()`, write manifest yaml → recibe step transitions; append a stdout file → recibe líneas con ordinals; transition a terminal → emit final + halt.
+  - `sse_test.go`: replay correcto desde fixture, tail con mock publisher al bus, heartbeat tras silencio, headers SSE correctos, cleanup en context cancel.
+- [ ] Smoke test manual en PR body: crear fixture de run en `~/.che/runs/`, `curl -N http://127.0.0.1:7878/api/pipelines/<slug>/runs/<run-id>/events`, append a stdout via shell, verificar eventos.
+
+## Archivos afectados
+
+- `internal/dash/bus.go` — crear — pub/sub in-process por runId con buffer 256
+- `internal/dash/bus_test.go` — crear — cobertura básica + drop on slow sub
+- `internal/dash/watcher.go` — crear — disk watcher polling 250ms por (slug, runId)
+- `internal/dash/watcher_test.go` — crear — manifest + stdout detection con fixture
+- `internal/dash/sse.go` — crear — handler SSE con replay + tail + heartbeat
+- `internal/dash/sse_test.go` — crear — replay correctness + tail + cleanup
+- `internal/dash/dash.go` — modificar — agregar dispatcher route + init bus en Serve()
+- `internal/dash/assets/dash.html` — modificar — EventSource + dedup + auto-scroll + badge
+
+## Riesgos
+
+- Polling cadence × N suscriptores: 250ms × N watchers concurrentes. CPU acumula con muchos runs vivos. Mitigación: test con 10 watchers; cadence ajustable a 500ms si hace falta.
+- macOS file change quirks: evitados al usar polling explícito en lugar de fsnotify.
+- Race replay vs tail: diseño explícito subscribe→snapshot→drain elimina el race. Tests cubren el caso.
+- Frontend dedup imperfecto: keys explícitos por tipo (status transitions + line ordinals) garantizan idempotencia.
+- Stdout rápido (1000+ líneas/seg): polling cada 250ms lee bursts de 250 líneas. Aceptado v1 sin batching.
+- Watcher leak: ref-counting + cleanup en `r.Context().Done()` mitiga.
+- Deviation del spec ("in-process bus" → "in-dash disk-watcher"): preserva behavior visible; documentado como asunción #1.
+
+## Out of scope
+
+- SSE global del rail (spec 4)
+- Patch al `internal/runner` (no se modifica)
+- fsnotify (polling es portable y suficiente; fsnotify es mejora futura si la cadence resulta insuficiente)
+- Batching/throttling de stdout events
+- Stderr endpoint (queda como follow-up)
+- Comandos via SSE (read-only)
+- Fusionar `che` (TUI) y `che dash` en un único proceso
+
+## Asunciones tecnicas validadas
+
+1. **Bus + watcher EN el proceso `che dash`, NO patch al runner.** El spec menciona "event bus in-process" + "runner publica al bus", pero `che` (TUI/runner) y `che dash` corren en procesos separados. El disk-watcher dentro del dash observa los archivos en disco (manifest atomic rename + stdout append) y traduce a eventos del bus. Behavior visible del spec preservada; arquitectura del repo no cambia.
+2. **Estrategia de file watching**: polling `os.Stat` cada 250ms (no `fsnotify`). Detecta manifest changes via `mtime`+`size`; stdout appends via `size delta`. Portable, evita quirks de macOS.
+3. **Lifecycle del watcher**: por (slug, runId). Ref-counted via bus — primer subscriber inicia watcher; último que se va detiene. Sin watchers ociosos.
+4. **Buffer del bus**: 256 eventos por suscriptor. Overflow → close + drop el subscriber (cliente reconecta + replay).
+5. **Replay correctness**: subscriber se suscribe AL bus PRIMERO, después se lee snapshot del disco, después se drain el buffer del bus. Garantiza no perder eventos publicados durante la ventana del snapshot.
+6. **SSE format**: `event: <type>\ndata: {...json...}\n\n`. Headers `Content-Type: text/event-stream`, `Cache-Control: no-cache`, `Connection: keep-alive`, `X-Accel-Buffering: no`. `http.Flusher` después de cada chunk.
+7. **Heartbeat**: `time.Ticker` cada 15s emitiendo `: heartbeat\n\n`.
+8. **Cleanup**: subscribe al `r.Context().Done()` para detectar client disconnect → unsubscribe + close. Estado terminal != paused → emit `run:status` final + close server-side.
+9. **Detección de fin de run en watcher**: cuando manifest transitions de `running` a terminal, watcher emite `run:status=<terminal>` y termina su goroutine (después de drain de stdout pending). Estado `paused` mantiene el watcher activo.
+10. **Frontend EventSource**: API estándar del browser. `new EventSource(URL)`. `addEventListener` per event type. Cleanup en useEffect cleanup.
+11. **Dedup en frontend**: `Set<string>` con keys `step:<idx>:start`, `step:<idx>:end`, `validator:<idx>:<loop>` para transitions; para stdout, contador `nextLineOrdinal` por step.
+12. **Auto-scroll**: threshold 50px del bottom. State `autoScrollEnabled` toggle por `onscroll` (off si user scrollea up >50px del bottom; on si vuelve).
+13. **Badge states**: 4 — `live` (pulsing green), `reconnecting…` (yellow, durante `onerror` con readyState=CONNECTING), `disconnected` (red, después de 10s sin succeed; muestra botón "retry"), hidden (run frozen).
+14. **Refetch del manifest al cerrar SSE**: cuando se cierra por terminal status, frontend hace fetch `/api/pipelines/:slug/runs/:runId` para reconciliar state.
+15. **Tests**: `bus_test.go` (subscribe/publish, fanout múltiple, slow-sub drop, unsubscribe libera), `watcher_test.go` (con `t.TempDir()`, write manifest yaml → recibe events; append stdout → recibe líneas; transition a terminal → emit + halt), `sse_test.go` (replay desde fixture, tail con mock publisher, heartbeat tras silencio, headers SSE).
+16. **Routing**: extender el dispatcher en `dash.go` con `[slug, "runs", runId, "events"]` → `handleEvents`.
+17. **Inicialización del bus**: singleton instanciado en `Serve()`, inyectado a los handlers SSE. Tests usan un bus separado.
+18. **JSON shape de payloads**:
+    - `run:status`: `{status}`
+    - `step:start`: `{idx, name, started_at}`
+    - `step:end`: `{idx, status, exit_code, finished_at, error?}`
+    - `step:stdout`: `{idx, line, ts, ordinal}` — agrego `ordinal` para dedup determinístico (extension al spec, justificado como detalle de implementación)
+    - `validator:loop`: `{idx, loop, max_loops, verdict, feedback}`
+    - Timestamps en `time.RFC3339`.
+19. **Smoke test manual en PR body**: crear fixtures de run en `~/.che/runs/<slug>/<runId>/`, simular writes via shell, `curl -N` al endpoint, verificar eventos.
+
+---
+
+_Plan generado por `/hs-plan` a partir de #123._

--- a/internal/dash/assets/dash.html
+++ b/internal/dash/assets/dash.html
@@ -642,10 +642,19 @@ const PipelineDetail = ({ pipeline, runs, onOpenRun, onRequestRun, onResumeDraft
 // Run detail (live + frozen share the same view)
 // ─────────────────────────────────────────────────────────────────────
 
-const RunDetail = ({ pipeline, run, slug, runId, stream, onBack, onCancel, onResume, onSelectStep, selectedStepIdx }) => {
+const RunDetail = ({ pipeline, run, slug, runId, stream, onBack, onCancel, onResume, onSelectStep, selectedStepIdx, onRunUpdate }) => {
   const [paneView, setPaneView] = useState("output");
   const [stdoutText, setStdoutText] = useState(null); // null=not fetched, ""=empty, str=content
   const [stdoutLoading, setStdoutLoading] = useState(false);
+
+  // SSE state: per-step live stdout lines (idx → string[]) and dedup sets.
+  const [stdoutLines, setStdoutLines] = useState({}); // { [stepIdx]: string[] }
+  const nextLineOrdinal = useRef({});                  // { [stepIdx]: int }
+  const seenKeys = useRef(new Set());                  // dedup: "step:<i>:start", etc.
+  const [sseStatus, setSseStatus] = useState("idle"); // idle | live | reconnecting | disconnected
+  const disconnectTimerRef = useRef(null);
+  const outputScrollRef = useRef(null);
+  const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
 
   // run may be null while the detail fetch is in flight — guard defensively
   const steps = run?.steps || [];
@@ -663,12 +672,118 @@ const RunDetail = ({ pipeline, run, slug, runId, stream, onBack, onCancel, onRes
     setStdoutLoading(false);
   }, [selectedStepIdx, runId]);
 
-  // lazy fetch stdout when tab is "output" and not yet loaded
+  // ── SSE lifecycle ─────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!slug || !runId || !run) return;
+    const liveStatuses = ["running", "paused"];
+    if (!liveStatuses.includes(run.status)) return;
+
+    const url = '/api/pipelines/' + slug + '/runs/' + runId + '/events';
+    const es = new EventSource(url);
+
+    es.onopen = () => {
+      setSseStatus("live");
+      if (disconnectTimerRef.current) {
+        clearTimeout(disconnectTimerRef.current);
+        disconnectTimerRef.current = null;
+      }
+    };
+
+    es.onerror = () => {
+      if (es.readyState === EventSource.CONNECTING) {
+        setSseStatus("reconnecting");
+      } else {
+        setSseStatus("disconnected");
+      }
+      // Start 10s timer to declare permanently disconnected.
+      if (!disconnectTimerRef.current) {
+        disconnectTimerRef.current = setTimeout(() => {
+          setSseStatus("disconnected");
+          disconnectTimerRef.current = null;
+        }, 10000);
+      }
+    };
+
+    es.addEventListener("run:status", (e) => {
+      const data = JSON.parse(e.data);
+      if (onRunUpdate) onRunUpdate({ type: "run:status", ...data });
+      if (data.status && data.status !== "running" && data.status !== "paused") {
+        // Terminal — close and refetch.
+        es.close();
+        setSseStatus("idle");
+        if (onRunUpdate) onRunUpdate({ type: "refetch" });
+      }
+    });
+
+    es.addEventListener("step:start", (e) => {
+      const data = JSON.parse(e.data);
+      const key = "step:" + data.idx + ":start";
+      if (seenKeys.current.has(key)) return;
+      seenKeys.current.add(key);
+      if (onRunUpdate) onRunUpdate({ type: "step:start", ...data });
+    });
+
+    es.addEventListener("step:end", (e) => {
+      const data = JSON.parse(e.data);
+      const key = "step:" + data.idx + ":end";
+      if (seenKeys.current.has(key)) return;
+      seenKeys.current.add(key);
+      if (onRunUpdate) onRunUpdate({ type: "step:end", ...data });
+    });
+
+    es.addEventListener("step:stdout", (e) => {
+      const data = JSON.parse(e.data);
+      const idx = data.idx;
+      const expected = nextLineOrdinal.current[idx] || 0;
+      if (data.ordinal < expected) return; // duplicate
+      nextLineOrdinal.current[idx] = data.ordinal + 1;
+      setStdoutLines(prev => ({
+        ...prev,
+        [idx]: [...(prev[idx] || []), data.line],
+      }));
+    });
+
+    es.addEventListener("validator:loop", (e) => {
+      const data = JSON.parse(e.data);
+      const key = "validator:" + data.idx + ":" + data.loop;
+      if (seenKeys.current.has(key)) return;
+      seenKeys.current.add(key);
+      if (onRunUpdate) onRunUpdate({ type: "validator:loop", ...data });
+    });
+
+    return () => {
+      es.close();
+      if (disconnectTimerRef.current) {
+        clearTimeout(disconnectTimerRef.current);
+        disconnectTimerRef.current = null;
+      }
+    };
+  }, [slug, runId, run?.status]);
+
+  // ── auto-scroll ───────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!autoScrollEnabled) return;
+    const el = outputScrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+  }, [stdoutLines, autoScrollEnabled]);
+
+  const handleOutputScroll = (e) => {
+    const el = e.target;
+    const distFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    setAutoScrollEnabled(distFromBottom <= 50);
+  };
+
+  // lazy fetch stdout when tab is "output" and not yet loaded (frozen runs)
   useEffect(() => {
     if (paneView !== "output") return;
     if (stdoutText !== null) return; // already fetched or loading
     if (!slug || !runId || selectedStep == null) return;
     if (selectedStep.status === "pending") return;
+    // If we have live SSE lines for this step, don't fetch from disk.
+    if (stdoutLines[selectedStepIdx] && stdoutLines[selectedStepIdx].length > 0) return;
+    // Only fetch if run is not live (frozen).
+    if (run?.status === "running" || run?.status === "paused") return;
 
     setStdoutLoading(true);
     const ctrl = new AbortController();
@@ -689,7 +804,7 @@ const RunDetail = ({ pipeline, run, slug, runId, stream, onBack, onCancel, onRes
         }
       });
     return () => ctrl.abort();
-  }, [paneView, selectedStepIdx, runId, slug, stdoutText]);
+  }, [paneView, selectedStepIdx, runId, slug, stdoutText, run?.status]);
 
   if (!run) {
     return (
@@ -848,6 +963,16 @@ const RunDetail = ({ pipeline, run, slug, runId, stream, onBack, onCancel, onRes
               )}
             </div>
             <div className="flex items-center gap-2 mono text-[10.5px] ink-3">
+              {/* SSE connection badge */}
+              {sseStatus === "live" && (
+                <span className="badge badge-running"><span className="dot dot-running" /> live</span>
+              )}
+              {sseStatus === "reconnecting" && (
+                <span className="badge badge-paused"><span className="dot dot-paused" /> reconnecting…</span>
+              )}
+              {sseStatus === "disconnected" && (
+                <span className="badge badge-failed"><span className="dot dot-failed" /> disconnected</span>
+              )}
               {paneView === "definition"
                 ? <span>step {(selectedStepIdx+1).toString().padStart(2,"00")} / {steps.length.toString().padStart(2,"00")}</span>
                 : paneView === "validator"
@@ -856,26 +981,50 @@ const RunDetail = ({ pipeline, run, slug, runId, stream, onBack, onCancel, onRes
             </div>
           </div>
 
-          {paneView === "output" ? (
-            <div className="stream flex-1 overflow-y-auto scroll-thin px-4 py-3">
-              {selectedStep?.status === "pending" ? (
-                <div className="ink-3 text-[12.5px]">step pendiente — aún no corrió</div>
-              ) : stdoutLoading ? (
-                <div className="ink-3 text-[12.5px]">cargando…</div>
-              ) : stdoutText === null ? null : stdoutText === '' ? (
-                <div className="ink-3 text-[12.5px]">sin stdout registrado</div>
-              ) : (
-                <>
-                  {selectedStep?.error && (
-                    <div className="mb-3 px-3 py-2 rounded text-[12px] mono" style={{background:"rgba(var(--failed-rgb,220,38,38),0.08)",color:"var(--failed)"}}>
-                      {selectedStep.error}
-                    </div>
-                  )}
-                  <pre className="mono text-[12px] ink whitespace-pre-wrap">{stdoutText}</pre>
-                </>
-              )}
-            </div>
-          ) : paneView === "definition" ? (
+          {paneView === "output" ? (() => {
+            // Determine output source: SSE lines (live) or fetched text (frozen).
+            const liveLines = stdoutLines[selectedStepIdx];
+            const hasLiveLines = liveLines && liveLines.length > 0;
+            const isLiveRun = run?.status === "running" || run?.status === "paused";
+            return (
+              <div
+                ref={outputScrollRef}
+                onScroll={handleOutputScroll}
+                className="stream flex-1 overflow-y-auto scroll-thin px-4 py-3"
+              >
+                {selectedStep?.status === "pending" ? (
+                  <div className="ink-3 text-[12.5px]">step pendiente — aún no corrió</div>
+                ) : hasLiveLines ? (
+                  <>
+                    {selectedStep?.error && (
+                      <div className="mb-3 px-3 py-2 rounded text-[12px] mono" style={{background:"rgba(220,38,38,0.08)",color:"var(--failed)"}}>
+                        {selectedStep.error}
+                      </div>
+                    )}
+                    <pre className="mono text-[12px] ink whitespace-pre-wrap">{liveLines.join("\n")}</pre>
+                    {isLiveRun && selectedStep?.status === "running" && (
+                      <span className="caret" />
+                    )}
+                  </>
+                ) : isLiveRun && selectedStep?.status === "running" ? (
+                  <div className="ink-3 text-[12.5px]">esperando stdout… <span className="caret" /></div>
+                ) : stdoutLoading ? (
+                  <div className="ink-3 text-[12.5px]">cargando…</div>
+                ) : stdoutText === null ? null : stdoutText === '' ? (
+                  <div className="ink-3 text-[12.5px]">sin stdout registrado</div>
+                ) : (
+                  <>
+                    {selectedStep?.error && (
+                      <div className="mb-3 px-3 py-2 rounded text-[12px] mono" style={{background:"rgba(220,38,38,0.08)",color:"var(--failed)"}}>
+                        {selectedStep.error}
+                      </div>
+                    )}
+                    <pre className="mono text-[12px] ink whitespace-pre-wrap">{stdoutText}</pre>
+                  </>
+                )}
+              </div>
+            );
+          })() : paneView === "definition" ? (
             <div className="flex-1 overflow-y-auto scroll-thin px-6 py-5">
               {selectedStep ? (
                 <div>
@@ -1400,6 +1549,87 @@ const App = () => {
     setTimeout(() => setToast(null), 1800);
   };
 
+  // ── SSE run update handler ────────────────────────────────────────────
+  // Called by RunDetail when SSE events arrive. Updates runDetail and runs
+  // state so steps column and badges refresh in real time.
+  const handleRunUpdate = useCallback((msg) => {
+    if (!selectedSlug || !openRunId) return;
+
+    if (msg.type === "refetch") {
+      // Re-fetch run detail after terminal status.
+      fetch('/api/pipelines/' + selectedSlug + '/runs/' + openRunId)
+        .then(r => r.json())
+        .then(data => {
+          setRunDetail(data);
+          setRuns(prev => ({
+            ...prev,
+            [selectedSlug]: (prev[selectedSlug] || []).map(r =>
+              r.id === openRunId ? { ...r, status: data.status, finished_at: data.finished_at } : r
+            ),
+          }));
+        })
+        .catch(err => console.error('[dash] refetch run detail:', err));
+      return;
+    }
+
+    if (msg.type === "run:status") {
+      setRunDetail(prev => prev ? { ...prev, status: msg.status } : prev);
+      setRuns(prev => ({
+        ...prev,
+        [selectedSlug]: (prev[selectedSlug] || []).map(r =>
+          r.id === openRunId ? { ...r, status: msg.status } : r
+        ),
+      }));
+      return;
+    }
+
+    if (msg.type === "step:start") {
+      setRunDetail(prev => {
+        if (!prev) return prev;
+        const steps = prev.steps.map(s =>
+          s.idx === msg.idx ? { ...s, status: "running", started_at: msg.started_at } : s
+        );
+        return { ...prev, steps };
+      });
+      return;
+    }
+
+    if (msg.type === "step:end") {
+      setRunDetail(prev => {
+        if (!prev) return prev;
+        const steps = prev.steps.map(s =>
+          s.idx === msg.idx
+            ? { ...s, status: msg.status, exit_code: msg.exit_code, finished_at: msg.finished_at, error: msg.error || s.error }
+            : s
+        );
+        return { ...prev, steps };
+      });
+      return;
+    }
+
+    if (msg.type === "validator:loop") {
+      setRunDetail(prev => {
+        if (!prev) return prev;
+        const steps = prev.steps.map(s => {
+          if (s.idx !== msg.idx) return s;
+          const v = s.validator || { loops_run: 0, max_loops: msg.max_loops };
+          return {
+            ...s,
+            validator: {
+              ...v,
+              loops_run: msg.loop,
+              max_loops: msg.max_loops,
+              final_verdict: msg.verdict || v.final_verdict,
+              last_feedback: msg.feedback || v.last_feedback,
+            },
+          };
+        });
+        return { ...prev, steps };
+      });
+      return;
+    }
+  }, [selectedSlug, openRunId]);
+
   const onSelectPipeline = (slug) => {
     setSelectedSlug(slug);
     setOpenRunId(null);
@@ -1435,6 +1665,7 @@ const App = () => {
               onBack={() => { setOpenRunId(null); setRunDetail(null); }}
               onCancel={cancelRun}
               onResume={resumeRun}
+              onRunUpdate={handleRunUpdate}
             />
           ) : (
             <PipelineDetail

--- a/internal/dash/bus.go
+++ b/internal/dash/bus.go
@@ -1,0 +1,147 @@
+// Package dash — bus.go: in-process pub/sub bus for per-run SSE events.
+//
+// Each (slug, runId) pair can have multiple subscribers. The bus is ref-counted:
+// the first subscriber for a (slug, runId) starts a disk watcher; the last one
+// to unsubscribe stops it.
+package dash
+
+import (
+	"sync"
+)
+
+// EventType is the SSE event type string.
+type EventType string
+
+const (
+	EventRunStatus    EventType = "run:status"
+	EventStepStart    EventType = "step:start"
+	EventStepEnd      EventType = "step:end"
+	EventStepStdout   EventType = "step:stdout"
+	EventValidatorLoop EventType = "validator:loop"
+)
+
+// Event is a single SSE event with a typed payload (JSON-marshallable map).
+type Event struct {
+	Type    EventType
+	Payload map[string]any
+}
+
+// subKey identifies a unique (slug, runId) watcher.
+type subKey struct {
+	slug  string
+	runID string
+}
+
+type subscriber struct {
+	ch      chan Event
+	cancel  func()
+	removed bool // set to true when removeSub has processed this subscriber
+}
+
+// Bus is a per-run pub/sub bus. Safe for concurrent use.
+type Bus struct {
+	mu      sync.Mutex
+	subs    map[subKey][]*subscriber
+	watchers map[subKey]*watcher
+	runsDir  string
+}
+
+// NewBus creates a new Bus serving runs from runsDir.
+func NewBus(runsDir string) *Bus {
+	return &Bus{
+		subs:     make(map[subKey][]*subscriber),
+		watchers: make(map[subKey]*watcher),
+		runsDir:  runsDir,
+	}
+}
+
+// Subscribe registers a new subscriber for (slug, runID).
+// Returns a receive-only channel and a cancel function.
+// The cancel function MUST be called when the subscriber is done.
+// If this is the first subscriber for the key, a disk watcher is started.
+// Buffer size is 256; if the subscriber is too slow, the channel is closed
+// (slow-subscriber drop) and the subscriber is removed.
+func (b *Bus) Subscribe(slug, runID string) (<-chan Event, func()) {
+	key := subKey{slug: slug, runID: runID}
+	ch := make(chan Event, 256)
+
+	b.mu.Lock()
+	sub := &subscriber{ch: ch}
+	b.subs[key] = append(b.subs[key], sub)
+
+	// Start watcher if this is the first subscriber.
+	if _, ok := b.watchers[key]; !ok {
+		w := newWatcher(b.runsDir, slug, runID, b)
+		b.watchers[key] = w
+		go w.run()
+	}
+	b.mu.Unlock()
+
+	cancel := func() {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		b.removeSub(key, sub)
+	}
+	sub.cancel = cancel
+	return ch, cancel
+}
+
+// removeSub removes sub from the key's subscriber list (must hold b.mu).
+// If the list becomes empty, the watcher for that key is stopped.
+// Safe to call multiple times for the same subscriber (idempotent).
+func (b *Bus) removeSub(key subKey, sub *subscriber) {
+	if sub.removed {
+		return
+	}
+	sub.removed = true
+
+	list := b.subs[key]
+	newList := list[:0]
+	for _, s := range list {
+		if s != sub {
+			newList = append(newList, s)
+		}
+	}
+	if len(newList) == 0 {
+		delete(b.subs, key)
+		if w, ok := b.watchers[key]; ok {
+			w.stop()
+			delete(b.watchers, key)
+		}
+	} else {
+		b.subs[key] = newList
+	}
+	// Close the channel so any consumer blocked on receive unblocks.
+	// Buffered items remain readable until drained by the consumer.
+	close(sub.ch)
+}
+
+// Publish sends an event to all subscribers of (slug, runID).
+// Slow subscribers whose buffer is full are closed and dropped.
+func (b *Bus) Publish(slug, runID string, ev Event) {
+	key := subKey{slug: slug, runID: runID}
+	b.mu.Lock()
+	list := b.subs[key]
+	var slow []*subscriber
+	for _, s := range list {
+		select {
+		case s.ch <- ev:
+		default:
+			slow = append(slow, s)
+		}
+	}
+	for _, s := range slow {
+		b.removeSub(key, s)
+	}
+	b.mu.Unlock()
+}
+
+// stopWatcher is called by the watcher itself when it detects a terminal
+// run status, after draining remaining events. It removes the watcher from
+// the map without stopping it again (it's already stopping).
+func (b *Bus) stopWatcher(slug, runID string) {
+	key := subKey{slug: slug, runID: runID}
+	b.mu.Lock()
+	delete(b.watchers, key)
+	b.mu.Unlock()
+}

--- a/internal/dash/bus_test.go
+++ b/internal/dash/bus_test.go
@@ -1,0 +1,100 @@
+package dash
+
+import (
+	"testing"
+	"time"
+)
+
+// TestBus_SubscribePublish verifies a single subscriber receives a published event.
+func TestBus_SubscribePublish(t *testing.T) {
+	b := NewBus("/tmp")
+	ch, cancel := b.Subscribe("sl", "r1")
+	defer cancel()
+
+	ev := Event{Type: EventRunStatus, Payload: map[string]any{"status": "running"}}
+	b.Publish("sl", "r1", ev)
+
+	select {
+	case got := <-ch:
+		if got.Type != EventRunStatus {
+			t.Fatalf("want %s, got %s", EventRunStatus, got.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for event")
+	}
+}
+
+// TestBus_Fanout verifies two subscribers both receive the same event.
+func TestBus_Fanout(t *testing.T) {
+	b := NewBus("/tmp")
+	ch1, cancel1 := b.Subscribe("sl", "r1")
+	ch2, cancel2 := b.Subscribe("sl", "r1")
+	defer cancel1()
+	defer cancel2()
+
+	ev := Event{Type: EventStepStart, Payload: map[string]any{"idx": 0}}
+	b.Publish("sl", "r1", ev)
+
+	for _, ch := range []<-chan Event{ch1, ch2} {
+		select {
+		case got := <-ch:
+			if got.Type != EventStepStart {
+				t.Fatalf("want %s, got %s", EventStepStart, got.Type)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timeout waiting for event on subscriber")
+		}
+	}
+}
+
+// TestBus_SlowDrop verifies that a slow subscriber (full buffer) is dropped
+// and the channel is closed when Publish overflows it.
+func TestBus_SlowDrop(t *testing.T) {
+	b := NewBus("/tmp")
+	ch, cancel := b.Subscribe("sl", "r2")
+	defer cancel()
+
+	ev := Event{Type: EventStepStdout, Payload: map[string]any{"line": "x"}}
+	// Fill the buffer + 1 extra to trigger the drop path.
+	for i := 0; i < 257; i++ {
+		b.Publish("sl", "r2", ev)
+	}
+
+	// The channel should eventually be closed (drained by removeSub).
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case _, more := <-ch:
+			if !more {
+				return // channel closed = drop happened
+			}
+		case <-deadline:
+			t.Fatal("timeout: slow subscriber not dropped")
+		}
+	}
+}
+
+// TestBus_UnsubscribeStopsWatcher verifies that canceling the sole subscriber
+// removes the watcher entry from the bus.
+func TestBus_UnsubscribeStopsWatcher(t *testing.T) {
+	b := NewBus(t.TempDir())
+	_, cancel := b.Subscribe("sl", "r3")
+
+	b.mu.Lock()
+	key := subKey{slug: "sl", runID: "r3"}
+	if _, ok := b.watchers[key]; !ok {
+		b.mu.Unlock()
+		t.Fatal("watcher should exist after subscribe")
+	}
+	b.mu.Unlock()
+
+	cancel()
+	// Give the goroutine a moment.
+	time.Sleep(20 * time.Millisecond)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, ok := b.watchers[key]; ok {
+		t.Fatal("watcher should be removed after sole subscriber cancels")
+	}
+}

--- a/internal/dash/dash.go
+++ b/internal/dash/dash.go
@@ -58,10 +58,13 @@ func Serve(ctx context.Context, opts Options) error {
 		runsDir = filepath.Join(home, ".che", "runs")
 	}
 
+	// Singleton bus for SSE per-run streaming.
+	bus := NewBus(runsDir)
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", handleIndex)
 	mux.HandleFunc("/api/pipelines", handleListPipelines(pipelinesDir))
-	mux.HandleFunc("/api/pipelines/", dispatchPipelinesPrefix(pipelinesDir, runsDir))
+	mux.HandleFunc("/api/pipelines/", dispatchPipelinesPrefix(pipelinesDir, runsDir, bus))
 
 	srv := &http.Server{
 		Handler:           mux,

--- a/internal/dash/runs.go
+++ b/internal/dash/runs.go
@@ -325,16 +325,18 @@ func writeJSONError(w http.ResponseWriter, code int, msg string) {
 // to sub-handlers based on path segments.
 //
 // Supported routes:
-//   /api/pipelines/<slug>                              → pipeline detail (spec 1)
-//   /api/pipelines/<slug>/runs                         → list runs
-//   /api/pipelines/<slug>/runs/<runId>                 → get run
-//   /api/pipelines/<slug>/runs/<runId>/steps/<idx>/stdout → get step stdout
+//   /api/pipelines/<slug>                                  → pipeline detail (spec 1)
+//   /api/pipelines/<slug>/runs                             → list runs
+//   /api/pipelines/<slug>/runs/<runId>                     → get run
+//   /api/pipelines/<slug>/runs/<runId>/events              → SSE per-run stream (spec 3)
+//   /api/pipelines/<slug>/runs/<runId>/steps/<idx>/stdout  → get step stdout
 //
 // Any other pattern returns 404.
-func dispatchPipelinesPrefix(pipelinesDir, runsDir string) http.HandlerFunc {
+func dispatchPipelinesPrefix(pipelinesDir, runsDir string, bus *Bus) http.HandlerFunc {
 	listRunsH := handleListRuns(runsDir)
 	getRunH := handleGetRun(runsDir)
 	getStdoutH := handleGetStepStdout(runsDir)
+	getEventsH := handleEvents(runsDir, bus)
 
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Strip the /api/pipelines/ prefix and split into segments.
@@ -375,6 +377,16 @@ func dispatchPipelinesPrefix(pipelinesDir, runsDir string) http.HandlerFunc {
 			}
 			r2 := requestWithHeaders(r, map[string]string{hdrSlug: slug, hdrRunID: runID})
 			getRunH(w, r2)
+
+		case 4:
+			// /api/pipelines/<slug>/runs/<runId>/events
+			slug, sub1, runID, sub2 := segs[0], segs[1], segs[2], segs[3]
+			if sub1 != "runs" || sub2 != "events" {
+				writeJSONError(w, http.StatusNotFound, "not found")
+				return
+			}
+			r2 := requestWithHeaders(r, map[string]string{hdrSlug: slug, hdrRunID: runID})
+			getEventsH(w, r2)
 
 		case 6:
 			// /api/pipelines/<slug>/runs/<runId>/steps/<idx>/stdout

--- a/internal/dash/runs_test.go
+++ b/internal/dash/runs_test.go
@@ -341,7 +341,7 @@ func TestDispatcherRouting(t *testing.T) {
 	// Plant stdout for step 0
 	plantStdoutLog(t, runsDir, "my-pipe", "run1", 0, "stdout content")
 
-	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir)
+	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir))
 
 	cases := []struct {
 		path           string

--- a/internal/dash/sse.go
+++ b/internal/dash/sse.go
@@ -1,0 +1,217 @@
+// Package dash — sse.go: SSE handler for per-run live events.
+//
+// GET /api/pipelines/:slug/runs/:runId/events
+//
+// Protocol:
+//  1. Subscribe to bus FIRST (before reading disk snapshot).
+//  2. Read manifest snapshot from disk.
+//  3. Emit replay events: run:status, step:start/end, step:stdout (running step),
+//     validator:loop (historic).
+//  4. Drain any bus events that arrived during snapshot.
+//  5. Tail: forward bus events until client disconnects or run is terminal.
+//
+// Heartbeat: `: heartbeat\n\n` comment every 15s when idle.
+package dash
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"time"
+
+	"github.com/chichex/che/internal/runner"
+)
+
+const heartbeatInterval = 15 * time.Second
+
+// handleEvents returns an http.HandlerFunc for SSE per-run events.
+// runsDir is the base directory for run data (~/.che/runs).
+// bus is the shared Bus singleton.
+func handleEvents(runsDir string, bus *Bus) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		slug := r.Header.Get(hdrSlug)
+		runID := r.Header.Get(hdrRunID)
+		if slug == "" || runID == "" {
+			http.Error(w, "missing slug or runId", http.StatusBadRequest)
+			return
+		}
+
+		// SSE headers.
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("X-Accel-Buffering", "no")
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+			return
+		}
+
+		// 1. Subscribe FIRST — before reading disk, so we don't miss events
+		//    that land during the snapshot window.
+		ch, cancel := bus.Subscribe(slug, runID)
+		defer cancel()
+
+		// 2. Read manifest snapshot.
+		runDir := filepath.Join(runsDir, slug, runID)
+		manifestPath := filepath.Join(runDir, "manifest.yaml")
+		m, err := parseManifest(manifestPath)
+		if err != nil {
+			// Run not found — emit a single error comment and close.
+			fmt.Fprintf(w, ": run not found\n\n")
+			flusher.Flush()
+			return
+		}
+
+		// 3. Replay from snapshot.
+		emitReplay(w, flusher, runDir, m)
+
+		// 4. Drain any buffered bus events that arrived during snapshot.
+	drainLoop:
+		for {
+			select {
+			case ev, more := <-ch:
+				if !more {
+					return
+				}
+				writeSSEEvent(w, ev)
+				flusher.Flush()
+			default:
+				break drainLoop
+			}
+		}
+
+		// 5. Tail: forward events from bus until client disconnects or
+		//    we see a terminal run:status.
+		heartbeat := time.NewTicker(heartbeatInterval)
+		defer heartbeat.Stop()
+
+		ctx := r.Context()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+
+			case <-heartbeat.C:
+				fmt.Fprintf(w, ": heartbeat\n\n")
+				flusher.Flush()
+
+			case ev, more := <-ch:
+				if !more {
+					return
+				}
+				writeSSEEvent(w, ev)
+				flusher.Flush()
+				heartbeat.Reset(heartbeatInterval)
+
+				// If we get a terminal run:status, close the stream.
+				if ev.Type == EventRunStatus {
+					if status, _ := ev.Payload["status"].(string); isTerminalStatus(status) {
+						return
+					}
+				}
+			}
+		}
+	}
+}
+
+// emitReplay emits the full historical state from the manifest and stdout files.
+// This gives a reconnecting client the current picture immediately.
+//
+// Order:
+//  1. run:status (current)
+//  2. step:start / step:end for each completed or running step
+//  3. step:stdout lines for the running step (or recently-done step with a log)
+//  4. validator:loop for each step that has a validator with loops_run > 0
+func emitReplay(w http.ResponseWriter, flusher http.Flusher, runDir string, m runner.Manifest) {
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// 1. run:status
+	writeSSEEvent(w, Event{Type: EventRunStatus, Payload: map[string]any{
+		"status": m.Status,
+	}})
+	flusher.Flush()
+
+	for _, s := range m.Steps {
+		// 2a. step:start for running or terminal steps.
+		switch s.Status {
+		case "running", "done", "failed", "cancelled", "interrupted":
+			startedAt := now
+			if !s.StartedAt.IsZero() {
+				startedAt = s.StartedAt.Format(time.RFC3339)
+			}
+			writeSSEEvent(w, Event{Type: EventStepStart, Payload: map[string]any{
+				"idx":        s.Idx,
+				"name":       s.Name,
+				"started_at": startedAt,
+			}})
+			flusher.Flush()
+		}
+
+		// 2b. step:end for terminal steps.
+		switch s.Status {
+		case "done", "failed", "cancelled", "interrupted":
+			p := map[string]any{
+				"idx":       s.Idx,
+				"status":    s.Status,
+				"exit_code": s.ExitCode,
+			}
+			if !s.FinishedAt.IsZero() {
+				p["finished_at"] = s.FinishedAt.Format(time.RFC3339)
+			}
+			if s.Error != "" {
+				p["error"] = s.Error
+			}
+			writeSSEEvent(w, Event{Type: EventStepEnd, Payload: p})
+			flusher.Flush()
+		}
+
+		// 3. step:stdout lines for running or recently-done steps.
+		if s.Status == "running" || s.Status == "done" || s.Status == "failed" {
+			lines, err := readStdoutLines(runDir, s.Idx)
+			if err == nil && len(lines) > 0 {
+				for ordinal, line := range lines {
+					writeSSEEvent(w, Event{Type: EventStepStdout, Payload: map[string]any{
+						"idx":     s.Idx,
+						"line":    line,
+						"ts":      now,
+						"ordinal": ordinal,
+					}})
+				}
+				flusher.Flush()
+			}
+		}
+
+		// 4. validator:loop history.
+		if s.Validator != nil && s.Validator.LoopsRun > 0 {
+			for loop := 1; loop <= s.Validator.LoopsRun; loop++ {
+				verdict := ""
+				feedback := ""
+				if loop == s.Validator.LoopsRun {
+					verdict = s.Validator.FinalVerdict
+					feedback = s.Validator.LastFeedback
+				}
+				writeSSEEvent(w, Event{Type: EventValidatorLoop, Payload: map[string]any{
+					"idx":       s.Idx,
+					"loop":      loop,
+					"max_loops": s.Validator.MaxLoops,
+					"verdict":   verdict,
+					"feedback":  feedback,
+				}})
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+// writeSSEEvent writes a single SSE event to w.
+// Format: "event: <type>\ndata: <json>\n\n"
+func writeSSEEvent(w http.ResponseWriter, ev Event) {
+	data, err := json.Marshal(ev.Payload)
+	if err != nil {
+		data = []byte("{}")
+	}
+	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Type, data)
+}

--- a/internal/dash/sse_test.go
+++ b/internal/dash/sse_test.go
@@ -1,0 +1,193 @@
+package dash
+
+import (
+	"bufio"
+	"context"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chichex/che/internal/runner"
+	"gopkg.in/yaml.v3"
+)
+
+// TestSSE_Headers verifies that the SSE handler sets the correct headers.
+func TestSSE_Headers(t *testing.T) {
+	runsDir := t.TempDir()
+	slug, runID := "pipe", "run-h"
+	runDir := filepath.Join(runsDir, slug, runID)
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeManifestForSSE(t, runDir, runner.Manifest{
+		RunID:     runID,
+		Pipeline:  slug,
+		Status:    runner.ManifestStatusRunning,
+		StartedAt: time.Now().UTC(),
+	})
+
+	bus := NewBus(runsDir)
+	h := handleEvents(runsDir, bus)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	req := httptest.NewRequest("GET", "/events", nil).WithContext(ctx)
+	req.Header.Set(hdrSlug, slug)
+	req.Header.Set(hdrRunID, runID)
+
+	rr := httptest.NewRecorder()
+	h(rr, req)
+
+	if ct := rr.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Content-Type want text/event-stream, got %q", ct)
+	}
+	if cc := rr.Header().Get("Cache-Control"); cc != "no-cache" {
+		t.Errorf("Cache-Control want no-cache, got %q", cc)
+	}
+	if ab := rr.Header().Get("X-Accel-Buffering"); ab != "no" {
+		t.Errorf("X-Accel-Buffering want no, got %q", ab)
+	}
+}
+
+// TestSSE_ReplaySnapshot verifies that connecting to the SSE endpoint for a
+// run that already has some state emits a run:status replay event.
+func TestSSE_ReplaySnapshot(t *testing.T) {
+	runsDir := t.TempDir()
+	slug, runID := "pipe", "run-r"
+	runDir := filepath.Join(runsDir, slug, runID)
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	m := runner.Manifest{
+		RunID:     runID,
+		Pipeline:  slug,
+		Status:    runner.ManifestStatusRunning,
+		StartedAt: time.Now().UTC(),
+		Steps: []runner.ManifestStep{
+			{Idx: 0, Name: "build", Status: "running", StartedAt: time.Now().UTC()},
+		},
+	}
+	writeManifestForSSE(t, runDir, m)
+
+	bus := NewBus(runsDir)
+	h := handleEvents(runsDir, bus)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	req := httptest.NewRequest("GET", "/events", nil).WithContext(ctx)
+	req.Header.Set(hdrSlug, slug)
+	req.Header.Set(hdrRunID, runID)
+
+	rr := httptest.NewRecorder()
+	h(rr, req)
+
+	body := rr.Body.String()
+
+	if !strings.Contains(body, "event: run:status") {
+		t.Errorf("expected run:status event in SSE output:\n%s", body)
+	}
+	if !strings.Contains(body, "running") {
+		t.Errorf("expected 'running' status in SSE output:\n%s", body)
+	}
+}
+
+// TestSSE_NotFound verifies that a missing run yields a comment and closes.
+func TestSSE_NotFound(t *testing.T) {
+	runsDir := t.TempDir()
+	bus := NewBus(runsDir)
+	h := handleEvents(runsDir, bus)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	req := httptest.NewRequest("GET", "/events", nil).WithContext(ctx)
+	req.Header.Set(hdrSlug, "noexist")
+	req.Header.Set(hdrRunID, "noexist")
+
+	rr := httptest.NewRecorder()
+	h(rr, req)
+
+	body := rr.Body.String()
+	if !strings.Contains(body, ": run not found") {
+		t.Errorf("expected 'run not found' comment, got:\n%s", body)
+	}
+}
+
+// TestSSE_TailEvent verifies that after replay, events published to the bus
+// are forwarded to the SSE stream.
+func TestSSE_TailEvent(t *testing.T) {
+	runsDir := t.TempDir()
+	slug, runID := "pipe", "run-t"
+	runDir := filepath.Join(runsDir, slug, runID)
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeManifestForSSE(t, runDir, runner.Manifest{
+		RunID: runID, Pipeline: slug,
+		Status: runner.ManifestStatusRunning, StartedAt: time.Now().UTC(),
+	})
+
+	bus := NewBus(runsDir)
+	h := handleEvents(runsDir, bus)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Millisecond)
+	defer cancel()
+
+	req := httptest.NewRequest("GET", "/events", nil).WithContext(ctx)
+	req.Header.Set(hdrSlug, slug)
+	req.Header.Set(hdrRunID, runID)
+
+	// Publish an event after a short delay to simulate a tail event.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		bus.Publish(slug, runID, Event{
+			Type:    EventStepStdout,
+			Payload: map[string]any{"idx": 0, "line": "hello tail", "ordinal": 0},
+		})
+	}()
+
+	rr := httptest.NewRecorder()
+	h(rr, req)
+
+	body := rr.Body.String()
+	if !strings.Contains(body, "step:stdout") {
+		t.Errorf("expected step:stdout in tail; got:\n%s", body)
+	}
+	if !strings.Contains(body, "hello tail") {
+		t.Errorf("expected 'hello tail' line; got:\n%s", body)
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────
+
+func writeManifestForSSE(t *testing.T, runDir string, m runner.Manifest) {
+	t.Helper()
+	data, err := yaml.Marshal(m)
+	if err != nil {
+		t.Fatalf("yaml marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "manifest.yaml"), data, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+// scanSSEEventTypes extracts event type names from raw SSE body.
+func scanSSEEventTypes(body string) []string {
+	var events []string
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "event: ") {
+			events = append(events, strings.TrimPrefix(line, "event: "))
+		}
+	}
+	return events
+}
+
+var _ = scanSSEEventTypes // avoid "declared but not used" if only used in comments

--- a/internal/dash/watcher.go
+++ b/internal/dash/watcher.go
@@ -1,0 +1,343 @@
+// Package dash — watcher.go: disk-polling watcher for a single (slug, runID).
+//
+// Polls manifest.yaml every 250ms via os.Stat (mtime+size) and step-NN.stdout.log
+// files via size delta. Publishes events to the Bus.
+//
+// Lifecycle: started by Bus.Subscribe (first subscriber), stopped when the last
+// subscriber unsubscribes OR when the run reaches a terminal status.
+package dash
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/chichex/che/internal/runner"
+	"gopkg.in/yaml.v3"
+)
+
+const pollInterval = 250 * time.Millisecond
+
+// isTerminalStatus returns true for run statuses that mean the run is over
+// (and not just paused).
+func isTerminalStatus(status string) bool {
+	switch status {
+	case runner.ManifestStatusDone,
+		runner.ManifestStatusFailed,
+		runner.ManifestStatusCancelled,
+		runner.ManifestStatusInterrupted:
+		return true
+	}
+	return false
+}
+
+// stdoutState tracks the last-seen size of a step's stdout log.
+type stdoutState struct {
+	size int64
+	// nextOrdinal is the ordinal to assign to the next line emitted.
+	nextOrdinal int
+}
+
+// watcher observes manifest.yaml and step-NN.stdout.log for a single run.
+type watcher struct {
+	runsDir string
+	slug    string
+	runID   string
+	bus     *Bus
+
+	stopCh chan struct{}
+	once   sync.Once
+}
+
+func newWatcher(runsDir, slug, runID string, bus *Bus) *watcher {
+	return &watcher{
+		runsDir: runsDir,
+		slug:    slug,
+		runID:   runID,
+		bus:     bus,
+		stopCh:  make(chan struct{}),
+	}
+}
+
+// stop signals the watcher to halt. Safe to call multiple times.
+func (w *watcher) stop() {
+	w.once.Do(func() { close(w.stopCh) })
+}
+
+// run is the main polling loop. Must be called in a goroutine.
+func (w *watcher) run() {
+	runDir := filepath.Join(w.runsDir, w.slug, w.runID)
+	manifestPath := filepath.Join(runDir, "manifest.yaml")
+
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	// Manifest tracking state.
+	var lastMtime time.Time
+	var lastSize int64
+	var lastManifest *runner.Manifest
+
+	// Stdout tracking: map step index (0-based) → state.
+	stdoutStates := make(map[int]*stdoutState)
+
+	for {
+		select {
+		case <-w.stopCh:
+			return
+		case <-ticker.C:
+			// ── manifest check ────────────────────────────────────
+			fi, err := os.Stat(manifestPath)
+			if err != nil {
+				continue
+			}
+			if fi.ModTime() == lastMtime && fi.Size() == lastSize {
+				// No change — still check stdout for running step.
+				if lastManifest != nil {
+					w.checkStdout(runDir, lastManifest, stdoutStates)
+				}
+				continue
+			}
+			// Manifest changed.
+			lastMtime = fi.ModTime()
+			lastSize = fi.Size()
+
+			data, err := os.ReadFile(manifestPath)
+			if err != nil {
+				continue
+			}
+			var m runner.Manifest
+			if err := yaml.Unmarshal(data, &m); err != nil {
+				continue
+			}
+
+			// Diff manifest vs last known.
+			w.diffManifest(lastManifest, &m)
+			lastManifest = &m
+
+			// Check stdout for running steps.
+			w.checkStdout(runDir, &m, stdoutStates)
+
+			// If run transitioned to terminal, drain stdout then stop.
+			if isTerminalStatus(m.Status) {
+				// Final stdout drain.
+				w.checkStdout(runDir, &m, stdoutStates)
+				// Tell the bus we're done so it removes this watcher entry.
+				w.bus.stopWatcher(w.slug, w.runID)
+				return
+			}
+		}
+	}
+}
+
+// diffManifest compares old vs new manifest and publishes step:start / step:end
+// events for any newly started or finished steps. Also emits run:status if
+// the top-level status changed.
+func (w *watcher) diffManifest(old, new *runner.Manifest) {
+	// Run status change.
+	oldStatus := ""
+	if old != nil {
+		oldStatus = old.Status
+	}
+	if new.Status != oldStatus {
+		w.publish(EventRunStatus, map[string]any{
+			"status": new.Status,
+		})
+	}
+
+	if old == nil {
+		// First read: emit step:start for already-running steps and
+		// step:end for finished ones. This is the "cold start" case.
+		for _, s := range new.Steps {
+			switch s.Status {
+			case "running":
+				payload := map[string]any{
+					"idx":        s.Idx,
+					"name":       s.Name,
+					"started_at": s.StartedAt.Format(time.RFC3339),
+				}
+				w.publish(EventStepStart, payload)
+			case "done", "failed", "cancelled", "interrupted":
+				payload := map[string]any{
+					"idx":         s.Idx,
+					"status":      s.Status,
+					"exit_code":   s.ExitCode,
+					"finished_at": s.FinishedAt.Format(time.RFC3339),
+				}
+				if s.Error != "" {
+					payload["error"] = s.Error
+				}
+				w.publish(EventStepEnd, payload)
+			}
+		}
+		return
+	}
+
+	// Build old-step map by idx.
+	oldSteps := make(map[int]runner.ManifestStep, len(old.Steps))
+	for _, s := range old.Steps {
+		oldSteps[s.Idx] = s
+	}
+
+	for _, ns := range new.Steps {
+		os, hadOld := oldSteps[ns.Idx]
+
+		// step:start — transitioned to running.
+		if ns.Status == "running" && (!hadOld || os.Status != "running") {
+			payload := map[string]any{
+				"idx":        ns.Idx,
+				"name":       ns.Name,
+				"started_at": ns.StartedAt.Format(time.RFC3339),
+			}
+			w.publish(EventStepStart, payload)
+		}
+
+		// step:end — transitioned to a terminal step status.
+		terminalStepStatus := func(st string) bool {
+			return st == "done" || st == "failed" || st == "cancelled" || st == "interrupted"
+		}
+		if terminalStepStatus(ns.Status) && (!hadOld || !terminalStepStatus(os.Status)) {
+			payload := map[string]any{
+				"idx":         ns.Idx,
+				"status":      ns.Status,
+				"exit_code":   ns.ExitCode,
+				"finished_at": ns.FinishedAt.Format(time.RFC3339),
+			}
+			if ns.Error != "" {
+				payload["error"] = ns.Error
+			}
+			w.publish(EventStepEnd, payload)
+		}
+
+		// validator:loop — loops_run increased.
+		if ns.Validator != nil {
+			var oldLoops int
+			if hadOld && os.Validator != nil {
+				oldLoops = os.Validator.LoopsRun
+			}
+			if ns.Validator.LoopsRun > oldLoops {
+				payload := map[string]any{
+					"idx":       ns.Idx,
+					"loop":      ns.Validator.LoopsRun,
+					"max_loops": ns.Validator.MaxLoops,
+					"verdict":   ns.Validator.FinalVerdict,
+					"feedback":  ns.Validator.LastFeedback,
+				}
+				w.publish(EventValidatorLoop, payload)
+			}
+		}
+	}
+}
+
+// checkStdout reads stdout log files for running (or recently-finished) steps
+// and publishes step:stdout events for any new lines since last check.
+func (w *watcher) checkStdout(runDir string, m *runner.Manifest, states map[int]*stdoutState) {
+	for _, s := range m.Steps {
+		// Only emit stdout for running steps (tail in progress) or pending/recently
+		// done steps that have a log file (in case we just missed the transition).
+		if s.Status == "pending" {
+			continue
+		}
+		nn := fmt.Sprintf("%02d", s.Idx+1) // 1-indexed, 2-padded
+		logPath := filepath.Join(runDir, "step-"+nn+".stdout.log")
+
+		fi, err := os.Stat(logPath)
+		if err != nil {
+			continue // file doesn't exist yet
+		}
+
+		st, ok := states[s.Idx]
+		if !ok {
+			st = &stdoutState{}
+			states[s.Idx] = st
+		}
+
+		if fi.Size() <= st.size {
+			continue // no new bytes
+		}
+
+		// Open and seek to last position.
+		f, err := os.Open(logPath)
+		if err != nil {
+			continue
+		}
+		if st.size > 0 {
+			if _, err := f.Seek(st.size, 0); err != nil {
+				f.Close()
+				continue
+			}
+		}
+
+		scanner := bufio.NewScanner(f)
+		ts := time.Now().UTC().Format(time.RFC3339)
+		for scanner.Scan() {
+			line := scanner.Text()
+			// Skip empty lines at EOF (partial last line).
+			if line == "" {
+				continue
+			}
+			w.publish(EventStepStdout, map[string]any{
+				"idx":     s.Idx,
+				"line":    line,
+				"ts":      ts,
+				"ordinal": st.nextOrdinal,
+			})
+			st.nextOrdinal++
+		}
+		f.Close()
+
+		// Update tracked size.
+		newFi, err := os.Stat(logPath)
+		if err == nil {
+			st.size = newFi.Size()
+		}
+	}
+}
+
+// publish sends an event to the bus for this (slug, runID).
+func (w *watcher) publish(typ EventType, payload map[string]any) {
+	w.bus.Publish(w.slug, w.runID, Event{Type: typ, Payload: payload})
+}
+
+// stdoutLogPath returns the path of a step's stdout log (1-indexed, 2-padded).
+func stdoutLogPath(runDir string, stepIdx int) string {
+	nn := fmt.Sprintf("%02d", stepIdx+1)
+	return filepath.Join(runDir, "step-"+nn+".stdout.log")
+}
+
+// readStdoutLines reads ALL lines from a step's stdout log file and returns
+// them. Used by the SSE handler for the replay snapshot.
+func readStdoutLines(runDir string, stepIdx int) ([]string, error) {
+	path := stdoutLogPath(runDir, stepIdx)
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return lines, scanner.Err()
+}
+
+// parseManifest reads and parses the manifest.yaml at the given path.
+func parseManifest(path string) (runner.Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return runner.Manifest{}, err
+	}
+	var m runner.Manifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		return runner.Manifest{}, err
+	}
+	return m, nil
+}
+

--- a/internal/dash/watcher_test.go
+++ b/internal/dash/watcher_test.go
@@ -1,0 +1,226 @@
+package dash
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/chichex/che/internal/runner"
+	"gopkg.in/yaml.v3"
+)
+
+// writeManifestYAML writes a runner.Manifest as YAML to runDir/manifest.yaml.
+func writeManifestYAML(t *testing.T, runDir string, m runner.Manifest) {
+	t.Helper()
+	data, err := yaml.Marshal(m)
+	if err != nil {
+		t.Fatalf("yaml marshal: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "manifest.yaml"), data, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+}
+
+// TestWatcher_ManifestChange verifies that writing a manifest with a running
+// step emits run:status and step:start events.
+func TestWatcher_ManifestChange(t *testing.T) {
+	runsDir := t.TempDir()
+	slug := "pipe"
+	runID := "run-1"
+	runDir := filepath.Join(runsDir, slug, runID)
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	b := NewBus(runsDir)
+	ch, cancel := b.Subscribe(slug, runID)
+	defer cancel()
+
+	// Write initial manifest with a running step.
+	m := runner.Manifest{
+		RunID:     runID,
+		Pipeline:  "pipe",
+		Status:    runner.ManifestStatusRunning,
+		StartedAt: time.Now().UTC(),
+		Steps: []runner.ManifestStep{
+			{Idx: 0, Name: "build", Status: "running", StartedAt: time.Now().UTC()},
+		},
+	}
+	writeManifestYAML(t, runDir, m)
+
+	// Collect events for up to 1 second.
+	events := collectEvents(ch, 2, time.Second)
+
+	types := eventTypes(events)
+	if !containsType(types, EventRunStatus) {
+		t.Errorf("want run:status in %v", types)
+	}
+	if !containsType(types, EventStepStart) {
+		t.Errorf("want step:start in %v", types)
+	}
+}
+
+// TestWatcher_StdoutAppend verifies that appending lines to a step stdout log
+// emits step:stdout events with incrementing ordinals.
+func TestWatcher_StdoutAppend(t *testing.T) {
+	runsDir := t.TempDir()
+	slug := "pipe"
+	runID := "run-2"
+	runDir := filepath.Join(runsDir, slug, runID)
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write manifest first so watcher has context.
+	m := runner.Manifest{
+		RunID:     runID,
+		Pipeline:  slug,
+		Status:    runner.ManifestStatusRunning,
+		StartedAt: time.Now().UTC(),
+		Steps: []runner.ManifestStep{
+			{Idx: 0, Name: "run", Status: "running", StartedAt: time.Now().UTC()},
+		},
+	}
+	writeManifestYAML(t, runDir, m)
+
+	b := NewBus(runsDir)
+	ch, cancel := b.Subscribe(slug, runID)
+	defer cancel()
+
+	// Give watcher time to do its first tick and read the manifest.
+	time.Sleep(400 * time.Millisecond)
+
+	// Append lines to stdout log.
+	logPath := filepath.Join(runDir, "step-01.stdout.log")
+	f, err := os.Create(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.WriteString("hello world\n")
+	f.WriteString("second line\n")
+	f.Close()
+
+	// Collect step:stdout events.
+	events := collectEvents(ch, 5, time.Second)
+	var stdoutEvents []Event
+	for _, ev := range events {
+		if ev.Type == EventStepStdout {
+			stdoutEvents = append(stdoutEvents, ev)
+		}
+	}
+
+	if len(stdoutEvents) < 2 {
+		t.Fatalf("want at least 2 step:stdout events, got %d (all events: %v)", len(stdoutEvents), eventTypes(events))
+	}
+
+	// Check ordinals are incrementing.
+	if ord, _ := stdoutEvents[0].Payload["ordinal"].(int); ord != 0 {
+		t.Errorf("first event ordinal want 0, got %d", ord)
+	}
+	if ord, _ := stdoutEvents[1].Payload["ordinal"].(int); ord != 1 {
+		t.Errorf("second event ordinal want 1, got %d", ord)
+	}
+}
+
+// TestWatcher_TerminalHalt verifies that transitioning to a terminal status
+// emits run:status terminal and stops the watcher.
+func TestWatcher_TerminalHalt(t *testing.T) {
+	runsDir := t.TempDir()
+	slug := "pipe"
+	runID := "run-3"
+	runDir := filepath.Join(runsDir, slug, runID)
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Start with running manifest.
+	m := runner.Manifest{
+		RunID:     runID,
+		Pipeline:  slug,
+		Status:    runner.ManifestStatusRunning,
+		StartedAt: time.Now().UTC(),
+		Steps: []runner.ManifestStep{
+			{Idx: 0, Name: "run", Status: "running", StartedAt: time.Now().UTC()},
+		},
+	}
+	writeManifestYAML(t, runDir, m)
+
+	b := NewBus(runsDir)
+	ch, cancel := b.Subscribe(slug, runID)
+	defer cancel()
+
+	// Wait a tick so the watcher reads the initial manifest.
+	time.Sleep(400 * time.Millisecond)
+
+	// Update to terminal.
+	fin := time.Now().UTC()
+	m.Status = runner.ManifestStatusDone
+	m.FinishedAt = fin
+	m.Steps[0].Status = "done"
+	m.Steps[0].FinishedAt = fin
+	writeManifestYAML(t, runDir, m)
+
+	// Collect events — look for run:status = done.
+	events := collectEvents(ch, 10, 2*time.Second)
+	var terminalSeen bool
+	for _, ev := range events {
+		if ev.Type == EventRunStatus {
+			if status, _ := ev.Payload["status"].(string); status == "done" {
+				terminalSeen = true
+			}
+		}
+	}
+	if !terminalSeen {
+		t.Errorf("want run:status=done event; got %v", eventTypes(events))
+	}
+
+	// After terminal, watcher should have self-removed from bus.
+	// Give it a moment to complete.
+	time.Sleep(400 * time.Millisecond)
+	b.mu.Lock()
+	key := subKey{slug: slug, runID: runID}
+	_, watcherExists := b.watchers[key]
+	b.mu.Unlock()
+	if watcherExists {
+		t.Error("watcher should have been removed after terminal status")
+	}
+}
+
+// ── helpers ───────────────────────────────────────────────────────────
+
+func collectEvents(ch <-chan Event, max int, timeout time.Duration) []Event {
+	var events []Event
+	dl := time.After(timeout)
+	for {
+		select {
+		case ev, more := <-ch:
+			if !more {
+				return events
+			}
+			events = append(events, ev)
+			if len(events) >= max {
+				return events
+			}
+		case <-dl:
+			return events
+		}
+	}
+}
+
+func eventTypes(events []Event) []EventType {
+	types := make([]EventType, len(events))
+	for i, e := range events {
+		types[i] = e.Type
+	}
+	return types
+}
+
+func containsType(types []EventType, t EventType) bool {
+	for _, tt := range types {
+		if tt == t {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #123

Plan de implementación para #123: **Streamear runs vivos de che dash via SSE (per-run events)**.

Archivo: `.harness/plans/123-streamear-runs-vivos-de-che-dash-via-sse.md`

Este PR construye sobre `hs-plan/121` (#122, spec 2). Resuelve un gap arquitectural del spec (in-process bus vs procesos separados) eligiendo disk-watcher dentro del dash — ver asunción técnica #1 del plan.

---

_PR generado por `/hs-plan`._
