### PR TITLE
fix(dash): guardar setRuns ante SSE de pipeline sin state

### DIFF
--- a/internal/dash/assets/dash.html
+++ b/internal/dash/assets/dash.html
@@ -1494,7 +1494,7 @@ const App = () => {
           const slug = "refactor-go";
           return {
             ...prev,
-            [slug]: prev[slug].map(r => {
+            [slug]: (prev[slug] || []).map(r => {
               if (r.id !== "7c2a91") return r;
               const steps = r.steps.map(s => ({ ...s,
                 status: s.status === "pending" || s.status === "running" ? "done" : s.status,
@@ -1519,7 +1519,7 @@ const App = () => {
       if (next.text.startsWith("validator: loop 3 verdict = accepted")) {
         setRuns(prev => ({
           ...prev,
-          "refactor-go": prev["refactor-go"].map(r => {
+          "refactor-go": (prev["refactor-go"] || []).map(r => {
             if (r.id !== "7c2a91") return r;
             const steps = [...r.steps];
             steps[2] = { ...steps[2], status: "done", exit_code: 0, duration_ms: 60000,
@@ -1533,7 +1533,7 @@ const App = () => {
       if (next.text.startsWith("ok  internal/runner/stream")) {
         setRuns(prev => ({
           ...prev,
-          "refactor-go": prev["refactor-go"].map(r => {
+          "refactor-go": (prev["refactor-go"] || []).map(r => {
             if (r.id !== "7c2a91") return r;
             const steps = [...r.steps];
             steps[3] = { ...steps[3], status: "done", exit_code: 0, duration_ms: 17000 };
@@ -1566,7 +1566,7 @@ const App = () => {
     // optimistic cancel
     setRuns(prev => ({
       ...prev,
-      [selectedSlug]: prev[selectedSlug].map(r =>
+      [selectedSlug]: (prev[selectedSlug] || []).map(r =>
         r.id === id ? { ...r, status: "cancelled", finished_at: new Date().toISOString() } : r)
     }));
     // start undo countdown
@@ -1588,7 +1588,7 @@ const App = () => {
     const id = toast.undoId;
     setRuns(prev => ({
       ...prev,
-      [selectedSlug]: prev[selectedSlug].map(r =>
+      [selectedSlug]: (prev[selectedSlug] || []).map(r =>
         r.id === id ? { ...r, status: "running", finished_at: null } : r)
     }));
     setToast(null);
@@ -1598,7 +1598,7 @@ const App = () => {
     if (!openRun) return;
     setRuns(prev => ({
       ...prev,
-      [selectedSlug]: prev[selectedSlug].map(r => {
+      [selectedSlug]: (prev[selectedSlug] || []).map(r => {
         if (r.id !== openRun.id) return r;
         const steps = r.steps.map(s => s.status === "paused" ? { ...s, status: "running" } : s);
         return { ...r, status: "running", steps };


### PR DESCRIPTION
## Resumen
Endurecer todos los `setRuns(prev => ...)` de `internal/dash/assets/dash.html` con el patrón `(prev[slug] || [])` para evitar el `TypeError: prev[slug].map is not a function` cuando llega un evento SSE (o el usuario interactúa) sobre un pipeline cuyo fetch de runs todavía no completó.

## Cambios
- `cancelRun` (L1567), `undoCancel` (L1589) y `resumeRun` (L1599) usan ahora `(prev[selectedSlug] || []).map(...)`.
- Los tres `setRuns` mock-only de la simulación de stream para `refactor-go` (L1493, L1520, L1534) usan `(prev["refactor-go"] || []).map(...)`.
- Los handlers SSE que ya estaban defensivos (L1395, L1433, L1623, L1636) quedan tal cual.

## Criterios cubiertos
- [x] Ningún `setRuns(prev => ...)` accede a `prev[slug]` ni `prev[selectedSlug]` sin el patrón `(... || [])`. Verificado con `grep -nE 'prev\[(slug|selectedSlug)\]\.(map|find)' internal/dash/assets/dash.html` → 0 matches.
- [x] Cancel, undoCancel y resumeRun ahora son no-ops naturales (`.map` sobre `[]`) cuando el fetch de runs no completó.
- [x] Mocks de `refactor-go` defensivos por consistencia.
- [x] `go build ./...` OK.
- [x] `go test ./internal/dash/...` OK.

## Notas de ejecución
- Smoke manual no ejecutado (no levanté el dash en browser); el cambio es un wrapper `|| []` puro y los tests del paquete pasan, así que la confianza viene del shape mecánico del fix + tests + grep de auditoría.

Closes #131
