### PR TITLE
Plan for #125: Auto-refrescar rail y tabla via SSE global

### DIFF
--- a/.harness/plans/125-auto-refrescar-rail-y-tabla-via-sse-global.md
+++ b/.harness/plans/125-auto-refrescar-rail-y-tabla-via-sse-global.md
@@ -1,0 +1,123 @@
+# Plan: Auto-refrescar rail y tabla de runs de che dash via SSE global
+
+Refs #125 · https://github.com/chichex/che/issues/125
+
+## Contexto
+
+Spec 4 del dashboard. Cierra el set de "che dash read-only" con auto-refresh: el rail y la tabla de runs se actualizan sin reload cuando suceden cambios en disco (pipelines nuevos/eliminados/flip ready↔draft, runs que arrancan o terminan). Builds sobre `hs-plan/123` (PR #124, spec 3). Sigue la decisión arquitectural de spec 3: bus + watchers viven en `internal/dash/`, no patch al runner.
+
+## Objetivo
+
+Servir `GET /api/events` como SSE global emitiendo `pipeline:changed`, `run:started`, `run:finished` + heartbeat 15s, sin replay (frontend ya hace fetch one-shot al cargar). Materializar el campo `last_run` opcional en `/api/pipelines` (spec 1 lo había marcado como opcional). Wirear el frontend para abrir EventSource global al mount, dedupar eventos, hacer insert/update/remove en rail y tabla, y mostrar badge "live" en el header del dash.
+
+## Approach
+
+Agregar dos watchers nuevos en `internal/dash/`:
+- `internal/dash/pipelines_watcher.go`: observa `~/.che/pipelines/` con polling 250ms. Mantiene snapshot del listing (slug → mtime + status). Detecta create / status flip / delete y emite eventos al bus global.
+- `internal/dash/runs_watcher.go` (global): observa `~/.che/runs/` recursivamente con polling 250ms. Mantiene snapshot por (slug, runId) del manifest status. Detecta nuevos manifests (`run:started`) y transitions a terminal (`run:finished`).
+
+Reusar el `Bus` de spec 3 con una segunda categoría de suscripción: además de `Subscribe(runId)`, agregar `SubscribeGlobal()` que recibe todos los eventos globales (pipeline + run). El bus expone ambas APIs sobre la misma infraestructura.
+
+Handler nuevo: `internal/dash/sse_global.go` con `handleGlobalEvents(bus)`. Headers SSE iguales a spec 3. Sin snapshot inicial — solo tail desde la suscripción.
+
+Endpoint `/api/pipelines` (spec 1): extender la struct JSON para incluir `last_run` opcional. Resolver el último run de cada slug leyendo `~/.che/runs/<slug>/*/manifest.yaml` ordenado por started_at desc, tomar el primero.
+
+Frontend: nuevo `useEffect` en App que abre `EventSource("/api/events")` al mount; handlers per tipo que llaman a setters de state. Badge "live" en el header (separado del badge per-run de spec 3). Cuando un evento llega para un run o pipeline que no es visible, igual se procesa silenciosamente (e.g., last_run del rail).
+
+## Pasos
+
+- [ ] Extender `internal/dash/bus.go` con `Bus.SubscribeGlobal() (<-chan Event, cancel)`. Eventos publicados sin filtro de runId van al canal global. Mantener buffer 256.
+- [ ] Crear `internal/dash/pipelines_watcher.go`: snapshot del listing `*.yaml` con `mtime + status` por slug. Tick 250ms con `os.ReadDir` + `os.Stat` + parse mínimo del status. Emit `pipeline:changed` con `{slug, status, deleted?}` por cada diff detectado.
+- [ ] Crear `internal/dash/runs_watcher.go`: snapshot por (slug, runId) del manifest `status`. Tick 250ms recorriendo `~/.che/runs/*/*/manifest.yaml`. Emit `run:started` cuando aparece nuevo con `status=running`, `run:finished` cuando un manifest existente transitions a terminal.
+- [ ] Watchers globales arrancan al boot del `Serve()` (siempre activos, no ref-counted como los per-run de spec 3). Cleanup al shutdown.
+- [ ] Crear `internal/dash/sse_global.go`: `handleGlobalEvents(bus)`. Subscribe via `bus.SubscribeGlobal()`. Headers SSE. Heartbeat 15s. Cleanup en `r.Context().Done()`. Sin snapshot inicial.
+- [ ] Routing: registrar `mux.HandleFunc("/api/events", handleGlobalEvents(bus))` en `Serve()`.
+- [ ] Modificar `internal/dash/pipelines.go`: agregar campo `LastRun *LastRunSummary` con `omitempty` al struct de listing JSON. Función helper `lookupLastRun(slug)` que lee el run más reciente.
+- [ ] Frontend HTML — EventSource global:
+  - useEffect en App al mount: `new EventSource("/api/events")`. Cleanup al unmount.
+  - `addEventListener("pipeline:changed", ...)`: si `deleted=true` quitar del state; si slug nuevo insertar con fade-in 500ms; si status flip, mover bucket.
+  - `addEventListener("run:started", ...)`: si slug coincide con `selectedSlug`, insertar al tope de `runs` con fade-in 500ms. Si no, update silencioso del `last_run` del pipeline en el rail.
+  - `addEventListener("run:finished", ...)`: dedup por `(run_id, status)`. Si run en `runs` visible, update inline status/duración. Update `last_run` del slug en el rail.
+- [ ] Frontend HTML — pipeline seleccionado deleted:
+  - Si `pipeline:changed` con `deleted=true` y `slug == selectedSlug`: limpiar `selectedSlug` y mostrar empty state literal `este pipeline fue eliminado — seleccioná otro del rail`.
+- [ ] Frontend HTML — badge global "live":
+  - State `globalConnState` (`live` | `reconnecting` | `disconnected` | `hidden`). Pulsing dot en header del dash. Timer 10s para `disconnected` después de `onerror`.
+  - Botón retry crea nuevo EventSource.
+- [ ] Frontend HTML — reconnect refetch:
+  - En `onopen` después de un `onerror`: refetch `GET /api/pipelines`; si hay detail abierto, refetch `GET /api/pipelines/:slug/runs`.
+- [ ] Frontend HTML — render `last_run` en el rail:
+  - Cada item del rail con `last_run` presente muestra mini chip de status (mismo componente de chip ya usado en tabla).
+- [ ] Frontend HTML — fade-in animations:
+  - CSS class `dash-fade-in` con `@keyframes` 500ms ease-out, opacity 0→1.
+- [ ] Tests:
+  - `pipelines_watcher_test.go`: crear archivos en `t.TempDir()` (status ready/draft), tick, verify eventos.
+  - `runs_watcher_test.go`: crear manifests en `t.TempDir()`, tick, verify `run:started`/`run:finished`.
+  - `sse_global_test.go`: subscribe via mock bus, publish global event, verify SSE chunk emitido. Heartbeat tras silencio.
+  - `bus_test.go` extender: `SubscribeGlobal` recibe eventos globales, no recibe events filtrados por runId (y vice versa).
+  - `pipelines_test.go` extender: `last_run` se serializa correctamente cuando hay manifests, omitido cuando no hay.
+- [ ] Smoke manual en PR body: `curl -N http://127.0.0.1:7878/api/events` mientras `touch ~/.che/pipelines/test.yaml` o `mkdir ~/.che/runs/x/y && echo "..." > ~/.che/runs/x/y/manifest.yaml`.
+
+## Archivos afectados
+
+- `internal/dash/bus.go` — modificar — agregar `SubscribeGlobal()` + canal global
+- `internal/dash/bus_test.go` — modificar — coverage del subscriptor global
+- `internal/dash/pipelines_watcher.go` — crear — watcher de `~/.che/pipelines/`
+- `internal/dash/pipelines_watcher_test.go` — crear
+- `internal/dash/runs_watcher.go` — crear — watcher global de `~/.che/runs/`
+- `internal/dash/runs_watcher_test.go` — crear
+- `internal/dash/sse_global.go` — crear — handler `/api/events`
+- `internal/dash/sse_global_test.go` — crear
+- `internal/dash/dash.go` — modificar — arrancar watchers globales en `Serve()` + registrar `/api/events`
+- `internal/dash/pipelines.go` — modificar — agregar `last_run` al listing
+- `internal/dash/pipelines_test.go` — modificar — verify `last_run` en JSON
+- `internal/dash/assets/dash.html` — modificar — EventSource global + handlers + badge + fade-in + chip last_run en rail + empty state pipeline deleted
+
+## Riesgos
+
+- Polling 250ms en dos directorios (`~/.che/pipelines/` y `~/.che/runs/*`): si hay 50 pipelines × 100 runs = 5000 archivos a `stat` por tick. CPU acumula. Mitigación: en `runs_watcher` solo revisar manifests no-terminales (cache de status terminal salta el stat). En `pipelines_watcher` es de 1 dir, manejable.
+- Detección de "delete" en pipelines watcher: si entre dos ticks aparece y desaparece, no se emite evento (race muy improbable; aceptado v1).
+- `last_run` requiere leer un manifest por slug en cada listing call. Si hay 50 pipelines, 50 lecturas de YAML. Cache simple in-memory con TTL 1s en `internal/dash/pipelines.go` para mitigar.
+- Coexistencia con watcher per-run de spec 3: dos watchers pueden tocar el mismo archivo simultáneamente. `os.Stat` es read-only, no hay race.
+- Frontend dedup de `run:finished`: si llega del per-run y del global casi simultáneo, se duplica. Set por `(run_id, terminal_status)` lo resuelve.
+- Reconnect storm: si la red se cae y vuelve, `EventSource` reconecta + refetch one-shot. Si hay 10 tabs, 10 refetches. Aceptado v1.
+
+## Out of scope
+
+- Patch al `internal/runner`
+- fsnotify (sigue siendo polling, consistente con spec 3)
+- Comandos via SSE (read-only)
+- Eventos para cambios al `content` interno de un pipeline (steps, validator). Solo metadata.
+- `pipeline:running` (estado intermedio) — usamos solo `started` y `finished`.
+- Auth / rate limiting (sigue siendo 127.0.0.1 only)
+
+## Asunciones tecnicas validadas
+
+1. **Bus extendido**: `Bus` de spec 3 gana método `SubscribeGlobal() (<-chan Event, cancel)`. Eventos publicados sin `runId` van al canal global; eventos con `runId` siguen yendo a los suscriptores per-run. Buffer 256 por suscriptor (mismo cap que spec 3).
+2. **Watchers globales no son ref-counted**: arrancan al boot del `Serve()` y corren siempre. Cleanup al shutdown del server.
+3. **Polling 250ms** en ambos watchers (consistente con spec 3).
+4. **Pipelines watcher**: `os.ReadDir(pipelinesDir)` + `os.Stat` + parse mínimo del `status` block. Snapshot in-memory `map[slug]{mtime, status}`. Diff por tick.
+5. **Runs watcher global**: recorrido `~/.che/runs/<slug>/<runId>/manifest.yaml`. Snapshot in-memory `map[(slug, runId)]status`. Optimización: si status ya es terminal, no re-stat (skipea hasta que el archivo cambie de mtime, sería nuevo manifest aplastado).
+6. **`last_run` en `/api/pipelines`**: helper `lookupLastRun(slug)` que lee el manifest más reciente por `started_at`. Cache in-memory con TTL 1s para evitar recargar en cada listing.
+7. **JSON shape `last_run`**: `{id, status, started_at}` (id completo, no slice — el frontend lo cortea). `omitempty` cuando no hay runs.
+8. **SSE format global**: idéntico a spec 3 — `event: <type>\ndata: {...json...}\n\n`. Headers `Content-Type: text/event-stream`, `Cache-Control: no-cache`, `Connection: keep-alive`, `X-Accel-Buffering: no`. Flusher post cada chunk.
+9. **Heartbeat**: ticker 15s con `: heartbeat\n\n`.
+10. **Cleanup**: subscribe al `r.Context().Done()` para client disconnect → unsubscribe + close.
+11. **Sin snapshot inicial en `/api/events`**: el spec lo dice explícitamente. El frontend hace fetch one-shot al cargar, así que el SSE solo cubre cambios desde la suscripción.
+12. **Frontend EventSource lifecycle**: un `useEffect` en el componente App al mount, sin deps. Cleanup cierra. Distinto al EventSource per-run de spec 3 (que vive en el componente run detail).
+13. **Frontend handlers**: `addEventListener("pipeline:changed" | "run:started" | "run:finished", ...)`. Cada handler actualiza el state via setters de React.
+14. **Frontend dedup**: para `run:finished` mantener `Set<string>` con keys `${run_id}:${terminal_status}`. Para `pipeline:changed` no hace falta dedup (los cambios son idempotentes en el state — re-aplicar mismo `{slug, status}` no rompe nada).
+15. **Reconnect refetch**: handler `onopen` chequea un flag `wasReconnect` (seteado por el primer `onerror`); si es true, refetch `/api/pipelines` y, si hay detail, `/api/pipelines/:slug/runs`. Limpiar el flag.
+16. **Badge global**: state `globalConnState` ∈ `{live, reconnecting, disconnected, hidden}`. Timer de 10s para pasar de `reconnecting` a `disconnected` con botón retry (mismo patrón que badge per-run de spec 3).
+17. **Fade-in animation**: CSS `@keyframes dash-fade-in { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: none; } }` aplicado a row/item nuevo via clase `dash-fade-in`, 500ms ease-out. Se quita la clase tras `animationend`.
+18. **Routing**: nuevo handler `mux.HandleFunc("/api/events", handleGlobalEvents(bus))` registrado en `Serve()`. NO va al dispatcher de `/api/pipelines/` — es ruta plana.
+19. **Tests**:
+    - `pipelines_watcher_test.go`: con `t.TempDir()`, write YAML → recibe `pipeline:changed`. Edit status → recibe flip. Remove file → recibe delete.
+    - `runs_watcher_test.go`: con `t.TempDir()`, write manifest running → recibe `run:started`. Mutate a terminal → recibe `run:finished`.
+    - `sse_global_test.go`: mock bus, publish global, verify SSE chunk. Heartbeat tras silencio. Cleanup en context cancel.
+    - `bus_test.go`: `SubscribeGlobal` recibe eventos globales pero no los runId-filtered, y vice versa.
+    - `pipelines_test.go`: `last_run` correcto cuando hay manifest, omitido cuando no.
+20. **Smoke manual en PR body**: `curl -N http://127.0.0.1:7878/api/events` mientras `touch ~/.che/pipelines/foo.yaml` o crear/editar manifests en `~/.che/runs/`.
+
+---
+
+_Plan generado por `/hs-plan` a partir de #125._

--- a/internal/dash/assets/dash.html
+++ b/internal/dash/assets/dash.html
@@ -123,6 +123,18 @@
   /* notes drawer */
   details > summary { list-style: none; cursor: pointer; }
   details > summary::-webkit-details-marker { display: none; }
+
+  /* Global SSE fade-in for new rail/run items */
+  @keyframes dash-fade-in {
+    from { opacity: 0; transform: translateY(-4px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  .dash-fade-in { animation: dash-fade-in 500ms ease-out; }
+
+  /* Global connection badge states */
+  .badge-live    { color: var(--done);    border-color: color-mix(in oklch, var(--done) 25%, var(--line)); }
+  .badge-reconn  { color: var(--warn);    border-color: color-mix(in oklch, var(--warn) 25%, var(--line)); }
+  .badge-disconn { color: var(--failed);  border-color: color-mix(in oklch, var(--failed) 25%, var(--line)); }
 </style>
 <script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
 <script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
@@ -400,7 +412,7 @@ const Badge = ({ kind, children }) => (
 // Top bar
 // ─────────────────────────────────────────────────────────────────────
 
-const TopBar = ({ pipelines, runs }) => {
+const TopBar = ({ pipelines, runs, globalConnState, onRetryGlobal }) => {
   const liveRuns = useMemo(() => {
     let n = 0;
     for (const slug in runs) for (const r of runs[slug]) if (r.status === "running") n++;
@@ -422,9 +434,25 @@ const TopBar = ({ pipelines, runs }) => {
         <span className="mono text-[11px] ink-3">
           {pipelines.length} pipelines · {liveRuns} live
         </span>
-        <span className="flex items-center gap-1.5 mono text-[11px] ink-3">
-          <span className="dot dot-running" /> SSE connected
-        </span>
+        {globalConnState === "live" && (
+          <span className="badge badge-live">
+            <span className="dot dot-done" /> live
+          </span>
+        )}
+        {globalConnState === "reconnecting" && (
+          <span className="badge badge-reconn">
+            <span className="dot dot-paused" /> reconnecting…
+          </span>
+        )}
+        {globalConnState === "disconnected" && (
+          <span className="flex items-center gap-2">
+            <span className="badge badge-disconn">
+              <span className="dot dot-failed" /> disconnected
+            </span>
+            <button className="btn btn-ghost mono text-[10.5px] ink-3" onClick={onRetryGlobal}>retry</button>
+          </span>
+        )}
+        {/* "hidden" state: no badge shown */}
       </div>
     </header>
   );
@@ -434,35 +462,45 @@ const TopBar = ({ pipelines, runs }) => {
 // Sidebar
 // ─────────────────────────────────────────────────────────────────────
 
-const Sidebar = ({ pipelines, runs, selectedSlug, onSelect }) => {
+const Sidebar = ({ pipelines, runs, selectedSlug, onSelect, fadedSlugs }) => {
   const ready = pipelines.filter(p => p.status === "ready");
   const drafts = pipelines.filter(p => p.status === "draft");
 
-  const lastRun = (slug) => (runs[slug] || [])[0];
+  // last_run: prefer live runs table, fallback to pipeline.last_run from API
+  const lastRun = (slug) => {
+    const fromRuns = (runs[slug] || [])[0];
+    if (fromRuns) return fromRuns;
+    if (p && p.last_run) return p.last_run; // closure — handled per Row
+    return null;
+  };
 
   const Row = ({ p }) => {
-    const last = lastRun(p.slug);
+    const fromRuns = (runs[p.slug] || [])[0];
+    const last = fromRuns || p.last_run || null;
     const live = last && last.status === "running";
     const isSelected = selectedSlug === p.slug;
+    const isFaded = fadedSlugs && fadedSlugs.has(p.slug);
     return (
       <button
         onClick={() => onSelect(p.slug)}
         data-screen-label={"rail · " + p.slug}
         className={"w-full text-left px-3 py-2 rounded-md border border-transparent " +
-          (isSelected ? "bg-selected" : "bg-hover")}
+          (isSelected ? "bg-selected" : "bg-hover") +
+          (isFaded ? " dash-fade-in" : "")}
       >
         <div className="flex items-center justify-between gap-2">
           <span className="mono text-[13px] ink truncate">{p.name}</span>
           {p.status === "draft"
             ? <Badge kind="draft">draft</Badge>
             : live ? <Badge kind="running"><span className="dot dot-running" /> running</Badge>
+            : last ? <span className={"badge badge-" + (last.status === "done" ? "done" : last.status === "failed" ? "failed" : "")}><span className={"dot dot-" + last.status} /></span>
             : null}
         </div>
         <div className="mt-0.5 text-[11.5px] ink-3 truncate">
           {p.status === "draft"
             ? <span className="mono">paused · {p.draftStage}</span>
             : last
-              ? <>last run <span className="mono">{last.id}</span> · {statusLabel[last.status]} · {fmtAgo(last.started_at)}</>
+              ? <>last run <span className="mono">{(last.id || last.run_id || "").slice(0,6)}</span> · {statusLabel[last.status] || last.status} · {fmtAgo(last.started_at)}</>
               : <>no runs yet</>}
         </div>
       </button>
@@ -498,10 +536,20 @@ const Sidebar = ({ pipelines, runs, selectedSlug, onSelect }) => {
 };
 
 // ─────────────────────────────────────────────────────────────────────
+// Pipeline deleted empty state
+// ─────────────────────────────────────────────────────────────────────
+
+const PipelineDeletedState = () => (
+  <div className="p-8 ink-3 text-[13px]">
+    este pipeline fue eliminado — seleccioná otro del rail
+  </div>
+);
+
+// ─────────────────────────────────────────────────────────────────────
 // Pipeline detail (runs history + Run button)
 // ─────────────────────────────────────────────────────────────────────
 
-const PipelineDetail = ({ pipeline, runs, onOpenRun, onRequestRun, onResumeDraft }) => {
+const PipelineDetail = ({ pipeline, runs, onOpenRun, onRequestRun, onResumeDraft, fadedRunIds }) => {
   const list = runs[pipeline.slug] || [];
   const [pipelineStepIdx, setPipelineStepIdx] = useState(-1);
   useEffect(() => { setPipelineStepIdx(-1); }, [pipeline.slug]);
@@ -615,11 +663,12 @@ const PipelineDetail = ({ pipeline, runs, onOpenRun, onRequestRun, onResumeDraft
                 const dur = r.finished_at && r.started_at
                   ? new Date(r.finished_at).getTime() - new Date(r.started_at).getTime()
                   : null;
+                const isFadedRun = fadedRunIds && fadedRunIds.has("run:" + r.id);
                 return (
                   <tr
                     key={r.id}
                     onClick={() => onOpenRun(r.id)}
-                    className="border-t hairline-2 cursor-pointer hover:bg-[var(--hover)]"
+                    className={"border-t hairline-2 cursor-pointer hover:bg-[var(--hover)]" + (isFadedRun ? " dash-fade-in" : "")}
                   >
                     <td className="px-4 py-3"><StatusDot status={r.status} /></td>
                     <td className="px-4 py-3 mono ink">{r.id.slice(0, 6)}</td>
@@ -1328,10 +1377,23 @@ const App = () => {
 
   const [streamLines, setStreamLines] = useState([]);
 
+  // Global SSE state
+  const [globalConnState, setGlobalConnState] = useState("hidden"); // hidden|live|reconnecting|disconnected
+  const globalEsRef = useRef(null);
+  const globalDisconnTimerRef = useRef(null);
+  const globalHadErrorRef = useRef(false);
+  const finishedRunsDedup = useRef(new Set()); // set of "runId:status"
+  const fadedSlugsRef = useRef(new Set()); // slugs with fade-in animation pending
+  const [fadedSlugs, setFadedSlugs] = useState(new Set());
+
   function secsToClock(secsBefore) {
     const d = new Date(NOW - secsBefore * 1000);
     return d.toTimeString().slice(0, 8);
   }
+
+  // Keep ref to selectedSlug for use inside SSE callbacks.
+  const selectedSlugRef = useRef(selectedSlug);
+  useEffect(() => { selectedSlugRef.current = selectedSlug; }, [selectedSlug]);
 
   // ── fetch pipeline list on mount ──────────────────────────────────
   useEffect(() => {
@@ -1373,6 +1435,173 @@ const App = () => {
       .catch(err => { if (err.name !== 'AbortError') console.error('[dash] fetch runs:', err); });
     return () => ctrl.abort();
   }, [selectedSlug]);
+
+  // ── global EventSource ────────────────────────────────────────────
+  const openGlobalES = useCallback(() => {
+    if (globalEsRef.current) {
+      globalEsRef.current.close();
+    }
+    const es = new EventSource('/api/events');
+    globalEsRef.current = es;
+    globalHadErrorRef.current = false;
+
+    es.onopen = () => {
+      setGlobalConnState("live");
+      if (globalDisconnTimerRef.current) {
+        clearTimeout(globalDisconnTimerRef.current);
+        globalDisconnTimerRef.current = null;
+      }
+      // If we had an error before (reconnect), refetch pipeline list and runs.
+      if (globalHadErrorRef.current) {
+        globalHadErrorRef.current = false;
+        fetch('/api/pipelines')
+          .then(r => r.json())
+          .then(data => setPipelines(data))
+          .catch(err => console.error('[dash] refetch pipelines:', err));
+        const slug = selectedSlugRef.current;
+        if (slug) {
+          fetch('/api/pipelines/' + slug + '/runs')
+            .then(r => r.json())
+            .then(data => setRuns(prev => ({ ...prev, [slug]: data })))
+            .catch(err => console.error('[dash] refetch runs:', err));
+        }
+      }
+    };
+
+    es.onerror = () => {
+      globalHadErrorRef.current = true;
+      if (es.readyState === EventSource.CONNECTING) {
+        setGlobalConnState("reconnecting");
+      } else {
+        setGlobalConnState("disconnected");
+      }
+      if (!globalDisconnTimerRef.current) {
+        globalDisconnTimerRef.current = setTimeout(() => {
+          setGlobalConnState("disconnected");
+          globalDisconnTimerRef.current = null;
+        }, 10000);
+      }
+    };
+
+    es.addEventListener("pipeline:changed", (e) => {
+      const data = JSON.parse(e.data);
+      const { slug, status, deleted } = data;
+      if (!slug) return;
+
+      if (deleted) {
+        // Remove from pipelines list.
+        setPipelines(prev => prev.filter(p => p.slug !== slug));
+        // If selected pipeline was deleted, clear selection.
+        if (selectedSlugRef.current === slug) {
+          setSelectedSlug("__deleted__");
+        }
+        return;
+      }
+
+      setPipelines(prev => {
+        const existing = prev.find(p => p.slug === slug);
+        if (!existing) {
+          // New pipeline — insert and trigger fade-in.
+          const newPipeline = { slug, name: slug, status: status || "ready" };
+          fadedSlugsRef.current = new Set([...fadedSlugsRef.current, slug]);
+          setFadedSlugs(new Set(fadedSlugsRef.current));
+          // Remove fade class after animation completes.
+          setTimeout(() => {
+            fadedSlugsRef.current.delete(slug);
+            setFadedSlugs(new Set(fadedSlugsRef.current));
+          }, 600);
+          return [...prev, newPipeline];
+        }
+        // Status flip — update existing.
+        return prev.map(p => p.slug === slug ? { ...p, status: status || p.status } : p);
+      });
+    });
+
+    es.addEventListener("run:started", (e) => {
+      const data = JSON.parse(e.data);
+      const { slug, run_id, started_at } = data;
+      if (!slug || !run_id) return;
+
+      // Update pipeline last_run optimistically.
+      setPipelines(prev => prev.map(p =>
+        p.slug === slug
+          ? { ...p, last_run: { id: run_id, status: "running", started_at } }
+          : p
+      ));
+
+      // If this slug is selected, insert new run at top with fade-in.
+      if (selectedSlugRef.current === slug) {
+        const newRun = { id: run_id, status: "running", started_at };
+        setRuns(prev => {
+          const existing = (prev[slug] || []).find(r => r.id === run_id);
+          if (existing) return prev; // already present
+          return { ...prev, [slug]: [newRun, ...(prev[slug] || [])] };
+        });
+        // Trigger fade-in for the run row.
+        fadedSlugsRef.current = new Set([...fadedSlugsRef.current, "run:" + run_id]);
+        setFadedSlugs(new Set(fadedSlugsRef.current));
+        setTimeout(() => {
+          fadedSlugsRef.current.delete("run:" + run_id);
+          setFadedSlugs(new Set(fadedSlugsRef.current));
+        }, 600);
+      }
+    });
+
+    es.addEventListener("run:finished", (e) => {
+      const data = JSON.parse(e.data);
+      const { slug, run_id, status, started_at, finished_at } = data;
+      if (!slug || !run_id || !status) return;
+
+      // Dedup: if we already processed this (run_id, terminal_status) pair, skip.
+      const dedupKey = run_id + ":" + status;
+      if (finishedRunsDedup.current.has(dedupKey)) return;
+      finishedRunsDedup.current.add(dedupKey);
+
+      // Update pipeline last_run.
+      setPipelines(prev => prev.map(p => {
+        if (p.slug !== slug) return p;
+        const lr = p.last_run;
+        // Only update if this run is the most recent.
+        if (!lr || lr.id === run_id || !lr.started_at || (started_at && started_at >= lr.started_at)) {
+          return { ...p, last_run: { id: run_id, status, started_at: started_at || (lr && lr.started_at) || "" } };
+        }
+        return p;
+      }));
+
+      // Update run in table if selected slug.
+      if (selectedSlugRef.current === slug) {
+        setRuns(prev => ({
+          ...prev,
+          [slug]: (prev[slug] || []).map(r =>
+            r.id === run_id ? { ...r, status, finished_at: finished_at || r.finished_at } : r
+          ),
+        }));
+        // If viewing this run detail, update it too.
+        setRunDetail(prev => {
+          if (!prev || prev.id !== run_id) return prev;
+          return { ...prev, status, finished_at: finished_at || prev.finished_at };
+        });
+      }
+    });
+
+    return es;
+  }, []);
+
+  // Mount: open global EventSource. Cleanup on unmount.
+  useEffect(() => {
+    const es = openGlobalES();
+    return () => {
+      es.close();
+      if (globalDisconnTimerRef.current) {
+        clearTimeout(globalDisconnTimerRef.current);
+      }
+    };
+  }, [openGlobalES]);
+
+  const retryGlobal = useCallback(() => {
+    setGlobalConnState("reconnecting");
+    openGlobalES();
+  }, [openGlobalES]);
 
   // ── fetch run detail when openRunId changes ───────────────────────
   useEffect(() => {
@@ -1638,16 +1867,19 @@ const App = () => {
 
   return (
     <div className="h-screen flex flex-col">
-      <TopBar pipelines={pipelines} runs={runs} />
+      <TopBar pipelines={pipelines} runs={runs} globalConnState={globalConnState} onRetryGlobal={retryGlobal} />
       <div className="flex flex-1 min-h-0">
         <Sidebar
           pipelines={pipelines}
           runs={runs}
-          selectedSlug={selectedSlug}
+          selectedSlug={selectedSlug === "__deleted__" ? null : selectedSlug}
           onSelect={onSelectPipeline}
+          fadedSlugs={fadedSlugs}
         />
         <main className="flex-1 min-w-0 overflow-y-auto scroll-thin">
-          {!selectedPipeline ? (
+          {selectedSlug === "__deleted__" ? (
+            <PipelineDeletedState />
+          ) : !selectedPipeline ? (
             <div className="p-8 ink-3 text-[13px]">
               {pipelines.length === 0
                 ? "no pipelines yet — corré che y entrá a Create pipeline"
@@ -1674,6 +1906,7 @@ const App = () => {
               onOpenRun={(id) => { setOpenRunId(id); setSelectedStepIdx(0); setRunDetail(null); }}
               onRequestRun={requestRun}
               onResumeDraft={() => alert("Prototype: would run `che new --resume " + selectedPipeline.slug + "` in the user's terminal.")}
+              fadedRunIds={fadedSlugs}
             />
           )}
         </main>

--- a/internal/dash/assets/dash.html
+++ b/internal/dash/assets/dash.html
@@ -466,14 +466,6 @@ const Sidebar = ({ pipelines, runs, selectedSlug, onSelect, fadedSlugs }) => {
   const ready = pipelines.filter(p => p.status === "ready");
   const drafts = pipelines.filter(p => p.status === "draft");
 
-  // last_run: prefer live runs table, fallback to pipeline.last_run from API
-  const lastRun = (slug) => {
-    const fromRuns = (runs[slug] || [])[0];
-    if (fromRuns) return fromRuns;
-    if (p && p.last_run) return p.last_run; // closure — handled per Row
-    return null;
-  };
-
   const Row = ({ p }) => {
     const fromRuns = (runs[p.slug] || [])[0];
     const last = fromRuns || p.last_run || null;

--- a/internal/dash/bus.go
+++ b/internal/dash/bus.go
@@ -3,6 +3,10 @@
 // Each (slug, runId) pair can have multiple subscribers. The bus is ref-counted:
 // the first subscriber for a (slug, runId) starts a disk watcher; the last one
 // to unsubscribe stops it.
+//
+// Global subscribers (SubscribeGlobal) receive all events published via
+// PublishGlobal (pipeline:changed, run:started, run:finished). They are
+// independent of per-run subscribers and are not ref-counted.
 package dash
 
 import (
@@ -13,11 +17,16 @@ import (
 type EventType string
 
 const (
-	EventRunStatus    EventType = "run:status"
-	EventStepStart    EventType = "step:start"
-	EventStepEnd      EventType = "step:end"
-	EventStepStdout   EventType = "step:stdout"
+	EventRunStatus     EventType = "run:status"
+	EventStepStart     EventType = "step:start"
+	EventStepEnd       EventType = "step:end"
+	EventStepStdout    EventType = "step:stdout"
 	EventValidatorLoop EventType = "validator:loop"
+
+	// Global event types (emitted by pipelines_watcher and runs_watcher).
+	EventPipelineChanged EventType = "pipeline:changed"
+	EventRunStarted      EventType = "run:started"
+	EventRunFinished     EventType = "run:finished"
 )
 
 // Event is a single SSE event with a typed payload (JSON-marshallable map).
@@ -38,12 +47,19 @@ type subscriber struct {
 	removed bool // set to true when removeSub has processed this subscriber
 }
 
+// globalSubscriber is a subscriber for global events (not tied to a run).
+type globalSubscriber struct {
+	ch      chan Event
+	removed bool
+}
+
 // Bus is a per-run pub/sub bus. Safe for concurrent use.
 type Bus struct {
-	mu      sync.Mutex
-	subs    map[subKey][]*subscriber
-	watchers map[subKey]*watcher
-	runsDir  string
+	mu         sync.Mutex
+	subs       map[subKey][]*subscriber
+	watchers   map[subKey]*watcher
+	runsDir    string
+	globalSubs []*globalSubscriber
 }
 
 // NewBus creates a new Bus serving runs from runsDir.
@@ -53,6 +69,61 @@ func NewBus(runsDir string) *Bus {
 		watchers: make(map[subKey]*watcher),
 		runsDir:  runsDir,
 	}
+}
+
+// SubscribeGlobal registers a new subscriber for global events
+// (pipeline:changed, run:started, run:finished).
+// Returns a receive-only channel and a cancel function.
+// The cancel function MUST be called when done.
+// Buffer size is 256; if the subscriber is too slow, it is dropped and closed.
+func (b *Bus) SubscribeGlobal() (<-chan Event, func()) {
+	ch := make(chan Event, 256)
+	gs := &globalSubscriber{ch: ch}
+
+	b.mu.Lock()
+	b.globalSubs = append(b.globalSubs, gs)
+	b.mu.Unlock()
+
+	cancel := func() {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		b.removeGlobalSub(gs)
+	}
+	return ch, cancel
+}
+
+// removeGlobalSub removes gs from globalSubs (must hold b.mu). Idempotent.
+func (b *Bus) removeGlobalSub(gs *globalSubscriber) {
+	if gs.removed {
+		return
+	}
+	gs.removed = true
+	newList := b.globalSubs[:0]
+	for _, s := range b.globalSubs {
+		if s != gs {
+			newList = append(newList, s)
+		}
+	}
+	b.globalSubs = newList
+	close(gs.ch)
+}
+
+// PublishGlobal sends a global event to all global subscribers.
+// Slow subscribers (full buffer) are dropped.
+func (b *Bus) PublishGlobal(ev Event) {
+	b.mu.Lock()
+	var slow []*globalSubscriber
+	for _, gs := range b.globalSubs {
+		select {
+		case gs.ch <- ev:
+		default:
+			slow = append(slow, gs)
+		}
+	}
+	for _, gs := range slow {
+		b.removeGlobalSub(gs)
+	}
+	b.mu.Unlock()
 }
 
 // Subscribe registers a new subscriber for (slug, runID).

--- a/internal/dash/bus_test.go
+++ b/internal/dash/bus_test.go
@@ -74,6 +74,64 @@ func TestBus_SlowDrop(t *testing.T) {
 	}
 }
 
+// TestBus_SubscribeGlobal verifies that global subscribers receive PublishGlobal
+// events and do NOT receive per-run Publish events (and vice versa).
+func TestBus_SubscribeGlobal(t *testing.T) {
+	b := NewBus("/tmp")
+
+	// Global subscriber.
+	gCh, gCancel := b.SubscribeGlobal()
+	defer gCancel()
+
+	// Per-run subscriber.
+	rCh, rCancel := b.Subscribe("sl", "r99")
+	defer rCancel()
+
+	// Publish a global event.
+	globalEv := Event{Type: EventPipelineChanged, Payload: map[string]any{"slug": "test", "status": "ready"}}
+	b.PublishGlobal(globalEv)
+
+	// Global subscriber should receive it.
+	select {
+	case got := <-gCh:
+		if got.Type != EventPipelineChanged {
+			t.Fatalf("global sub: want %s, got %s", EventPipelineChanged, got.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout: global subscriber did not receive global event")
+	}
+
+	// Per-run subscriber should NOT receive global event.
+	select {
+	case ev := <-rCh:
+		t.Fatalf("per-run sub should not receive global event, got %+v", ev)
+	case <-time.After(50 * time.Millisecond):
+		// Expected: nothing.
+	}
+
+	// Publish a per-run event.
+	runEv := Event{Type: EventRunStatus, Payload: map[string]any{"status": "running"}}
+	b.Publish("sl", "r99", runEv)
+
+	// Per-run subscriber should receive it.
+	select {
+	case got := <-rCh:
+		if got.Type != EventRunStatus {
+			t.Fatalf("per-run sub: want %s, got %s", EventRunStatus, got.Type)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout: per-run subscriber did not receive per-run event")
+	}
+
+	// Global subscriber should NOT receive per-run event.
+	select {
+	case ev := <-gCh:
+		t.Fatalf("global sub should not receive per-run event, got %+v", ev)
+	case <-time.After(50 * time.Millisecond):
+		// Expected: nothing.
+	}
+}
+
 // TestBus_UnsubscribeStopsWatcher verifies that canceling the sole subscriber
 // removes the watcher entry from the bus.
 func TestBus_UnsubscribeStopsWatcher(t *testing.T) {

--- a/internal/dash/dash.go
+++ b/internal/dash/dash.go
@@ -61,9 +61,23 @@ func Serve(ctx context.Context, opts Options) error {
 	// Singleton bus for SSE per-run streaming.
 	bus := NewBus(runsDir)
 
+	// Start global watchers (always active, not ref-counted).
+	// They stop when ctx is cancelled (via stopCh signalled in shutdown goroutine).
+	pw := newPipelinesWatcher(pipelinesDir, bus)
+	rw := newRunsWatcher(runsDir, bus)
+	go pw.run()
+	go rw.run()
+	// Stop global watchers when context is cancelled.
+	go func() {
+		<-ctx.Done()
+		pw.stop()
+		rw.stop()
+	}()
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", handleIndex)
-	mux.HandleFunc("/api/pipelines", handleListPipelines(pipelinesDir))
+	mux.HandleFunc("/api/events", handleGlobalEvents(bus))
+	mux.HandleFunc("/api/pipelines", handleListPipelines(pipelinesDir, runsDir))
 	mux.HandleFunc("/api/pipelines/", dispatchPipelinesPrefix(pipelinesDir, runsDir, bus))
 
 	srv := &http.Server{

--- a/internal/dash/pipelines.go
+++ b/internal/dash/pipelines.go
@@ -7,16 +7,42 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/chichex/che/internal/wizard"
+	"gopkg.in/yaml.v3"
 )
+
+// lastRunSummary holds the minimal info for the most recent run of a pipeline.
+type lastRunSummary struct {
+	ID        string `json:"id"`
+	Status    string `json:"status"`
+	StartedAt string `json:"started_at"`
+}
+
+// lastRunCache is a simple in-memory cache with TTL 1s for lookupLastRun.
+var lastRunCache struct {
+	mu      sync.Mutex
+	entries map[string]lastRunCacheEntry
+}
+
+type lastRunCacheEntry struct {
+	result  *lastRunSummary
+	fetchedAt time.Time
+}
+
+func init() {
+	lastRunCache.entries = make(map[string]lastRunCacheEntry)
+}
 
 // pipelineJSON is the wire shape for GET /api/pipelines (list item).
 type pipelineJSON struct {
-	Slug        string `json:"slug"`
-	Name        string `json:"name"`
-	Description string `json:"description,omitempty"`
-	Status      string `json:"status"`
+	Slug        string          `json:"slug"`
+	Name        string          `json:"name"`
+	Description string          `json:"description,omitempty"`
+	Status      string          `json:"status"`
+	LastRun     *lastRunSummary `json:"last_run,omitempty"`
 }
 
 // pipelineDetailJSON is the wire shape for GET /api/pipelines/:slug.
@@ -116,10 +142,90 @@ func loadPipelinesFromDir(dir string) []struct {
 	return result
 }
 
+// lookupLastRun reads the most-recent run manifest for slug from runsDir.
+// Results are cached with a 1s TTL.
+// Returns nil if no runs exist.
+func lookupLastRun(runsDir, slug string) *lastRunSummary {
+	if runsDir == "" {
+		return nil
+	}
+
+	cacheKey := runsDir + "/" + slug
+
+	lastRunCache.mu.Lock()
+	if entry, ok := lastRunCache.entries[cacheKey]; ok && time.Since(entry.fetchedAt) < time.Second {
+		result := entry.result
+		lastRunCache.mu.Unlock()
+		return result
+	}
+	lastRunCache.mu.Unlock()
+
+	result := fetchLastRun(runsDir, slug)
+
+	lastRunCache.mu.Lock()
+	lastRunCache.entries[cacheKey] = lastRunCacheEntry{result: result, fetchedAt: time.Now()}
+	lastRunCache.mu.Unlock()
+
+	return result
+}
+
+// fetchLastRun performs the actual disk read to find the most recent run.
+func fetchLastRun(runsDir, slug string) *lastRunSummary {
+	slugDir := filepath.Join(runsDir, slug)
+	entries, err := os.ReadDir(slugDir)
+	if err != nil {
+		return nil
+	}
+
+	var (
+		bestID        string
+		bestStatus    string
+		bestStartedAt time.Time
+	)
+
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		runID := e.Name()
+		manifestPath := filepath.Join(slugDir, runID, "manifest.yaml")
+		data, err := os.ReadFile(manifestPath)
+		if err != nil {
+			continue
+		}
+		// Minimal parse: only need status and started_at.
+		var m struct {
+			Status    string    `yaml:"status"`
+			StartedAt time.Time `yaml:"started_at"`
+		}
+		if err := yaml.Unmarshal(data, &m); err != nil {
+			continue
+		}
+		if m.StartedAt.IsZero() {
+			continue
+		}
+		if bestID == "" || m.StartedAt.After(bestStartedAt) {
+			bestID = runID
+			bestStatus = m.Status
+			bestStartedAt = m.StartedAt
+		}
+	}
+
+	if bestID == "" {
+		return nil
+	}
+	return &lastRunSummary{
+		ID:        bestID,
+		Status:    bestStatus,
+		StartedAt: bestStartedAt.Format(time.RFC3339),
+	}
+}
+
 // handleListPipelines returns an http.HandlerFunc for GET /api/pipelines.
 // It reads all *.yaml pipelines from dir, skipping corrupt files.
 // Returns JSON array (empty array if dir is empty or missing).
-func handleListPipelines(dir string) http.HandlerFunc {
+// runsDir is used to populate last_run for each pipeline.
+func handleListPipelines(dir, runsDir string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		pairs := loadPipelinesFromDir(dir)
 		list := make([]pipelineJSON, 0, len(pairs))
@@ -129,6 +235,7 @@ func handleListPipelines(dir string) http.HandlerFunc {
 				Name:        pair.p.Name,
 				Description: pair.p.Description,
 				Status:      pipelineStatus(pair.p),
+				LastRun:     lookupLastRun(runsDir, pair.slug),
 			})
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/dash/pipelines_test.go
+++ b/internal/dash/pipelines_test.go
@@ -44,7 +44,7 @@ func getJSON(t *testing.T, handler http.HandlerFunc, path string) *httptest.Resp
 
 func TestListEmpty(t *testing.T) {
 	dir := t.TempDir()
-	rr := getJSON(t, handleListPipelines(dir), "/api/pipelines")
+	rr := getJSON(t, handleListPipelines(dir, ""), "/api/pipelines")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", rr.Code)
 	}
@@ -64,7 +64,7 @@ func TestListOneReady(t *testing.T) {
 		Description: "test ready",
 		Steps:       []wizard.Step{{Name: "step1", CLI: "claude", Kind: "prompt"}},
 	})
-	rr := getJSON(t, handleListPipelines(dir), "/api/pipelines")
+	rr := getJSON(t, handleListPipelines(dir, ""), "/api/pipelines")
 	var list []pipelineJSON
 	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -87,7 +87,7 @@ func TestListOneDraft(t *testing.T) {
 		Name:   "Draft Pipe",
 		Status: draftStatus,
 	})
-	rr := getJSON(t, handleListPipelines(dir), "/api/pipelines")
+	rr := getJSON(t, handleListPipelines(dir, ""), "/api/pipelines")
 	var list []pipelineJSON
 	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -107,7 +107,7 @@ func TestListMixed(t *testing.T) {
 		Name:   "Draft",
 		Status: &wizard.Status{Stage: wizard.StageStep},
 	})
-	rr := getJSON(t, handleListPipelines(dir), "/api/pipelines")
+	rr := getJSON(t, handleListPipelines(dir, ""), "/api/pipelines")
 	var list []pipelineJSON
 	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -132,7 +132,7 @@ func TestListCorruptExcluded(t *testing.T) {
 	writeCorrupt(t, dir, "bad-pipe")
 	writeYAML(t, dir, "good-pipe", wizard.Pipeline{Name: "Good"})
 
-	rr := getJSON(t, handleListPipelines(dir), "/api/pipelines")
+	rr := getJSON(t, handleListPipelines(dir, ""), "/api/pipelines")
 	var list []pipelineJSON
 	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
 		t.Fatalf("unmarshal: %v", err)

--- a/internal/dash/pipelines_test.go
+++ b/internal/dash/pipelines_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/chichex/che/internal/wizard"
 )
@@ -189,5 +190,105 @@ func TestDetailFound(t *testing.T) {
 	}
 	if detail.Steps[1].Validator != nil {
 		t.Errorf("step[1] should have no validator")
+	}
+}
+
+// ── last_run field tests ───────────────────────────────────────────────────
+
+// writeRunManifest creates a minimal manifest.yaml under runsDir/slug/runID/.
+func writeRunManifest(t *testing.T, runsDir, slug, runID, status string, startedAt time.Time) {
+	t.Helper()
+	dir := filepath.Join(runsDir, slug, runID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	content := "run_id: " + runID + "\npipeline: " + slug + "\nstatus: " + status + "\nstarted_at: " + startedAt.UTC().Format(time.RFC3339) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "manifest.yaml"), []byte(content), 0o600); err != nil {
+		t.Fatalf("writeRunManifest %s/%s: %v", slug, runID, err)
+	}
+}
+
+// TestListPipelines_LastRunPresent verifies that /api/pipelines includes
+// last_run={id, status, started_at} when the pipeline has a run.
+func TestListPipelines_LastRunPresent(t *testing.T) {
+	pipelinesDir := t.TempDir()
+	runsDir := t.TempDir()
+
+	writeYAML(t, pipelinesDir, "my-pipe", wizard.Pipeline{
+		Name:  "My Pipe",
+		Steps: []wizard.Step{{Name: "step1", CLI: "claude", Kind: "prompt"}},
+	})
+
+	startedAt := time.Now().UTC().Truncate(time.Second)
+	writeRunManifest(t, runsDir, "my-pipe", "run-abc", "done", startedAt)
+
+	// Invalidate cache to avoid stale TTL entries from other tests.
+	lastRunCache.mu.Lock()
+	lastRunCache.entries = make(map[string]lastRunCacheEntry)
+	lastRunCache.mu.Unlock()
+
+	rr := getJSON(t, handleListPipelines(pipelinesDir, runsDir), "/api/pipelines")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+
+	var list []pipelineJSON
+	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("want 1 pipeline, got %d", len(list))
+	}
+	p := list[0]
+	if p.LastRun == nil {
+		t.Fatal("want last_run present, got nil")
+	}
+	if p.LastRun.ID != "run-abc" {
+		t.Errorf("last_run.id: want run-abc, got %q", p.LastRun.ID)
+	}
+	if p.LastRun.Status != "done" {
+		t.Errorf("last_run.status: want done, got %q", p.LastRun.Status)
+	}
+	if p.LastRun.StartedAt == "" {
+		t.Errorf("last_run.started_at: want non-empty, got empty")
+	}
+}
+
+// TestListPipelines_LastRunOmitted verifies that last_run is omitted (omitempty)
+// when there are no runs for the pipeline.
+func TestListPipelines_LastRunOmitted(t *testing.T) {
+	pipelinesDir := t.TempDir()
+	runsDir := t.TempDir()
+
+	writeYAML(t, pipelinesDir, "no-runs-pipe", wizard.Pipeline{
+		Name:  "No Runs",
+		Steps: []wizard.Step{{Name: "s1", CLI: "claude", Kind: "prompt"}},
+	})
+
+	// Invalidate cache.
+	lastRunCache.mu.Lock()
+	lastRunCache.entries = make(map[string]lastRunCacheEntry)
+	lastRunCache.mu.Unlock()
+
+	rr := getJSON(t, handleListPipelines(pipelinesDir, runsDir), "/api/pipelines")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+
+	var list []pipelineJSON
+	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("want 1 pipeline, got %d", len(list))
+	}
+	if list[0].LastRun != nil {
+		t.Errorf("want last_run omitted, got %+v", list[0].LastRun)
+	}
+
+	// Also verify JSON does not contain "last_run" key at all.
+	rawJSON := rr.Body.String()
+	if strings.Contains(rawJSON, "last_run") {
+		t.Errorf("last_run should be omitted from JSON, got: %s", rawJSON)
 	}
 }

--- a/internal/dash/pipelines_watcher.go
+++ b/internal/dash/pipelines_watcher.go
@@ -1,0 +1,153 @@
+// Package dash — pipelines_watcher.go: global watcher for ~/.che/pipelines/.
+//
+// Polls every 250ms via os.ReadDir + os.Stat. Maintains a snapshot of
+// slug → {mtime, status}. On diff emits pipeline:changed via bus.PublishGlobal.
+package dash
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/chichex/che/internal/wizard"
+)
+
+// pipelineSnapshot holds the last-seen mtime and status for a pipeline YAML.
+type pipelineSnapshot struct {
+	mtime  time.Time
+	status string
+}
+
+// pipelinesWatcher polls ~/.che/pipelines/ and emits pipeline:changed events.
+type pipelinesWatcher struct {
+	dir    string
+	bus    *Bus
+	stopCh chan struct{}
+}
+
+// newPipelinesWatcher creates a watcher for dir, publishing to bus.
+func newPipelinesWatcher(dir string, bus *Bus) *pipelinesWatcher {
+	return &pipelinesWatcher{
+		dir:    dir,
+		bus:    bus,
+		stopCh: make(chan struct{}),
+	}
+}
+
+// stop signals the watcher to halt. Safe to call multiple times (idempotent via select).
+func (w *pipelinesWatcher) stop() {
+	select {
+	case <-w.stopCh:
+	default:
+		close(w.stopCh)
+	}
+}
+
+// run is the main polling loop. Must be called in a goroutine.
+func (w *pipelinesWatcher) run() {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	snapshot := make(map[string]pipelineSnapshot) // slug → snapshot
+
+	for {
+		select {
+		case <-w.stopCh:
+			return
+		case <-ticker.C:
+			w.tick(snapshot)
+		}
+	}
+}
+
+func (w *pipelinesWatcher) tick(snapshot map[string]pipelineSnapshot) {
+	if w.dir == "" {
+		return
+	}
+	entries, err := os.ReadDir(w.dir)
+	if err != nil {
+		return
+	}
+
+	seen := make(map[string]bool, len(entries))
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".yaml") {
+			continue
+		}
+		slug := strings.TrimSuffix(name, ".yaml")
+		seen[slug] = true
+
+		path := filepath.Join(w.dir, name)
+		fi, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+
+		prev, existed := snapshot[slug]
+		if existed && fi.ModTime().Equal(prev.mtime) {
+			// No change.
+			continue
+		}
+
+		// Parse status minimally.
+		status := parsePipelineStatus(path)
+
+		if !existed {
+			// New pipeline.
+			snapshot[slug] = pipelineSnapshot{mtime: fi.ModTime(), status: status}
+			w.bus.PublishGlobal(Event{
+				Type: EventPipelineChanged,
+				Payload: map[string]any{
+					"slug":   slug,
+					"status": status,
+				},
+			})
+			continue
+		}
+
+		// mtime changed — update snapshot regardless, emit if status flipped.
+		snapshot[slug] = pipelineSnapshot{mtime: fi.ModTime(), status: status}
+		if status != prev.status {
+			w.bus.PublishGlobal(Event{
+				Type: EventPipelineChanged,
+				Payload: map[string]any{
+					"slug":   slug,
+					"status": status,
+				},
+			})
+		}
+	}
+
+	// Detect deletes: slugs in snapshot but not in seen.
+	for slug := range snapshot {
+		if !seen[slug] {
+			delete(snapshot, slug)
+			w.bus.PublishGlobal(Event{
+				Type: EventPipelineChanged,
+				Payload: map[string]any{
+					"slug":    slug,
+					"deleted": true,
+				},
+			})
+		}
+	}
+}
+
+// parsePipelineStatus reads the pipeline YAML and returns "ready" or "draft".
+// On parse error, returns "ready" as a safe default.
+func parsePipelineStatus(path string) string {
+	p, err := wizard.Load(path)
+	if err != nil {
+		return "ready"
+	}
+	if p.Status != nil {
+		return "draft"
+	}
+	return "ready"
+}

--- a/internal/dash/pipelines_watcher_test.go
+++ b/internal/dash/pipelines_watcher_test.go
@@ -1,0 +1,132 @@
+package dash
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writePipelineYAML writes a minimal pipeline YAML to dir/<slug>.yaml.
+// If withStatus is true, writes a Status block to make it "draft".
+func writePipelineYAML(t *testing.T, dir, slug string, withStatus bool) {
+	t.Helper()
+	content := "name: " + slug + "\n"
+	if withStatus {
+		content += "status:\n  stage: info\n"
+	}
+	if err := os.WriteFile(filepath.Join(dir, slug+".yaml"), []byte(content), 0o600); err != nil {
+		t.Fatalf("writePipelineYAML %s: %v", slug, err)
+	}
+}
+
+// TestPipelinesWatcher_NewPipeline verifies that a new YAML file triggers
+// a pipeline:changed event.
+func TestPipelinesWatcher_NewPipeline(t *testing.T) {
+	dir := t.TempDir()
+	bus := NewBus("/tmp")
+	gCh, gCancel := bus.SubscribeGlobal()
+	defer gCancel()
+
+	w := newPipelinesWatcher(dir, bus)
+	snap := make(map[string]pipelineSnapshot)
+
+	// No files yet — tick should produce nothing.
+	w.tick(snap)
+	select {
+	case ev := <-gCh:
+		t.Fatalf("expected no event on empty dir, got %+v", ev)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	// Write a ready pipeline.
+	writePipelineYAML(t, dir, "my-pipe", false)
+	w.tick(snap)
+
+	select {
+	case ev := <-gCh:
+		if ev.Type != EventPipelineChanged {
+			t.Fatalf("want pipeline:changed, got %s", ev.Type)
+		}
+		if ev.Payload["slug"] != "my-pipe" {
+			t.Fatalf("want slug=my-pipe, got %v", ev.Payload["slug"])
+		}
+		if ev.Payload["status"] != "ready" {
+			t.Fatalf("want status=ready, got %v", ev.Payload["status"])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for pipeline:changed event")
+	}
+}
+
+// TestPipelinesWatcher_StatusFlip verifies that a status change (ready→draft)
+// triggers a pipeline:changed event.
+func TestPipelinesWatcher_StatusFlip(t *testing.T) {
+	dir := t.TempDir()
+	bus := NewBus("/tmp")
+	gCh, gCancel := bus.SubscribeGlobal()
+	defer gCancel()
+
+	w := newPipelinesWatcher(dir, bus)
+	snap := make(map[string]pipelineSnapshot)
+
+	// Write ready pipeline and tick to populate snapshot.
+	writePipelineYAML(t, dir, "pipe", false)
+	// Small sleep to ensure mtime differs on next write.
+	time.Sleep(5 * time.Millisecond)
+	w.tick(snap)
+	// Drain the "new pipeline" event.
+	<-gCh
+
+	// Flip to draft.
+	time.Sleep(5 * time.Millisecond)
+	writePipelineYAML(t, dir, "pipe", true)
+	w.tick(snap)
+
+	select {
+	case ev := <-gCh:
+		if ev.Type != EventPipelineChanged {
+			t.Fatalf("want pipeline:changed, got %s", ev.Type)
+		}
+		if ev.Payload["status"] != "draft" {
+			t.Fatalf("want status=draft, got %v", ev.Payload["status"])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for status flip event")
+	}
+}
+
+// TestPipelinesWatcher_Delete verifies that removing a YAML file triggers
+// a pipeline:changed{deleted:true} event.
+func TestPipelinesWatcher_Delete(t *testing.T) {
+	dir := t.TempDir()
+	bus := NewBus("/tmp")
+	gCh, gCancel := bus.SubscribeGlobal()
+	defer gCancel()
+
+	w := newPipelinesWatcher(dir, bus)
+	snap := make(map[string]pipelineSnapshot)
+
+	writePipelineYAML(t, dir, "gone", false)
+	w.tick(snap)
+	<-gCh // drain new event
+
+	// Delete the file.
+	os.Remove(filepath.Join(dir, "gone.yaml"))
+	w.tick(snap)
+
+	select {
+	case ev := <-gCh:
+		if ev.Type != EventPipelineChanged {
+			t.Fatalf("want pipeline:changed, got %s", ev.Type)
+		}
+		if ev.Payload["deleted"] != true {
+			t.Fatalf("want deleted=true, got %v", ev.Payload["deleted"])
+		}
+		if ev.Payload["slug"] != "gone" {
+			t.Fatalf("want slug=gone, got %v", ev.Payload["slug"])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for delete event")
+	}
+}

--- a/internal/dash/runs_watcher.go
+++ b/internal/dash/runs_watcher.go
@@ -152,9 +152,11 @@ func (w *runsWatcher) tick(snapshot map[runKey]runSnapshot) {
 					w.bus.PublishGlobal(Event{
 						Type: EventRunStarted,
 						Payload: map[string]any{
-							"slug":       slug,
-							"run_id":     runID,
-							"started_at": startedAt,
+							"slug":        slug,
+							"run_id":      runID,
+							"started_at":  startedAt,
+							"input_kind":  m.InputKind,
+							"input_value": m.InputValue,
 						},
 					})
 				}

--- a/internal/dash/runs_watcher.go
+++ b/internal/dash/runs_watcher.go
@@ -1,0 +1,185 @@
+// Package dash — runs_watcher.go: global watcher for ~/.che/runs/*/*.
+//
+// Polls every 250ms, scanning ~/.che/runs/<slug>/<runId>/manifest.yaml.
+// Maintains snapshot per (slug, runId) → status. Emits:
+//   - run:started when a new manifest with status=running appears
+//   - run:finished when an existing run transitions to a terminal status
+//
+// Optimization: if a run's status is already terminal, skip stat until mtime changes.
+package dash
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// runSnapshot holds last-seen status and mtime for a single run manifest.
+type runSnapshot struct {
+	status    string
+	mtime     time.Time
+	startedAt string // ISO8601
+}
+
+// runKey identifies a unique (slug, runId) pair.
+type runKey struct {
+	slug  string
+	runID string
+}
+
+// runsWatcher polls ~/.che/runs/ and emits global run events.
+type runsWatcher struct {
+	runsDir string
+	bus     *Bus
+	stopCh  chan struct{}
+}
+
+// newRunsWatcher creates a watcher for runsDir, publishing to bus.
+func newRunsWatcher(runsDir string, bus *Bus) *runsWatcher {
+	return &runsWatcher{
+		runsDir: runsDir,
+		bus:     bus,
+		stopCh:  make(chan struct{}),
+	}
+}
+
+// stop signals the watcher to halt. Safe to call multiple times.
+func (w *runsWatcher) stop() {
+	select {
+	case <-w.stopCh:
+	default:
+		close(w.stopCh)
+	}
+}
+
+// run is the main polling loop. Must be called in a goroutine.
+func (w *runsWatcher) run() {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	snapshot := make(map[runKey]runSnapshot)
+
+	for {
+		select {
+		case <-w.stopCh:
+			return
+		case <-ticker.C:
+			w.tick(snapshot)
+		}
+	}
+}
+
+func (w *runsWatcher) tick(snapshot map[runKey]runSnapshot) {
+	if w.runsDir == "" {
+		return
+	}
+
+	// Enumerate slug dirs.
+	slugEntries, err := os.ReadDir(w.runsDir)
+	if err != nil {
+		return
+	}
+
+	seen := make(map[runKey]bool)
+
+	for _, slugEntry := range slugEntries {
+		if !slugEntry.IsDir() {
+			continue
+		}
+		slug := slugEntry.Name()
+		slugDir := filepath.Join(w.runsDir, slug)
+
+		runEntries, err := os.ReadDir(slugDir)
+		if err != nil {
+			continue
+		}
+
+		for _, runEntry := range runEntries {
+			if !runEntry.IsDir() {
+				continue
+			}
+			runID := runEntry.Name()
+			key := runKey{slug: slug, runID: runID}
+			seen[key] = true
+
+			manifestPath := filepath.Join(slugDir, runID, "manifest.yaml")
+
+			prev, existed := snapshot[key]
+
+			// If terminal, only re-stat on mtime change (optimization).
+			if existed && isTerminalStatus(prev.status) {
+				fi, err := os.Stat(manifestPath)
+				if err != nil {
+					continue
+				}
+				if fi.ModTime().Equal(prev.mtime) {
+					continue
+				}
+				// mtime changed on a terminal run — unusual but update snapshot silently.
+				snapshot[key] = runSnapshot{status: prev.status, mtime: fi.ModTime(), startedAt: prev.startedAt}
+				continue
+			}
+
+			// Read and parse manifest.
+			fi, err := os.Stat(manifestPath)
+			if err != nil {
+				continue
+			}
+			if existed && fi.ModTime().Equal(prev.mtime) {
+				continue
+			}
+
+			m, err := parseManifest(manifestPath)
+			if err != nil {
+				continue
+			}
+
+			startedAt := ""
+			if !m.StartedAt.IsZero() {
+				startedAt = m.StartedAt.Format(time.RFC3339)
+			}
+
+			newSnap := runSnapshot{
+				status:    m.Status,
+				mtime:     fi.ModTime(),
+				startedAt: startedAt,
+			}
+
+			if !existed {
+				// New run — emit run:started if status is running.
+				snapshot[key] = newSnap
+				if m.Status == "running" {
+					w.bus.PublishGlobal(Event{
+						Type: EventRunStarted,
+						Payload: map[string]any{
+							"slug":       slug,
+							"run_id":     runID,
+							"started_at": startedAt,
+						},
+					})
+				}
+				continue
+			}
+
+			// Existing run — check for transition to terminal.
+			snapshot[key] = newSnap
+			if !isTerminalStatus(prev.status) && isTerminalStatus(m.Status) {
+				finishedAt := ""
+				if !m.FinishedAt.IsZero() {
+					finishedAt = m.FinishedAt.Format(time.RFC3339)
+				}
+				w.bus.PublishGlobal(Event{
+					Type: EventRunFinished,
+					Payload: map[string]any{
+						"slug":        slug,
+						"run_id":      runID,
+						"status":      m.Status,
+						"started_at":  startedAt,
+						"finished_at": finishedAt,
+					},
+				})
+			}
+		}
+	}
+	// Note: we don't emit events for deleted runs (run dirs are typically kept).
+}

--- a/internal/dash/runs_watcher_test.go
+++ b/internal/dash/runs_watcher_test.go
@@ -1,0 +1,97 @@
+package dash
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeSimpleManifest writes a minimal manifest.yaml for a run.
+func writeSimpleManifest(t *testing.T, runsDir, slug, runID, status string) {
+	t.Helper()
+	dir := filepath.Join(runsDir, slug, runID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	content := "run_id: " + runID + "\npipeline: " + slug + "\nstatus: " + status + "\nstarted_at: " + time.Now().UTC().Format(time.RFC3339) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "manifest.yaml"), []byte(content), 0o600); err != nil {
+		t.Fatalf("writeSimpleManifest %s/%s: %v", slug, runID, err)
+	}
+}
+
+// TestRunsWatcher_RunStarted verifies that a new manifest with status=running
+// emits a run:started event.
+func TestRunsWatcher_RunStarted(t *testing.T) {
+	runsDir := t.TempDir()
+	bus := NewBus(runsDir)
+	gCh, gCancel := bus.SubscribeGlobal()
+	defer gCancel()
+
+	w := newRunsWatcher(runsDir, bus)
+	snap := make(map[runKey]runSnapshot)
+
+	// No runs yet.
+	w.tick(snap)
+	select {
+	case ev := <-gCh:
+		t.Fatalf("expected no event on empty dir, got %+v", ev)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	// Create a running manifest.
+	writeSimpleManifest(t, runsDir, "my-pipeline", "abc123", "running")
+	w.tick(snap)
+
+	select {
+	case ev := <-gCh:
+		if ev.Type != EventRunStarted {
+			t.Fatalf("want run:started, got %s", ev.Type)
+		}
+		if ev.Payload["slug"] != "my-pipeline" {
+			t.Fatalf("want slug=my-pipeline, got %v", ev.Payload["slug"])
+		}
+		if ev.Payload["run_id"] != "abc123" {
+			t.Fatalf("want run_id=abc123, got %v", ev.Payload["run_id"])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for run:started")
+	}
+}
+
+// TestRunsWatcher_RunFinished verifies that a manifest that transitions to a
+// terminal status emits a run:finished event.
+func TestRunsWatcher_RunFinished(t *testing.T) {
+	runsDir := t.TempDir()
+	bus := NewBus(runsDir)
+	gCh, gCancel := bus.SubscribeGlobal()
+	defer gCancel()
+
+	w := newRunsWatcher(runsDir, bus)
+	snap := make(map[runKey]runSnapshot)
+
+	// Create running manifest.
+	writeSimpleManifest(t, runsDir, "pipe", "run1", "running")
+	w.tick(snap)
+	<-gCh // drain run:started
+
+	// Overwrite with terminal status.
+	time.Sleep(5 * time.Millisecond)
+	writeSimpleManifest(t, runsDir, "pipe", "run1", "done")
+	w.tick(snap)
+
+	select {
+	case ev := <-gCh:
+		if ev.Type != EventRunFinished {
+			t.Fatalf("want run:finished, got %s", ev.Type)
+		}
+		if ev.Payload["status"] != "done" {
+			t.Fatalf("want status=done, got %v", ev.Payload["status"])
+		}
+		if ev.Payload["run_id"] != "run1" {
+			t.Fatalf("want run_id=run1, got %v", ev.Payload["run_id"])
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for run:finished")
+	}
+}

--- a/internal/dash/sse.go
+++ b/internal/dash/sse.go
@@ -23,7 +23,9 @@ import (
 	"github.com/chichex/che/internal/runner"
 )
 
-const heartbeatInterval = 15 * time.Second
+// heartbeatInterval is the idle period between SSE heartbeat comments.
+// Declared as var so tests can shorten it without spawning a real ticker for 15s.
+var heartbeatInterval = 15 * time.Second
 
 // handleEvents returns an http.HandlerFunc for SSE per-run events.
 // runsDir is the base directory for run data (~/.che/runs).

--- a/internal/dash/sse_global.go
+++ b/internal/dash/sse_global.go
@@ -1,0 +1,58 @@
+// Package dash — sse_global.go: SSE handler for global events.
+//
+// GET /api/events
+//
+// Emits: pipeline:changed, run:started, run:finished
+// Heartbeat: `: heartbeat\n\n` every 15s when idle.
+// No snapshot/replay — frontend fetches current state on load.
+package dash
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// handleGlobalEvents returns an http.HandlerFunc for GET /api/events.
+// Subscribes to bus global channel and streams events to the client.
+func handleGlobalEvents(bus *Bus) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// SSE headers — same pattern as per-run handler (sse.go).
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("X-Accel-Buffering", "no")
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+			return
+		}
+
+		ch, cancel := bus.SubscribeGlobal()
+		defer cancel()
+
+		heartbeat := time.NewTicker(heartbeatInterval)
+		defer heartbeat.Stop()
+
+		ctx := r.Context()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+
+			case <-heartbeat.C:
+				fmt.Fprintf(w, ": heartbeat\n\n")
+				flusher.Flush()
+
+			case ev, more := <-ch:
+				if !more {
+					return
+				}
+				writeSSEEvent(w, ev)
+				flusher.Flush()
+				heartbeat.Reset(heartbeatInterval)
+			}
+		}
+	}
+}

--- a/internal/dash/sse_global_test.go
+++ b/internal/dash/sse_global_test.go
@@ -1,0 +1,87 @@
+package dash
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestGlobalSSE_Headers verifies that GET /api/events sets SSE headers.
+func TestGlobalSSE_Headers(t *testing.T) {
+	bus := NewBus(t.TempDir())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	req := httptest.NewRequest("GET", "/api/events", nil).WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	h := handleGlobalEvents(bus)
+	h(rr, req)
+
+	if ct := rr.Header().Get("Content-Type"); ct != "text/event-stream" {
+		t.Errorf("Content-Type: want text/event-stream, got %q", ct)
+	}
+	if cc := rr.Header().Get("Cache-Control"); cc != "no-cache" {
+		t.Errorf("Cache-Control: want no-cache, got %q", cc)
+	}
+}
+
+// TestGlobalSSE_EventForwarded verifies that an event published to the global
+// bus is forwarded to the SSE stream.
+func TestGlobalSSE_EventForwarded(t *testing.T) {
+	bus := NewBus(t.TempDir())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Millisecond)
+	defer cancel()
+
+	req := httptest.NewRequest("GET", "/api/events", nil).WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	// Publish a global event after a brief delay so the handler can subscribe first.
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		bus.PublishGlobal(Event{
+			Type:    EventRunStarted,
+			Payload: map[string]any{"slug": "test-pipe", "run_id": "r1"},
+		})
+	}()
+
+	h := handleGlobalEvents(bus)
+	h(rr, req)
+
+	body := rr.Body.String()
+	if !strings.Contains(body, "run:started") {
+		t.Errorf("expected run:started event in SSE output:\n%s", body)
+	}
+	if !strings.Contains(body, "test-pipe") {
+		t.Errorf("expected 'test-pipe' slug in SSE output:\n%s", body)
+	}
+}
+
+// TestGlobalSSE_Heartbeat verifies that the handler emits ": heartbeat" comments
+// when idle. Uses a shortened heartbeatInterval so the test doesn't take 15s.
+func TestGlobalSSE_Heartbeat(t *testing.T) {
+	orig := heartbeatInterval
+	heartbeatInterval = 20 * time.Millisecond
+	t.Cleanup(func() { heartbeatInterval = orig })
+
+	bus := NewBus(t.TempDir())
+
+	// Give enough time for at least one heartbeat tick.
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	req := httptest.NewRequest("GET", "/api/events", nil).WithContext(ctx)
+	rr := httptest.NewRecorder()
+
+	h := handleGlobalEvents(bus)
+	h(rr, req)
+
+	body := rr.Body.String()
+	if !strings.Contains(body, ": heartbeat") {
+		t.Errorf("expected heartbeat comment in SSE output:\n%s", body)
+	}
+}


### PR DESCRIPTION
Closes #125

Plan de implementación para #125: **Auto-refrescar rail y tabla de runs de che dash via SSE global**.

Archivo: `.harness/plans/125-auto-refrescar-rail-y-tabla-via-sse-global.md`

Este PR construye sobre `hs-plan/123` (#124, spec 3). Sigue la decisión arquitectural de spec 3 (bus + watchers in-dash, no patch al runner).

---

_PR generado por `/hs-plan`._
