### PR TITLE
feat(dash): POST /api/pipelines/:slug/runs + restaurar Run UI

### DIFF
--- a/EXEC_NOTES.md
+++ b/EXEC_NOTES.md
@@ -1,0 +1,39 @@
+# Notas de ejecucion · #130
+
+## Desviaciones respecto del plan
+
+### AC #1 del plan vs realidad del builtin
+El plan dice "POST /api/pipelines/che-funnel/runs con body vacio responde 201". Pero `internal/wizard/embedded/che-funnel.yaml` declara `input: text` en el primer step — el handler responde correctamente `400 {"error":"input requerido"}` ante body vacio. El happy-path "body vacio → 201" lo verifica el AC #1 de TestCreateRun_HappyPathNoInput, que usa un pipeline-fixture (`no-input-pipe`) creado con `input: none`. Para hacer la verificacion manual con `che-funnel` hay que pasar un body con `input`. Comportamiento es el correcto; la inconsistencia esta en el plan.
+
+### Headless runner: parallel synchronous executor, no extraccion de runStep
+El plan #1 propuso "extraer `runStepsHeadless` reusando la mecanica de `enterRunning`/`startStep`/`handleStepDone`". Esos handlers viven dentro de `tea.Cmd` con un canal `lineCh` por step y `runState` con cancel handles — extraerlos limpio era un refactor mas grande que el budget del risk #1 (~200 LOC). El path tomado:
+
+- Nuevo archivo `internal/runner/headless.go` que escribe los mismos artefactos en disco (manifest.yaml + step-NN.{stdout,stderr,result}.{log,yaml}) reusando `loadPipelineForRun`, `wizard.IsValid`, `initRunDir` (parametrizado via `initRunDirAt`), `initManifest`, `writeManifest`, `writeStepResult`, `closeManifest` y `spawnCmdFn`.
+- Step executor sincronico (`runStepHeadless`) que hace `cmd.Run()` blocking con multi-writer a archivo + buffer en memoria. Sin streaming hacia el caller (no lo necesitamos: el watcher de `runs_watcher.go` traduce los writes a SSE).
+- La TUI queda 100% intacta (no se toca `spawn.go`, `running.go`, `runner.go`).
+
+Total nuevo: `headless.go` ~260 LOC (con comentarios extensos en castellano siguiendo el estilo del repo). Bien debajo del threshold de split del plan.
+
+### Modal: error inline + pending state
+Se agrego un boton `pending` desactivado mientras la request esta en vuelo + estado `modalError` que renderea el `{"error":"..."}` del backend inline (no se cierra el modal en 400/404/409/500 — AC #8). No se cierra en 500, exactamente como pide el AC.
+
+### Shortcut `R`: skip cuando hay input focused
+El shortcut `R` no se dispara si el foco esta en un `INPUT`/`TEXTAREA`/contentEditable — evita que tipear "r" en el drawer de notes abra el modal. No estaba explicito en el AC pero es comportamiento esperado.
+
+## Riesgos residuales (de los riesgos del plan)
+
+1. **Lock se libera al terminar `Execute()`** — la version inicial dejaba el `runLock` activo hasta que el server reiniciaba (release solo en path de error del starter). Fixed: la interfaz `runStarter` ahora recibe `onDone func()` que el `runnerStarter` invoca via `defer` en la goroutine de `Execute()`. El handler pasa `func() { lock.release(slug) }`. Resultado: un segundo POST al mismo slug, despues de que termine el primero (cualquier status terminal), arranca sin 409. Tests: `TestCreateRun_LockReleasedOnExecuteDone` + `TestCreateRun_ConflictLockHeldByMemory` (sigue pasando: el mock `recordingStarter` ignora el callback, asi que el lock se mantiene retenido durante el test sync sin necesidad de simular el lifecycle del run).
+
+2. **`recentRunningWindow = 60s`** — hardcoded segun el nit del validator. TODO inline en `runs_create.go` apunta a #50 para reemplazarlo por el heartbeat real cuando aterrice.
+
+## Fix follow-up (post-feedback)
+
+- `RunModal` ahora deriva el shape de input desde `pipeline.steps[0].input` (string `text`/`issue`/`pr`/`url`/`file`/`none`) en lugar del objeto `pipeline.input.{kind,label,placeholder}` que la API nunca expuso. Asi `che-funnel` (declara `input: text` en step 0) arranca correctamente desde el dash con un campo de texto, y los pickers mock siguen apareciendo para `issue`/`pr`. Resuelve el feedback "el RunModal espera `pipeline.input` que no esta en la API".
+
+- `runStarter.Start` recibe `onDone func()` y el handler libera el lock al finalizar Execute() (ver punto 1).
+
+## Verificacion local
+
+- `go vet ./...` OK
+- `go test ./...` OK (todo el repo, no solo runner/dash)
+- Smoke manual del browser: NO ejecutado (este PR es draft; lo cubre el reviewer humano segun el AC final del plan).

--- a/internal/dash/assets/dash.html
+++ b/internal/dash/assets/dash.html
@@ -544,7 +544,7 @@ const PipelineDeletedState = () => (
 // Pipeline detail (runs history + Run button)
 // ─────────────────────────────────────────────────────────────────────
 
-const PipelineDetail = ({ pipeline, runs, onOpenRun, onResumeDraft, fadedRunIds }) => {
+const PipelineDetail = ({ pipeline, runs, onOpenRun, onRequestRun, onResumeDraft, fadedRunIds }) => {
   const list = runs[pipeline.slug] || [];
   const [pipelineStepIdx, setPipelineStepIdx] = useState(-1);
   useEffect(() => { setPipelineStepIdx(-1); }, [pipeline.slug]);
@@ -582,6 +582,13 @@ const PipelineDetail = ({ pipeline, runs, onOpenRun, onResumeDraft, fadedRunIds 
           </div>
           <p className="ink-2 text-[14px] max-w-[640px]">{pipeline.description}</p>
         </div>
+        <button
+          className="btn btn-primary"
+          onClick={onRequestRun}
+        >
+          Run pipeline
+          <span className="kbd" style={{borderColor:"rgba(255,255,255,0.25)",color:"rgba(255,255,255,0.7)",background:"transparent"}}>R</span>
+        </button>
       </div>
 
       {/* Steps stripe */}
@@ -1111,6 +1118,135 @@ const RunDetail = ({ pipeline, run, slug, runId, stream, onBack, onCancel, onRes
 };
 
 // ─────────────────────────────────────────────────────────────────────
+// Run modal
+// ─────────────────────────────────────────────────────────────────────
+
+// NOTE: MOCK_ISSUES / MOCK_PRS son datos placeholder. El picker pr/issue del
+// modal los muestra con disclaimer ("datos mock") hasta que aterricen los
+// endpoints /api/issues + /api/prs (fuera del scope de #130). El runner
+// igual recibe el string raw (ej. "#1284") y lo resuelve via gh — el modal
+// solo elige la referencia.
+const MOCK_ISSUES = [
+  { id: "#1284", title: "runner: context.Canceled bleeds into step error", labels: ["bug", "runner"], updated: "2h ago" },
+  { id: "#1281", title: "validator pauses but dash shows running", labels: ["bug", "dash"], updated: "5h ago" },
+  { id: "#1277", title: "docs/cli.md drift after flag rename", labels: ["docs"], updated: "1d ago" },
+  { id: "#1270", title: "add --resume to `che new` wizard", labels: ["enhancement", "wizard"], updated: "2d ago" },
+  { id: "#1264", title: "SSE heartbeat drops on macOS Sequoia", labels: ["bug", "dash"], updated: "4d ago" },
+];
+
+const MOCK_PRS = [
+  { id: "#1289", title: "runner: preserve context.Canceled semantics", author: "@mat", state: "open",  updated: "40m ago" },
+  { id: "#1287", title: "dash: validator history panel",              author: "@mat", state: "open",  updated: "3h ago" },
+  { id: "#1283", title: "manifest: add validator.history field",       author: "@nico", state: "open",  updated: "6h ago" },
+  { id: "#1278", title: "docs: regenerate cli.md from --help",         author: "@bot",  state: "draft", updated: "1d ago" },
+];
+
+const RunModal = ({ pipeline, onClose, onConfirm, error, pending }) => {
+  const [value, setValue] = useState("");
+  const ref = useRef(null);
+  useEffect(() => { ref.current && ref.current.focus(); }, []);
+  const needsInput = !!(pipeline.input && pipeline.input.kind && pipeline.input.kind !== "none");
+  const isMockPicker = needsInput && (pipeline.input.kind === "issue" || pipeline.input.kind === "pr");
+
+  const submit = (e) => {
+    e && e.preventDefault();
+    if (pending) return;
+    if (needsInput && !value.trim()) return;
+    onConfirm(value.trim());
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center"
+         style={{background:"rgba(20,20,24,0.35)"}}
+         onClick={pending ? undefined : onClose}>
+      <form
+        className="panel rounded-lg w-[480px] shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={submit}
+      >
+        <div className="px-5 py-4 border-b hairline">
+          <div className="text-[11px] uppercase tracking-wider ink-3 font-semibold mb-1">launch run</div>
+          <div className="mono text-[15px] ink font-semibold">{pipeline.name}</div>
+        </div>
+        <div className="px-5 py-5">
+          {isMockPicker ? (
+            <>
+              <div className="flex items-center gap-2 mb-1.5">
+                <span className="text-[12px] ink-2">{pipeline.input.label || (pipeline.input.kind === "issue" ? "Select an issue" : "Select a pull request")}</span>
+                <span className="badge mono" style={{padding:"0 6px",fontSize:10}}>input: {pipeline.input.kind}</span>
+                <span className="ml-auto text-[10.5px] ink-3 mono">datos mock</span>
+              </div>
+              <div className="border hairline rounded-md max-h-[260px] overflow-y-auto scroll-thin">
+                {(pipeline.input.kind === "issue" ? MOCK_ISSUES : MOCK_PRS).map(it => {
+                  const selected = value === it.id;
+                  return (
+                    <div
+                      key={it.id}
+                      className={"w-full flex items-stretch border-b hairline last:border-b-0 transition-colors " + (selected ? "bg-black/[0.04]" : "hover:bg-black/[0.02]")}
+                    >
+                      <button
+                        type="button"
+                        onClick={() => setValue(it.id)}
+                        className="flex-1 text-left px-3 py-2.5 flex items-center gap-3 min-w-0"
+                      >
+                        <span className={"mono text-[11.5px] shrink-0 w-14 " + (selected ? "ink font-semibold" : "ink-2")}>{it.id}</span>
+                        <span className="text-[12.5px] ink truncate flex-1">{it.title}</span>
+                        {it.labels && it.labels.map(l => (
+                          <span key={l} className="badge mono" style={{padding:"0 6px",fontSize:10}}>{l}</span>
+                        ))}
+                        {it.state && (
+                          <span className={"badge mono " + (it.state === "draft" ? "" : "badge-running")} style={{padding:"0 6px",fontSize:10}}>{it.state}</span>
+                        )}
+                        <span className="text-[10.5px] ink-3 mono shrink-0">{it.updated}</span>
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+              <div className="text-[11px] ink-3 mt-2">
+                Placeholder hasta que aterricen /api/issues + /api/prs. El runner recibe el id raw (<span className="mono">{value || "#…"}</span>) y lo resuelve via <span className="mono">gh {pipeline.input.kind} view</span>.
+              </div>
+            </>
+          ) : needsInput ? (
+            <>
+              <div className="flex items-center gap-2 mb-1.5">
+                <span className="text-[12px] ink-2">{pipeline.input.label || "Input"}</span>
+                <span className="badge mono" style={{padding:"0 6px",fontSize:10}}>input: {pipeline.input.kind}</span>
+              </div>
+              <input
+                ref={ref}
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                placeholder={pipeline.input.placeholder || ""}
+                className="w-full mono text-[13px] ink px-3 py-2 rounded border hairline outline-none focus:border-[var(--ink)]"
+              />
+              <div className="text-[11px] ink-3 mt-2">
+                El runner resuelve este valor en R1 · InputPrompt según el tipo <span className="mono">{pipeline.input.kind}</span>, y lo pasa al primer step como su input.
+              </div>
+            </>
+          ) : (
+            <div className="text-[13px] ink-2">
+              Sin input — Start run para arrancar el pipeline.
+            </div>
+          )}
+          {error && (
+            <div className="mt-3 text-[12.5px]" style={{color:"#c0392b"}} role="alert">
+              {error}
+            </div>
+          )}
+        </div>
+        <div className="px-5 py-3 border-t hairline flex items-center justify-end gap-2">
+          <button type="button" className="btn" onClick={onClose} disabled={pending}>Cancel</button>
+          <button type="submit" className="btn btn-primary" disabled={pending || (needsInput && !value.trim())}>
+            {pending ? "Starting…" : "Start run"}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+// ─────────────────────────────────────────────────────────────────────
 // Undo toast
 // ─────────────────────────────────────────────────────────────────────
 
@@ -1234,6 +1370,9 @@ const App = () => {
   const [selectedStepIdx, setSelectedStepIdx] = useState(0);
   const [toast, setToast] = useState(null);
   const [notesOpen, setNotesOpen] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalError, setModalError] = useState(null);
+  const [modalPending, setModalPending] = useState(false);
 
   const [streamLines, setStreamLines] = useState([]);
 
@@ -1551,15 +1690,60 @@ const App = () => {
   useEffect(() => {
     const onKey = (e) => {
       if (e.key === "Escape") {
-        if (notesOpen) setNotesOpen(false);
+        if (modalOpen && !modalPending) closeModal();
+        else if (notesOpen) setNotesOpen(false);
         else if (openRunId) setOpenRunId(null);
+      }
+      if (e.key.toLowerCase() === "r" && !modalOpen && !openRunId) {
+        // No interferir cuando el foco esta en un input/textarea: el usuario
+        // tipeando "r" en el drawer de notes no debe abrir el modal.
+        const tag = (e.target && e.target.tagName) || "";
+        if (tag === "INPUT" || tag === "TEXTAREA" || (e.target && e.target.isContentEditable)) return;
+        if (selectedPipeline && selectedPipeline.status === "ready") setModalOpen(true);
       }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [notesOpen, openRunId]);
+  }, [modalOpen, modalPending, notesOpen, openRunId, selectedPipeline]);
 
   // ── handlers ──────────────────────────────────────────────────────
+  const requestRun = () => { setModalError(null); setModalOpen(true); };
+  const closeModal = () => { setModalOpen(false); setModalError(null); setModalPending(false); };
+
+  const confirmRun = async (input) => {
+    if (!selectedSlug) return;
+    setModalError(null);
+    setModalPending(true);
+    try {
+      const body = input ? JSON.stringify({ input }) : null;
+      const res = await fetch("/api/pipelines/" + encodeURIComponent(selectedSlug) + "/runs", {
+        method: "POST",
+        headers: body ? { "Content-Type": "application/json" } : undefined,
+        body,
+      });
+      if (!res.ok) {
+        let errMsg = "Error " + res.status;
+        try {
+          const data = await res.json();
+          if (data && data.error) errMsg = data.error;
+        } catch (_) {}
+        setModalError(errMsg);
+        setModalPending(false);
+        return;
+      }
+      const data = await res.json();
+      setModalOpen(false);
+      setModalError(null);
+      setModalPending(false);
+      const newId = (data && data.run_id) || "(unknown)";
+      setToast({ message: "Run started · " + newId, remaining: 0, kind: "started" });
+      setTimeout(() => setToast(null), 2200);
+    } catch (e) {
+      setModalError((e && e.message) || "Error de red");
+      setModalPending(false);
+    }
+  };
+
   const cancelRun = () => {
     if (!openRun) return;
     const id = openRun.id;
@@ -1734,6 +1918,7 @@ const App = () => {
               pipeline={selectedPipeline}
               runs={runs}
               onOpenRun={(id) => { setOpenRunId(id); setSelectedStepIdx(0); setRunDetail(null); }}
+              onRequestRun={requestRun}
               onResumeDraft={() => alert("Prototype: would run `che new --resume " + selectedPipeline.slug + "` in the user's terminal.")}
               fadedRunIds={fadedSlugs}
             />
@@ -1751,6 +1936,16 @@ const App = () => {
       </button>
 
       <NotesDrawer open={notesOpen} onClose={() => setNotesOpen(false)} />
+
+      {modalOpen && selectedPipeline && (
+        <RunModal
+          pipeline={selectedPipeline}
+          onClose={closeModal}
+          onConfirm={confirmRun}
+          error={modalError}
+          pending={modalPending}
+        />
+      )}
 
       <UndoToast toast={toast} onUndo={toast?.undoId ? undoCancel : () => setToast(null)} />
     </div>

--- a/internal/dash/assets/dash.html
+++ b/internal/dash/assets/dash.html
@@ -1145,8 +1145,12 @@ const RunModal = ({ pipeline, onClose, onConfirm, error, pending }) => {
   const [value, setValue] = useState("");
   const ref = useRef(null);
   useEffect(() => { ref.current && ref.current.focus(); }, []);
-  const needsInput = !!(pipeline.input && pipeline.input.kind && pipeline.input.kind !== "none");
-  const isMockPicker = needsInput && (pipeline.input.kind === "issue" || pipeline.input.kind === "pr");
+  // El input shape se deriva de steps[0].input (la API ya lo expone como string).
+  // Trato vacio/missing como "none" — mismo criterio que runner.firstInputKind.
+  const firstStep = (pipeline.steps && pipeline.steps[0]) || null;
+  const inputKind = (firstStep && firstStep.input) ? firstStep.input : "none";
+  const needsInput = inputKind !== "none";
+  const isMockPicker = needsInput && (inputKind === "issue" || inputKind === "pr");
 
   const submit = (e) => {
     e && e.preventDefault();
@@ -1172,12 +1176,12 @@ const RunModal = ({ pipeline, onClose, onConfirm, error, pending }) => {
           {isMockPicker ? (
             <>
               <div className="flex items-center gap-2 mb-1.5">
-                <span className="text-[12px] ink-2">{pipeline.input.label || (pipeline.input.kind === "issue" ? "Select an issue" : "Select a pull request")}</span>
-                <span className="badge mono" style={{padding:"0 6px",fontSize:10}}>input: {pipeline.input.kind}</span>
+                <span className="text-[12px] ink-2">{inputKind === "issue" ? "Select an issue" : "Select a pull request"}</span>
+                <span className="badge mono" style={{padding:"0 6px",fontSize:10}}>input: {inputKind}</span>
                 <span className="ml-auto text-[10.5px] ink-3 mono">datos mock</span>
               </div>
               <div className="border hairline rounded-md max-h-[260px] overflow-y-auto scroll-thin">
-                {(pipeline.input.kind === "issue" ? MOCK_ISSUES : MOCK_PRS).map(it => {
+                {(inputKind === "issue" ? MOCK_ISSUES : MOCK_PRS).map(it => {
                   const selected = value === it.id;
                   return (
                     <div
@@ -1204,24 +1208,23 @@ const RunModal = ({ pipeline, onClose, onConfirm, error, pending }) => {
                 })}
               </div>
               <div className="text-[11px] ink-3 mt-2">
-                Placeholder hasta que aterricen /api/issues + /api/prs. El runner recibe el id raw (<span className="mono">{value || "#…"}</span>) y lo resuelve via <span className="mono">gh {pipeline.input.kind} view</span>.
+                Placeholder hasta que aterricen /api/issues + /api/prs. El runner recibe el id raw (<span className="mono">{value || "#…"}</span>) y lo resuelve via <span className="mono">gh {inputKind} view</span>.
               </div>
             </>
           ) : needsInput ? (
             <>
               <div className="flex items-center gap-2 mb-1.5">
-                <span className="text-[12px] ink-2">{pipeline.input.label || "Input"}</span>
-                <span className="badge mono" style={{padding:"0 6px",fontSize:10}}>input: {pipeline.input.kind}</span>
+                <span className="text-[12px] ink-2">Input</span>
+                <span className="badge mono" style={{padding:"0 6px",fontSize:10}}>input: {inputKind}</span>
               </div>
               <input
                 ref={ref}
                 value={value}
                 onChange={(e) => setValue(e.target.value)}
-                placeholder={pipeline.input.placeholder || ""}
                 className="w-full mono text-[13px] ink px-3 py-2 rounded border hairline outline-none focus:border-[var(--ink)]"
               />
               <div className="text-[11px] ink-3 mt-2">
-                El runner resuelve este valor en R1 · InputPrompt según el tipo <span className="mono">{pipeline.input.kind}</span>, y lo pasa al primer step como su input.
+                El runner resuelve este valor en R1 · InputPrompt según el tipo <span className="mono">{inputKind}</span>, y lo pasa al primer step como su input.
               </div>
             </>
           ) : (

--- a/internal/dash/dash.go
+++ b/internal/dash/dash.go
@@ -74,11 +74,17 @@ func Serve(ctx context.Context, opts Options) error {
 		rw.stop()
 	}()
 
+	// Run starter + lock — comparte estado entre handlers para que el POST
+	// /runs no pueda double-arrancar el mismo slug. runsRoot="" deja al
+	// runner usar ~/.che/runs (mismo path que la TUI).
+	starter := &runnerStarter{runsRoot: ""}
+	lock := newRunLock()
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", handleIndex)
 	mux.HandleFunc("/api/events", handleGlobalEvents(bus))
 	mux.HandleFunc("/api/pipelines", handleListPipelines(pipelinesDir, runsDir))
-	mux.HandleFunc("/api/pipelines/", dispatchPipelinesPrefix(pipelinesDir, runsDir, bus))
+	mux.HandleFunc("/api/pipelines/", dispatchPipelinesPrefix(pipelinesDir, runsDir, bus, starter, lock))
 
 	srv := &http.Server{
 		Handler:           mux,

--- a/internal/dash/runs.go
+++ b/internal/dash/runs.go
@@ -325,15 +325,17 @@ func writeJSONError(w http.ResponseWriter, code int, msg string) {
 // to sub-handlers based on path segments.
 //
 // Supported routes:
-//   /api/pipelines/<slug>                                  → pipeline detail (spec 1)
-//   /api/pipelines/<slug>/runs                             → list runs
-//   /api/pipelines/<slug>/runs/<runId>                     → get run
-//   /api/pipelines/<slug>/runs/<runId>/events              → SSE per-run stream (spec 3)
-//   /api/pipelines/<slug>/runs/<runId>/steps/<idx>/stdout  → get step stdout
+//   GET  /api/pipelines/<slug>                                  → pipeline detail (spec 1)
+//   GET  /api/pipelines/<slug>/runs                             → list runs
+//   POST /api/pipelines/<slug>/runs                             → start a new run
+//   GET  /api/pipelines/<slug>/runs/<runId>                     → get run
+//   GET  /api/pipelines/<slug>/runs/<runId>/events              → SSE per-run stream (spec 3)
+//   GET  /api/pipelines/<slug>/runs/<runId>/steps/<idx>/stdout  → get step stdout
 //
 // Any other pattern returns 404.
-func dispatchPipelinesPrefix(pipelinesDir, runsDir string, bus *Bus) http.HandlerFunc {
+func dispatchPipelinesPrefix(pipelinesDir, runsDir string, bus *Bus, starter runStarter, lock *runLock) http.HandlerFunc {
 	listRunsH := handleListRuns(runsDir)
+	createRunH := handleCreateRun(pipelinesDir, runsDir, starter, lock)
 	getRunH := handleGetRun(runsDir)
 	getStdoutH := handleGetStepStdout(runsDir)
 	getEventsH := handleEvents(runsDir, bus)
@@ -366,7 +368,12 @@ func dispatchPipelinesPrefix(pipelinesDir, runsDir string, bus *Bus) http.Handle
 				return
 			}
 			r2 := requestWithHeaders(r, map[string]string{hdrSlug: slug})
-			listRunsH(w, r2)
+			switch r.Method {
+			case http.MethodPost:
+				createRunH(w, r2)
+			default:
+				listRunsH(w, r2)
+			}
 
 		case 3:
 			// /api/pipelines/<slug>/runs/<runId>

--- a/internal/dash/runs_create.go
+++ b/internal/dash/runs_create.go
@@ -23,8 +23,13 @@ import (
 // — el impl real (`runnerStarter`) llama a `runner.StartHeadless` + corre
 // `Execute()` en goroutine; los tests pasan un mock que solo registra el
 // llamado y devuelve un runID determinista.
+//
+// onDone se invoca cuando Execute() termina (ok o fallo) — el handler lo usa
+// para liberar el lock por-slug y habilitar runs posteriores del mismo
+// pipeline dentro de la misma sesion del dash. Es opcional (nil OK): los
+// tests con mocks no necesitan simular el ciclo de vida del Execute.
 type runStarter interface {
-	Start(target, input string) (runID string, err error)
+	Start(target, input string, onDone func()) (runID string, err error)
 }
 
 // runnerStarter es el impl real del runStarter sobre internal/runner. El
@@ -40,13 +45,19 @@ type runnerStarter struct {
 // run-dir asi el caller puede responder 201 sin esperar a que el pipeline
 // termine. Errores de Execute() en la goroutine se logean con prefijo
 // [dash] (idem el resto del paquete) — el manifest queda como auditoria
-// en disco.
-func (s *runnerStarter) Start(target, input string) (string, error) {
+// en disco. onDone se invoca al final del Execute() (en defer asi tambien
+// corre si Execute panickea) para que el handler libere el lock por-slug.
+func (s *runnerStarter) Start(target, input string, onDone func()) (string, error) {
 	hr, err := runner.StartHeadless(target, input, s.runsRoot)
 	if err != nil {
 		return "", err
 	}
 	go func() {
+		defer func() {
+			if onDone != nil {
+				onDone()
+			}
+		}()
 		if err := hr.Execute(); err != nil {
 			log.Printf("[dash] run %s/%s execute: %v", filepath.Base(filepath.Dir(hr.RunDir)), hr.RunID, err)
 		}
@@ -241,7 +252,14 @@ func handleCreateRun(pipelinesDir, runsDir string, starter runStarter, lock *run
 			return
 		}
 
-		runID, err := starter.Start(target, body.Input)
+		// onDone libera el lock cuando Execute() del runner termina. Asi un
+		// segundo POST al mismo slug, despues de que el primer run cierre,
+		// puede arrancar sin esperar a que el server reinicie. Los tests
+		// con mocks (recordingStarter) pueden ignorar el callback para
+		// preservar el comportamiento "lock retenido durante el test".
+		slugCopy := slug
+		onDone := func() { lock.release(slugCopy) }
+		runID, err := starter.Start(target, body.Input, onDone)
 		if err != nil {
 			lock.release(slug)
 			log.Printf("[dash] starter.Start %s: %v", slug, err)

--- a/internal/dash/runs_create.go
+++ b/internal/dash/runs_create.go
@@ -1,0 +1,297 @@
+package dash
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/chichex/che/internal/runner"
+	"github.com/chichex/che/internal/wizard"
+	"gopkg.in/yaml.v3"
+)
+
+// runStarter es el contrato del backend que dispara un run nuevo. La interfaz
+// existe para que los handlers se puedan testear sin spawnear procesos reales
+// — el impl real (`runnerStarter`) llama a `runner.StartHeadless` + corre
+// `Execute()` en goroutine; los tests pasan un mock que solo registra el
+// llamado y devuelve un runID determinista.
+type runStarter interface {
+	Start(target, input string) (runID string, err error)
+}
+
+// runnerStarter es el impl real del runStarter sobre internal/runner. El
+// dash le pasa runsRoot opcional para overridear ~/.che/runs/<slug>/ (por
+// ahora siempre ""; lo dejamos preparado para sandboxing en tests
+// integrados o flags futuros).
+type runnerStarter struct {
+	runsRoot string
+}
+
+// Start carga el pipeline, persiste el manifest inicial y dispara la
+// ejecucion en background. Devuelve el runID apenas se materializa el
+// run-dir asi el caller puede responder 201 sin esperar a que el pipeline
+// termine. Errores de Execute() en la goroutine se logean con prefijo
+// [dash] (idem el resto del paquete) — el manifest queda como auditoria
+// en disco.
+func (s *runnerStarter) Start(target, input string) (string, error) {
+	hr, err := runner.StartHeadless(target, input, s.runsRoot)
+	if err != nil {
+		return "", err
+	}
+	go func() {
+		if err := hr.Execute(); err != nil {
+			log.Printf("[dash] run %s/%s execute: %v", filepath.Base(filepath.Dir(hr.RunDir)), hr.RunID, err)
+		}
+	}()
+	return hr.RunID, nil
+}
+
+// runLock es el lock por-slug en memoria que evita arrancar dos runs del
+// mismo pipeline al mismo tiempo desde el dash. La heuristica del manifest
+// reciente cubre el caso "TUI corriendo en otra terminal" (otro proceso —
+// el lock en memoria no lo ve); juntas, las dos cubren el 90% del caso
+// real hasta que aterrice el lock cross-process del epico #50.
+type runLock struct {
+	mu     sync.Mutex
+	active map[string]bool
+}
+
+func newRunLock() *runLock {
+	return &runLock{active: make(map[string]bool)}
+}
+
+// tryAcquire intenta tomar el lock del slug. Devuelve true si el slug
+// estaba libre y queda marcado como en curso; false si ya hay otro run del
+// mismo slug arrancando desde el dash.
+func (l *runLock) tryAcquire(slug string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.active[slug] {
+		return false
+	}
+	l.active[slug] = true
+	return true
+}
+
+// release libera el lock del slug. Solo se invoca en el path "no logre
+// arrancar el run" — si arrancamos OK, el lock se libera cuando el watcher
+// del runs-dir vea status terminal en el manifest (futuro). En la primera
+// pasada el lock por slug queda activo hasta que el server reinicie:
+// suficiente para evitar el double-click; el ciclo de vida cross-process
+// queda fuera de scope (#50).
+func (l *runLock) release(slug string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	delete(l.active, slug)
+}
+
+// recentRunningWindow es el TTL para considerar un manifest reciente con
+// status=running como "todavia en curso". TODO(#50): cuando aterrice el lock
+// con heartbeat se reemplaza por chequeo del heartbeat real.
+const recentRunningWindow = 60 * time.Second
+
+// hasRecentRunningManifest devuelve true si el slug tiene un run con
+// status=running cuyo started_at cae dentro de los ultimos recentRunningWindow.
+// Se invoca antes de tomar el lock para cubrir el caso del run lanzado desde
+// otro proceso (typicamente la TUI en otra terminal). Errores de IO se
+// tratan como "no hay manifest reciente" — best-effort: preferimos arrancar
+// el run a bloquearlo por un readdir roto.
+func hasRecentRunningManifest(runsDir, slug string, now time.Time) bool {
+	if runsDir == "" || slug == "" {
+		return false
+	}
+	slugDir := filepath.Join(runsDir, slug)
+	entries, err := os.ReadDir(slugDir)
+	if err != nil {
+		return false
+	}
+	type entry struct {
+		path      string
+		startedAt time.Time
+		status    string
+	}
+	var manifests []entry
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		mPath := filepath.Join(slugDir, e.Name(), "manifest.yaml")
+		data, err := os.ReadFile(mPath)
+		if err != nil {
+			continue
+		}
+		var m struct {
+			Status    string    `yaml:"status"`
+			StartedAt time.Time `yaml:"started_at"`
+		}
+		if err := yaml.Unmarshal(data, &m); err != nil {
+			continue
+		}
+		manifests = append(manifests, entry{path: mPath, startedAt: m.StartedAt, status: m.Status})
+	}
+	sort.SliceStable(manifests, func(i, j int) bool {
+		return manifests[i].startedAt.After(manifests[j].startedAt)
+	})
+	if len(manifests) == 0 {
+		return false
+	}
+	latest := manifests[0]
+	if latest.status != runner.ManifestStatusRunning {
+		return false
+	}
+	if latest.startedAt.IsZero() {
+		return false
+	}
+	return now.Sub(latest.startedAt) < recentRunningWindow
+}
+
+// loadPipelineForSlug busca un pipeline por slug: primero en disco
+// (pipelinesDir/<slug>.yaml), luego en wizard.Builtins(). Devuelve la
+// pipeline, el target que el runner espera ("<path>" o "builtin:<slug>"),
+// y found=false si no existe en ningun lado. Errores reales (IO, parse)
+// se logean igual que en el resto del dash.
+func loadPipelineForSlug(pipelinesDir, slug string) (p wizard.Pipeline, target string, found bool, err error) {
+	if pipelinesDir != "" {
+		path := filepath.Join(pipelinesDir, slug+".yaml")
+		loaded, lerr := wizard.Load(path)
+		if lerr == nil {
+			return loaded, path, true, nil
+		}
+		if !os.IsNotExist(lerr) {
+			return wizard.Pipeline{}, "", false, lerr
+		}
+	}
+	b, berr := wizard.BuiltinBySlug(slug)
+	if berr != nil {
+		return wizard.Pipeline{}, "", false, berr
+	}
+	if b == nil {
+		return wizard.Pipeline{}, "", false, nil
+	}
+	return b.Pipeline, "builtin:" + slug, true, nil
+}
+
+// createRunBody es el body JSON esperado por POST /api/pipelines/:slug/runs.
+// `input` es opcional; cuando steps[0].input != "none" y no llega valor,
+// devolvemos 400. Body vacio (Content-Length=0) tambien es valido y se
+// trata como "sin input" — el handler decide segun el kind del pipeline.
+type createRunBody struct {
+	Input string `json:"input"`
+}
+
+// createRunResponse es el wire shape de la respuesta 201. `url` ayuda a la
+// UI a navegar al run nuevo sin reconstruir la ruta.
+type createRunResponse struct {
+	RunID string `json:"run_id"`
+	URL   string `json:"url"`
+}
+
+// handleCreateRun devuelve el handler de POST /api/pipelines/:slug/runs.
+// El slug llega por header (puesto por el dispatcher antes de invocar el
+// handler — mismo mecanismo que listRunsH / getRunH).
+func handleCreateRun(pipelinesDir, runsDir string, starter runStarter, lock *runLock) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		slug := extractSlug(r)
+		if slug == "" {
+			writeJSONError(w, http.StatusNotFound, "pipeline not found")
+			return
+		}
+
+		// Validar slug + cargar pipeline (disk first, builtin fallback).
+		p, target, found, err := loadPipelineForSlug(pipelinesDir, slug)
+		if err != nil {
+			log.Printf("[dash] createRun load %s: %v", slug, err)
+			writeJSONError(w, http.StatusInternalServerError, "internal server error")
+			return
+		}
+		if !found {
+			writeJSONError(w, http.StatusNotFound, "pipeline not found")
+			return
+		}
+
+		// Parse del body — tolerante con body vacio (typ. che-funnel input=none).
+		body, perr := parseCreateRunBody(r)
+		if perr != nil {
+			writeJSONError(w, http.StatusBadRequest, "body invalido")
+			return
+		}
+
+		// Validacion del input segun el kind del primer step.
+		if requiresInput(p) && body.Input == "" {
+			writeJSONError(w, http.StatusBadRequest, "input requerido")
+			return
+		}
+
+		// 409 si hay run reciente con status=running (otro proceso —
+		// typically TUI) O si el lock en memoria del dash esta tomado.
+		if hasRecentRunningManifest(runsDir, slug, time.Now()) {
+			writeJSONError(w, http.StatusConflict, "pipeline ya en curso")
+			return
+		}
+		if !lock.tryAcquire(slug) {
+			writeJSONError(w, http.StatusConflict, "pipeline ya en curso")
+			return
+		}
+
+		runID, err := starter.Start(target, body.Input)
+		if err != nil {
+			lock.release(slug)
+			log.Printf("[dash] starter.Start %s: %v", slug, err)
+			writeJSONError(w, http.StatusInternalServerError, "no se pudo arrancar el run")
+			return
+		}
+
+		resp := createRunResponse{
+			RunID: runID,
+			URL:   fmt.Sprintf("/api/pipelines/%s/runs/%s", slug, runID),
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// parseCreateRunBody lee el JSON del request (Content-Length=0 OK), validando
+// que sea un objeto. Decoder.DisallowUnknownFields es laxo aca — si el
+// front-end manda campos extra futuros, mejor ignorarlos que romper.
+func parseCreateRunBody(r *http.Request) (createRunBody, error) {
+	var body createRunBody
+	if r.Body == nil {
+		return body, nil
+	}
+	defer r.Body.Close()
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		return body, err
+	}
+	if len(data) == 0 {
+		return body, nil
+	}
+	if err := json.Unmarshal(data, &body); err != nil {
+		return body, errors.New("invalid json")
+	}
+	return body, nil
+}
+
+// requiresInput devuelve true si el primer step del pipeline declara un
+// input distinto de "none" (o "" tratado como "none" — defensive, mismo
+// criterio que runner.firstInputKind). Step 0 es el unico que pide input
+// crudo del usuario; steps siguientes leen previous_output via runner.
+func requiresInput(p wizard.Pipeline) bool {
+	if len(p.Steps) == 0 {
+		return false
+	}
+	kind := p.Steps[0].Input
+	if kind == "" {
+		return false
+	}
+	return kind != wizard.InputNone
+}

--- a/internal/dash/runs_create_test.go
+++ b/internal/dash/runs_create_test.go
@@ -19,18 +19,23 @@ import (
 
 // recordingStarter es un runStarter de tests: registra cada Start y devuelve
 // un runID determinista. Sirve para los happy-paths (verificamos que el
-// handler llamo al starter con los argumentos esperados).
+// handler llamo al starter con los argumentos esperados). El callback
+// onDone se guarda para los tests que quieren simular "Execute() termino"
+// invocandolo manualmente; los demas lo ignoran y el lock queda retenido
+// durante la duracion del test (semantica original).
 type recordingStarter struct {
 	mu        sync.Mutex
 	calls     []struct{ target, input string }
+	dones     []func()
 	nextRunID string
 	err       error
 }
 
-func (s *recordingStarter) Start(target, input string) (string, error) {
+func (s *recordingStarter) Start(target, input string, onDone func()) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.calls = append(s.calls, struct{ target, input string }{target, input})
+	s.dones = append(s.dones, onDone)
 	if s.err != nil {
 		return "", s.err
 	}
@@ -41,7 +46,7 @@ func (s *recordingStarter) Start(target, input string) (string, error) {
 // rutas donde el resultado del Start no importa (ej. dispatcher routing).
 type noopStarter struct{}
 
-func (s *noopStarter) Start(_, _ string) (string, error) { return "noop-run", nil }
+func (s *noopStarter) Start(_, _ string, _ func()) (string, error) { return "noop-run", nil }
 
 // ── helpers ──────────────────────────────────────────────────────────────
 
@@ -316,6 +321,45 @@ func TestCreateRun_StarterErrorReleasesLock(t *testing.T) {
 	rr2 := postRun(t, dispatcher, "boom-pipe", nil)
 	if rr2.Code != http.StatusCreated {
 		t.Fatalf("retry: want 201, got %d body=%s", rr2.Code, rr2.Body.String())
+	}
+}
+
+// TestCreateRun_LockReleasedOnExecuteDone verifica el AC del fix: una vez
+// que Execute() termina (el starter invoca onDone), el lock por-slug queda
+// libre y un POST posterior puede arrancar un run nuevo. Sin esto, el
+// dash quedaba "atascado" en 409 hasta reiniciar el server.
+func TestCreateRun_LockReleasedOnExecuteDone(t *testing.T) {
+	pipelinesDir := t.TempDir()
+	runsDir := t.TempDir()
+	writeYAML(t, pipelinesDir, "loop-pipe", wizard.Pipeline{
+		Name:  "loop-pipe",
+		Steps: []wizard.Step{{Name: "single", CLI: "claude", Kind: "prompt", Input: wizard.InputNone}},
+	})
+	starter := &recordingStarter{nextRunID: "RUN-A"}
+	lock := newRunLock()
+	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, lock)
+
+	// Primer run arranca OK.
+	rr1 := postRun(t, dispatcher, "loop-pipe", nil)
+	if rr1.Code != http.StatusCreated {
+		t.Fatalf("first run: want 201, got %d body=%s", rr1.Code, rr1.Body.String())
+	}
+
+	// Simula "Execute() termino" invocando el onDone que el handler le paso al starter.
+	starter.mu.Lock()
+	if len(starter.dones) != 1 || starter.dones[0] == nil {
+		starter.mu.Unlock()
+		t.Fatalf("expected starter to receive onDone callback, got dones=%v", starter.dones)
+	}
+	done := starter.dones[0]
+	starter.mu.Unlock()
+	done()
+
+	// Lock liberado → segundo POST arranca, no devuelve 409.
+	starter.nextRunID = "RUN-B"
+	rr2 := postRun(t, dispatcher, "loop-pipe", nil)
+	if rr2.Code != http.StatusCreated {
+		t.Fatalf("second run after onDone: want 201, got %d body=%s", rr2.Code, rr2.Body.String())
 	}
 }
 

--- a/internal/dash/runs_create_test.go
+++ b/internal/dash/runs_create_test.go
@@ -1,0 +1,340 @@
+package dash
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chichex/che/internal/runner"
+	"github.com/chichex/che/internal/wizard"
+)
+
+// ── mocks ────────────────────────────────────────────────────────────────
+
+// recordingStarter es un runStarter de tests: registra cada Start y devuelve
+// un runID determinista. Sirve para los happy-paths (verificamos que el
+// handler llamo al starter con los argumentos esperados).
+type recordingStarter struct {
+	mu        sync.Mutex
+	calls     []struct{ target, input string }
+	nextRunID string
+	err       error
+}
+
+func (s *recordingStarter) Start(target, input string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, struct{ target, input string }{target, input})
+	if s.err != nil {
+		return "", s.err
+	}
+	return s.nextRunID, nil
+}
+
+// noopStarter es un starter que solo devuelve un runID fijo. Lo usamos en
+// rutas donde el resultado del Start no importa (ej. dispatcher routing).
+type noopStarter struct{}
+
+func (s *noopStarter) Start(_, _ string) (string, error) { return "noop-run", nil }
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+// postRun arma un POST contra el dispatcher con el body JSON dado y devuelve
+// el recorder. Cuando body es nil, no se envia Content-Type ni payload —
+// emula el `fetch POST` sin body que la UI dispara para pipelines input=none.
+func postRun(t *testing.T, dispatcher http.HandlerFunc, slug string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader *bytes.Reader
+	if body != nil {
+		data, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal body: %v", err)
+		}
+		reader = bytes.NewReader(data)
+	} else {
+		reader = bytes.NewReader(nil)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/pipelines/"+slug+"/runs", reader)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	rr := httptest.NewRecorder()
+	dispatcher(rr, req)
+	return rr
+}
+
+func decodeCreateRunResponse(t *testing.T, rr *httptest.ResponseRecorder) createRunResponse {
+	t.Helper()
+	var resp createRunResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response: %v body=%s", err, rr.Body.String())
+	}
+	return resp
+}
+
+func decodeErrorBody(t *testing.T, rr *httptest.ResponseRecorder) string {
+	t.Helper()
+	var body map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal error body: %v body=%s", err, rr.Body.String())
+	}
+	return body["error"]
+}
+
+// ── tests ────────────────────────────────────────────────────────────────
+
+// TestCreateRun_HappyPathNoInput cubre el AC #1: POST a un pipeline con
+// input=none responde 201 + runID + url, sin pasar body. El handler tiene
+// que llamar al starter con target derivado del slug (path en disco) e
+// input string vacio.
+func TestCreateRun_HappyPathNoInput(t *testing.T) {
+	pipelinesDir := t.TempDir()
+	runsDir := t.TempDir()
+	writeYAML(t, pipelinesDir, "no-input-pipe", wizard.Pipeline{
+		Name:  "no-input-pipe",
+		Steps: []wizard.Step{{Name: "single", CLI: "claude", Kind: "prompt", Input: wizard.InputNone}},
+	})
+	starter := &recordingStarter{nextRunID: "RUN-001"}
+	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
+
+	rr := postRun(t, dispatcher, "no-input-pipe", nil)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	resp := decodeCreateRunResponse(t, rr)
+	if resp.RunID != "RUN-001" {
+		t.Errorf("run_id: got %q want %q", resp.RunID, "RUN-001")
+	}
+	wantURL := "/api/pipelines/no-input-pipe/runs/RUN-001"
+	if resp.URL != wantURL {
+		t.Errorf("url: got %q want %q", resp.URL, wantURL)
+	}
+	if len(starter.calls) != 1 {
+		t.Fatalf("starter.calls: got %d want 1", len(starter.calls))
+	}
+	if !strings.HasSuffix(starter.calls[0].target, "no-input-pipe.yaml") {
+		t.Errorf("starter.target: got %q want suffix no-input-pipe.yaml", starter.calls[0].target)
+	}
+	if starter.calls[0].input != "" {
+		t.Errorf("starter.input: got %q want empty", starter.calls[0].input)
+	}
+}
+
+// TestCreateRun_HappyPathWithInput cubre el AC #2: POST con body
+// {"input":"foo"} propaga el input al starter.
+func TestCreateRun_HappyPathWithInput(t *testing.T) {
+	pipelinesDir := t.TempDir()
+	runsDir := t.TempDir()
+	writeYAML(t, pipelinesDir, "text-pipe", wizard.Pipeline{
+		Name:  "text-pipe",
+		Steps: []wizard.Step{{Name: "single", CLI: "claude", Kind: "prompt", Input: wizard.InputText}},
+	})
+	starter := &recordingStarter{nextRunID: "RUN-text"}
+	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
+
+	rr := postRun(t, dispatcher, "text-pipe", map[string]string{"input": "foo"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if len(starter.calls) != 1 || starter.calls[0].input != "foo" {
+		t.Errorf("starter.input: got %+v want input=foo", starter.calls)
+	}
+}
+
+// TestCreateRun_BuiltinSlug verifica que el handler resuelve slugs que
+// existen solo como builtin (sin .yaml en disco). target esperado:
+// "builtin:che-funnel". che-funnel declara input=text en su primer step
+// (segun internal/wizard/embedded/che-funnel.yaml), asi que mandamos
+// {"input": "..."} para satisfacer la validacion.
+func TestCreateRun_BuiltinSlug(t *testing.T) {
+	pipelinesDir := t.TempDir()
+	runsDir := t.TempDir()
+	starter := &recordingStarter{nextRunID: "RUN-builtin"}
+	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
+
+	rr := postRun(t, dispatcher, "che-funnel", map[string]string{"input": "una idea"})
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if len(starter.calls) != 1 || starter.calls[0].target != "builtin:che-funnel" {
+		t.Errorf("starter.target: got %+v want builtin:che-funnel", starter.calls)
+	}
+}
+
+// TestCreateRun_InputRequired cubre AC #3: POST a un pipeline con
+// input.kind != none sin body responde 400 con "input requerido".
+func TestCreateRun_InputRequired(t *testing.T) {
+	pipelinesDir := t.TempDir()
+	runsDir := t.TempDir()
+	writeYAML(t, pipelinesDir, "text-pipe", wizard.Pipeline{
+		Name:  "text-pipe",
+		Steps: []wizard.Step{{Name: "single", CLI: "claude", Kind: "prompt", Input: wizard.InputText}},
+	})
+	starter := &recordingStarter{}
+	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
+
+	rr := postRun(t, dispatcher, "text-pipe", nil)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if msg := decodeErrorBody(t, rr); msg != "input requerido" {
+		t.Errorf("error: got %q want 'input requerido'", msg)
+	}
+	if len(starter.calls) != 0 {
+		t.Errorf("starter no debio invocarse; calls=%+v", starter.calls)
+	}
+}
+
+// TestCreateRun_NotFound cubre AC #4: slug que no existe ni en disco ni en
+// builtins responde 404.
+func TestCreateRun_NotFound(t *testing.T) {
+	pipelinesDir := t.TempDir()
+	runsDir := t.TempDir()
+	starter := &recordingStarter{}
+	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
+
+	rr := postRun(t, dispatcher, "no-existe", nil)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("want 404, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if msg := decodeErrorBody(t, rr); msg != "pipeline not found" {
+		t.Errorf("error: got %q want 'pipeline not found'", msg)
+	}
+}
+
+// TestCreateRun_ConflictLockHeldByMemory verifica que el lock en memoria
+// rechaza un segundo POST mientras el primero todavia esta vivo.
+func TestCreateRun_ConflictLockHeldByMemory(t *testing.T) {
+	pipelinesDir := t.TempDir()
+	runsDir := t.TempDir()
+	writeYAML(t, pipelinesDir, "lock-pipe", wizard.Pipeline{
+		Name:  "lock-pipe",
+		Steps: []wizard.Step{{Name: "single", CLI: "claude", Kind: "prompt", Input: wizard.InputNone}},
+	})
+	starter := &recordingStarter{nextRunID: "RUN-lock"}
+	lock := newRunLock()
+	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, lock)
+
+	// Primer POST OK.
+	rr1 := postRun(t, dispatcher, "lock-pipe", nil)
+	if rr1.Code != http.StatusCreated {
+		t.Fatalf("primer POST: want 201, got %d", rr1.Code)
+	}
+
+	// Segundo POST con lock activo → 409.
+	rr2 := postRun(t, dispatcher, "lock-pipe", nil)
+	if rr2.Code != http.StatusConflict {
+		t.Fatalf("segundo POST: want 409, got %d body=%s", rr2.Code, rr2.Body.String())
+	}
+	if msg := decodeErrorBody(t, rr2); msg != "pipeline ya en curso" {
+		t.Errorf("error: got %q want 'pipeline ya en curso'", msg)
+	}
+}
+
+// TestCreateRun_ConflictRecentManifest cubre el caso "TUI corriendo en otra
+// pestana": hay un manifest del slug en disco con status=running y
+// started_at < 60s atras. El handler responde 409 ANTES de tomar el lock.
+func TestCreateRun_ConflictRecentManifest(t *testing.T) {
+	pipelinesDir := t.TempDir()
+	runsDir := t.TempDir()
+	writeYAML(t, pipelinesDir, "race-pipe", wizard.Pipeline{
+		Name:  "race-pipe",
+		Steps: []wizard.Step{{Name: "single", CLI: "claude", Kind: "prompt", Input: wizard.InputNone}},
+	})
+	// Manifest del run "ajeno" (TUI), iniciado hace 5s.
+	now := time.Now().Add(-5 * time.Second)
+	plantManifest(t, runsDir, "race-pipe", "tui-run", runner.Manifest{
+		RunID:     "tui-run",
+		Pipeline:  "race-pipe",
+		StartedAt: now,
+		Status:    runner.ManifestStatusRunning,
+	})
+	starter := &recordingStarter{}
+	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
+
+	rr := postRun(t, dispatcher, "race-pipe", nil)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("want 409, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if len(starter.calls) != 0 {
+		t.Errorf("starter no debio invocarse; calls=%+v", starter.calls)
+	}
+}
+
+// TestCreateRun_OldRunningManifestDoesNotBlock verifica que un manifest con
+// status=running pero started_at > 60s atras NO bloquea el run nuevo —
+// asumimos que es un huerfano (probable interrupcion previa).
+func TestCreateRun_OldRunningManifestDoesNotBlock(t *testing.T) {
+	pipelinesDir := t.TempDir()
+	runsDir := t.TempDir()
+	writeYAML(t, pipelinesDir, "stale-pipe", wizard.Pipeline{
+		Name:  "stale-pipe",
+		Steps: []wizard.Step{{Name: "single", CLI: "claude", Kind: "prompt", Input: wizard.InputNone}},
+	})
+	old := time.Now().Add(-10 * time.Minute)
+	plantManifest(t, runsDir, "stale-pipe", "old-run", runner.Manifest{
+		RunID: "old-run", Pipeline: "stale-pipe", StartedAt: old, Status: runner.ManifestStatusRunning,
+	})
+	starter := &recordingStarter{nextRunID: "RUN-fresh"}
+	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
+
+	rr := postRun(t, dispatcher, "stale-pipe", nil)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("want 201, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// TestCreateRun_StarterErrorReleasesLock cubre el error path: si el starter
+// devuelve error, el handler responde 500 y el lock queda libre para
+// reintentar.
+func TestCreateRun_StarterErrorReleasesLock(t *testing.T) {
+	pipelinesDir := t.TempDir()
+	runsDir := t.TempDir()
+	writeYAML(t, pipelinesDir, "boom-pipe", wizard.Pipeline{
+		Name:  "boom-pipe",
+		Steps: []wizard.Step{{Name: "single", CLI: "claude", Kind: "prompt", Input: wizard.InputNone}},
+	})
+	starter := &recordingStarter{err: errors.New("simulated")}
+	lock := newRunLock()
+	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, lock)
+
+	rr1 := postRun(t, dispatcher, "boom-pipe", nil)
+	if rr1.Code != http.StatusInternalServerError {
+		t.Fatalf("want 500, got %d body=%s", rr1.Code, rr1.Body.String())
+	}
+
+	// El lock debe estar libre — segundo POST consigue arrancar (con un
+	// starter feliz, intercambiamos el err por nil).
+	starter.err = nil
+	starter.nextRunID = "RUN-retry"
+	rr2 := postRun(t, dispatcher, "boom-pipe", nil)
+	if rr2.Code != http.StatusCreated {
+		t.Fatalf("retry: want 201, got %d body=%s", rr2.Code, rr2.Body.String())
+	}
+}
+
+// TestCreateRun_InvalidJSON cubre el 400 cuando el body no parsea como JSON.
+func TestCreateRun_InvalidJSON(t *testing.T) {
+	pipelinesDir := t.TempDir()
+	runsDir := t.TempDir()
+	writeYAML(t, pipelinesDir, "any-pipe", wizard.Pipeline{
+		Name:  "any-pipe",
+		Steps: []wizard.Step{{Name: "single", CLI: "claude", Kind: "prompt", Input: wizard.InputNone}},
+	})
+	starter := &recordingStarter{}
+	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/pipelines/any-pipe/runs", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	dispatcher(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/dash/runs_test.go
+++ b/internal/dash/runs_test.go
@@ -341,7 +341,7 @@ func TestDispatcherRouting(t *testing.T) {
 	// Plant stdout for step 0
 	plantStdoutLog(t, runsDir, "my-pipe", "run1", 0, "stdout content")
 
-	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir))
+	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), &noopStarter{}, newRunLock())
 
 	cases := []struct {
 		path           string

--- a/internal/runner/headless.go
+++ b/internal/runner/headless.go
@@ -1,0 +1,283 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/chichex/che/internal/wizard"
+)
+
+// HeadlessRun es el handle de un run iniciado en modo headless: el run-dir y
+// el manifest inicial ya estan en disco con status=running; los steps todavia
+// no se ejecutaron. El caller invoca Execute() (sincronico) para correr la
+// maquina de steps; el dash lo hace en una goroutine separada al server
+// para responder 201 con el RunID apenas StartHeadless retorna.
+//
+// El modo headless es una simplificacion deliberada del runner TUI: corre los
+// steps en serie, escribe los mismos artefactos en disco (manifest.yaml,
+// step-NN.stdout.log, step-NN.stderr.log, step-NN.result.yaml) y respeta el
+// schema del Manifest. NO soporta validator loops, retry, cancel ni
+// streaming hacia el caller — el flow de dash POST + SSE per-run no los
+// necesita (el watcher en runs_watcher.go traduce los writes a SSE).
+type HeadlessRun struct {
+	RunID  string
+	RunDir string
+
+	p       wizard.Pipeline
+	target  string
+	input   InputState
+	started time.Time
+	steps   []StepRun
+}
+
+// StartHeadless prepara un run headless: carga el pipeline desde target,
+// valida el shape (wizard.IsValid), crea el run-dir y persiste el manifest
+// inicial con status=running. Devuelve el handle listo para Execute().
+//
+// target acepta los mismos shapes que Run: "builtin:<slug>" o un path en
+// disco. inputValue es el valor crudo del input (equivalente a lo que R1
+// resuelve en la TUI); para pipelines con steps[0].input == "none" se
+// ignora. runsRoot overridea ~/.che/runs/<slug>/ cuando no esta vacio
+// (override de tests + opcional para el dash si queremos sandboxear).
+func StartHeadless(target, inputValue, runsRoot string) (*HeadlessRun, error) {
+	p, err := loadPipelineForRun(target)
+	if err != nil {
+		return nil, err
+	}
+	if verr := wizard.IsValid(p); verr != nil {
+		return nil, fmt.Errorf("runner: pipeline invalido: %w", verr)
+	}
+	return startHeadlessFromPipeline(p, target, inputValue, runsRoot)
+}
+
+// startHeadlessFromPipeline es el core de StartHeadless sin la validacion de
+// wizard.IsValid + el load del target. Lo usan los tests que quieren saltar
+// la deteccion de CLIs instalados (validate.go usa skills.Detect, dependent
+// del PATH del host) y construir un pipeline directamente con un CLI fake.
+func startHeadlessFromPipeline(p wizard.Pipeline, target, inputValue, runsRoot string) (*HeadlessRun, error) {
+	kind := firstInputKind(p)
+	is := InputState{Kind: kind}
+	if kind != wizard.InputNone {
+		is.Value = inputValue
+		is.ResolvedPayload = inputValue
+	}
+
+	id, runDir, err := initRunDirAt(p, runsRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	started := time.Now().UTC()
+	stepRuns := make([]StepRun, 0, len(p.Steps))
+	for i, ps := range p.Steps {
+		stepRuns = append(stepRuns, StepRun{
+			Idx:    i + 1,
+			Name:   ps.Name,
+			CLI:    ps.CLI,
+			Kind:   ps.Kind,
+			Status: StepStatusPending,
+		})
+	}
+
+	if _, err := initManifest(p, id, runDir, target, is.Kind, is.Value, started, stepRuns); err != nil {
+		return nil, err
+	}
+
+	return &HeadlessRun{
+		RunID:   id,
+		RunDir:  runDir,
+		p:       p,
+		target:  target,
+		input:   is,
+		started: started,
+		steps:   stepRuns,
+	}, nil
+}
+
+// Execute corre los steps del pipeline en serie. Bloquea hasta que termine
+// (done | failed). Errores fatales se reflejan en el manifest con status
+// terminal y se devuelven al caller (que en el dash los logea con prefijo
+// [dash]). Un recover() defensivo cierra el manifest como failed si algo
+// panickea durante la ejecucion — asi un crash deja el manifest auditado
+// en vez de huerfano con status=running.
+func (h *HeadlessRun) Execute() (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			_ = closeManifest(h.RunDir, h.baseManifest(), ManifestStatusFailed, h.steps)
+			err = fmt.Errorf("runner.headless: panic: %v", r)
+		}
+	}()
+
+	for i := range h.p.Steps {
+		step := h.p.Steps[i]
+		payload, perr := h.payloadForStep(i)
+		if perr != nil {
+			h.steps[i].StartedAt = time.Now()
+			h.steps[i].FinishedAt = time.Now()
+			h.steps[i].ExitCode = -1
+			h.steps[i].SpawnError = perr.Error()
+			h.steps[i].Status = StepStatusFailed
+			_ = closeManifest(h.RunDir, h.baseManifest(), ManifestStatusFailed, h.steps[:i+1])
+			return perr
+		}
+
+		h.steps[i].StartedAt = time.Now()
+		h.steps[i].Status = StepStatusRunning
+		_ = writeManifest(h.RunDir, h.runningSnapshot())
+
+		exitCode, stdout, _, spawnErr := runStepHeadless(step, payload, h.RunDir, i+1)
+		h.steps[i].FinishedAt = time.Now()
+		h.steps[i].ExitCode = exitCode
+		h.steps[i].SpawnError = spawnErr
+
+		_ = writeStepResult(h.RunDir, StepResult{
+			StepIdx:  i + 1,
+			StepName: step.Name,
+			ExitCode: exitCode,
+			Output:   stdout,
+		})
+
+		if spawnErr != "" || exitCode != 0 {
+			h.steps[i].Status = StepStatusFailed
+			_ = closeManifest(h.RunDir, h.baseManifest(), ManifestStatusFailed, h.steps[:i+1])
+			if spawnErr != "" {
+				return fmt.Errorf("step %d (%s): %s", i+1, step.Name, spawnErr)
+			}
+			return fmt.Errorf("step %d (%s) exit %d", i+1, step.Name, exitCode)
+		}
+
+		h.steps[i].Status = StepStatusDone
+	}
+
+	return closeManifest(h.RunDir, h.baseManifest(), ManifestStatusDone, h.steps)
+}
+
+// payloadForStep devuelve el stdin del subprocess para el step en idx
+// (0-based). Step 0 usa ResolvedPayload del input (R1 equivalente); steps
+// >= 1 leen el output del step anterior via readStepResult (mismo path que
+// resolvePayloadForStep en running.go).
+func (h *HeadlessRun) payloadForStep(idx int) (string, error) {
+	if idx == 0 {
+		return h.input.ResolvedPayload, nil
+	}
+	prev, err := readStepResult(h.RunDir, idx)
+	if err != nil {
+		return "", fmt.Errorf("previous_output step %d: %w", idx+1, err)
+	}
+	return prev.Output, nil
+}
+
+// baseManifest arma el header del Manifest que comparte todos los snapshots
+// del run. closeManifest le sobrescribe Status/FinishedAt + Steps al cerrar.
+func (h *HeadlessRun) baseManifest() Manifest {
+	return Manifest{
+		RunID:        h.RunID,
+		Pipeline:     h.p.Name,
+		StartedAt:    h.started,
+		PipelinePath: h.target,
+		InputKind:    h.input.Kind,
+		InputValue:   h.input.Value,
+	}
+}
+
+// runningSnapshot arma el shape "en curso" del manifest segun el estado vivo
+// de h.steps. Misma idea que manifestRunningSnapshot en running.go pero sin
+// depender del RunModel (que es TUI-specific).
+func (h *HeadlessRun) runningSnapshot() Manifest {
+	mf := h.baseManifest()
+	mf.Status = ManifestStatusRunning
+	mf.Steps = make([]ManifestStep, 0, len(h.steps))
+	for _, s := range h.steps {
+		mf.Steps = append(mf.Steps, ManifestStep{
+			Idx:        s.Idx,
+			Name:       s.Name,
+			CLI:        s.CLI,
+			Kind:       s.Kind,
+			Status:     string(s.Status),
+			ExitCode:   s.ExitCode,
+			StartedAt:  s.StartedAt,
+			FinishedAt: s.FinishedAt,
+			Error:      s.SpawnError,
+		})
+	}
+	return mf
+}
+
+// runStepHeadless ejecuta el subprocess de un step en modo blocking: arma el
+// cmd via spawnCmdFn (la misma factoria que usa la TUI, asi los tests
+// pueden seguir mockeandola), redirecciona stdout/stderr a archivos +
+// builders en memoria, y devuelve el resultado del Wait sincronicamente.
+//
+// La rama del exec.ExitError vs SpawnError sigue el mismo criterio que
+// stepDoneMsg en spawn.go: ExitCode "real" cuando el subprocess corrio y
+// salio no-cero; SpawnErr cuando el binario no se pudo arrancar o Wait
+// devolvio un error no-Exit.
+func runStepHeadless(step wizard.Step, payload, runDir string, idx int) (exitCode int, stdout, stderr, spawnErr string) {
+	cmd, err := spawnCmdFn(step, payload)
+	if err != nil {
+		return -1, "", "", err.Error()
+	}
+
+	stdoutPath := filepath.Join(runDir, fmt.Sprintf("step-%02d.stdout.log", idx))
+	stderrPath := filepath.Join(runDir, fmt.Sprintf("step-%02d.stderr.log", idx))
+
+	stdoutFile, ferr := os.OpenFile(stdoutPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if ferr != nil {
+		return -1, "", "", fmt.Sprintf("create stdout.log: %v", ferr)
+	}
+	defer stdoutFile.Close()
+
+	stderrFile, ferr := os.OpenFile(stderrPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if ferr != nil {
+		return -1, "", "", fmt.Sprintf("create stderr.log: %v", ferr)
+	}
+	defer stderrFile.Close()
+
+	var stdoutBuf, stderrBuf strings.Builder
+	cmd.Stdout = io.MultiWriter(stdoutFile, &stdoutBuf)
+	cmd.Stderr = io.MultiWriter(stderrFile, &stderrBuf)
+
+	runErr := cmd.Run()
+	_ = stdoutFile.Sync()
+	_ = stderrFile.Sync()
+
+	if runErr != nil {
+		var ee *exec.ExitError
+		if errors.As(runErr, &ee) {
+			return ee.ExitCode(), stdoutBuf.String(), stderrBuf.String(), ""
+		}
+		return -1, stdoutBuf.String(), stderrBuf.String(), runErr.Error()
+	}
+	return 0, stdoutBuf.String(), stderrBuf.String(), ""
+}
+
+// initRunDirAt es la version parametrizada de initRunDir. Cuando runsRoot
+// esta vacio, cae al default (~/.che/runs via runDirRootFn). El extra
+// parametro permite que el dash use un override sin tocar la variable
+// global swappable de tests.
+func initRunDirAt(p wizard.Pipeline, runsRoot string) (string, string, error) {
+	slug := wizard.Slug(p.Name)
+	if slug == "" {
+		slug = "pipeline"
+	}
+	root := runsRoot
+	if root == "" {
+		root = runDirRootFn()
+	}
+	slugDir := filepath.Join(root, slug)
+	if err := os.MkdirAll(slugDir, 0o700); err != nil {
+		return "", "", fmt.Errorf("mkdir %s: %w", slugDir, err)
+	}
+	_ = gcRunHistory(slugDir, runHistoryCap())
+	id, runDir := makeRunID(slugDir, nowFn())
+	if err := os.MkdirAll(runDir, 0o700); err != nil {
+		return "", "", fmt.Errorf("mkdir %s: %w", runDir, err)
+	}
+	return id, runDir, nil
+}

--- a/internal/runner/headless_test.go
+++ b/internal/runner/headless_test.go
@@ -1,0 +1,145 @@
+package runner
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chichex/che/internal/wizard"
+	"gopkg.in/yaml.v3"
+)
+
+// TestHeadless_SmokeManifestDone es el smoke test del nucleo headless segun
+// el AC del plan: un pipeline trivial con un solo step que ejecuta "echo
+// ok" debe dejar el manifest final con status=done y exit_code=0 para ese
+// step. Cubre el flow StartHeadless (via startHeadlessFromPipeline para
+// bypassear wizard.IsValid, que depende del PATH del host) + Execute +
+// closeManifest.
+//
+// Usamos un runsRoot bajo t.TempDir() para no tocar ~/.che. spawnCmdFn se
+// mockea con /bin/echo para no depender de un CLI real (mismo patron que
+// usan los tests de spawn.go).
+func TestHeadless_SmokeManifestDone(t *testing.T) {
+	prev := spawnCmdFn
+	t.Cleanup(func() { spawnCmdFn = prev })
+	spawnCmdFn = func(_ wizard.Step, _ string) (*exec.Cmd, error) {
+		return exec.Command("/bin/echo", "ok"), nil
+	}
+
+	runsRoot := t.TempDir()
+	p := wizard.Pipeline{
+		Name: "headless-smoke",
+		Steps: []wizard.Step{
+			{
+				Name:    "single",
+				CLI:     "echo",
+				Kind:    wizard.KindPrompt,
+				Input:   wizard.InputNone,
+				Content: "irrelevant",
+			},
+		},
+	}
+
+	hr, err := startHeadlessFromPipeline(p, "test:headless-smoke", "", runsRoot)
+	if err != nil {
+		t.Fatalf("startHeadlessFromPipeline: %v", err)
+	}
+	if hr.RunID == "" {
+		t.Fatal("RunID vacio")
+	}
+	if hr.RunDir == "" {
+		t.Fatal("RunDir vacio")
+	}
+
+	if err := hr.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	// Manifest final: status=done, 1 step con exit_code=0.
+	mPath := filepath.Join(hr.RunDir, "manifest.yaml")
+	data, err := os.ReadFile(mPath)
+	if err != nil {
+		t.Fatalf("read manifest.yaml: %v", err)
+	}
+	var m Manifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	if m.Status != ManifestStatusDone {
+		t.Errorf("manifest.status: got %q want %q", m.Status, ManifestStatusDone)
+	}
+	if len(m.Steps) != 1 {
+		t.Fatalf("manifest.steps len: got %d want 1", len(m.Steps))
+	}
+	if m.Steps[0].Status != string(StepStatusDone) {
+		t.Errorf("manifest.steps[0].status: got %q want %q", m.Steps[0].Status, StepStatusDone)
+	}
+	if m.Steps[0].ExitCode != 0 {
+		t.Errorf("manifest.steps[0].exit_code: got %d want 0", m.Steps[0].ExitCode)
+	}
+
+	// Smoke check del result.yaml: contiene "ok" en Output.
+	rPath := filepath.Join(hr.RunDir, "step-01.result.yaml")
+	rdata, err := os.ReadFile(rPath)
+	if err != nil {
+		t.Fatalf("read step-01.result.yaml: %v", err)
+	}
+	var r StepResult
+	if err := yaml.Unmarshal(rdata, &r); err != nil {
+		t.Fatalf("unmarshal result: %v", err)
+	}
+	if !strings.Contains(r.Output, "ok") {
+		t.Errorf("step result.output no contiene 'ok': %q", r.Output)
+	}
+
+	// El run-dir vive bajo runsRoot/<slug>/<runID>/.
+	wantPrefix := filepath.Join(runsRoot, wizard.Slug(p.Name))
+	if !strings.HasPrefix(hr.RunDir, wantPrefix) {
+		t.Errorf("RunDir no esta bajo runsRoot/<slug>: got %q want prefix %q", hr.RunDir, wantPrefix)
+	}
+}
+
+// TestHeadless_StepFailsClosesManifestFailed verifica que un step con exit
+// !=0 cierra el manifest con status=failed y devuelve error al caller. Es la
+// otra mitad del happy path: confirma que el branch terminal de Execute no
+// queda colgado en running.
+func TestHeadless_StepFailsClosesManifestFailed(t *testing.T) {
+	prev := spawnCmdFn
+	t.Cleanup(func() { spawnCmdFn = prev })
+	spawnCmdFn = func(_ wizard.Step, _ string) (*exec.Cmd, error) {
+		return exec.Command("/bin/sh", "-c", "exit 7"), nil
+	}
+
+	runsRoot := t.TempDir()
+	p := wizard.Pipeline{
+		Name: "headless-fail",
+		Steps: []wizard.Step{
+			{Name: "boom", CLI: "echo", Kind: wizard.KindPrompt, Input: wizard.InputNone, Content: "x"},
+		},
+	}
+	hr, err := startHeadlessFromPipeline(p, "test:headless-fail", "", runsRoot)
+	if err != nil {
+		t.Fatalf("startHeadlessFromPipeline: %v", err)
+	}
+	if err := hr.Execute(); err == nil {
+		t.Fatal("Execute: queria error de step exit !=0, got nil")
+	}
+
+	mPath := filepath.Join(hr.RunDir, "manifest.yaml")
+	data, err := os.ReadFile(mPath)
+	if err != nil {
+		t.Fatalf("read manifest.yaml: %v", err)
+	}
+	var m Manifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		t.Fatalf("unmarshal manifest: %v", err)
+	}
+	if m.Status != ManifestStatusFailed {
+		t.Errorf("manifest.status: got %q want %q", m.Status, ManifestStatusFailed)
+	}
+	if len(m.Steps) != 1 || m.Steps[0].ExitCode != 7 {
+		t.Errorf("manifest.steps: want 1 step con exit_code=7; got %+v", m.Steps)
+	}
+}


### PR DESCRIPTION
## Resumen
Habilita el lanzamiento de runs desde `che dash` agregando `POST /api/pipelines/:slug/runs`, restaurando la UI de Run pipeline (modal + boton + shortcut `R`) que `a6fcca9` removio, e introduciendo un modo headless en `internal/runner` que reusa los helpers existentes sin tocar la TUI.

## Cambios
- `internal/runner/headless.go` + test: `StartHeadless(target, input, runsRoot)` carga el pipeline, valida, crea el run-dir + manifest inicial; `(*HeadlessRun).Execute()` corre los steps en serie escribiendo `manifest.yaml` / `step-NN.{stdout,stderr,result}.{log,yaml}`. Reusa `loadPipelineForRun` / `wizard.IsValid` / `initRunDir` (parametrizado a `initRunDirAt`) / `initManifest` / `closeManifest` / `spawnCmdFn`. No toca `spawn.go`/`running.go`/`runner.go`.
- `internal/dash/runs_create.go` + test: interfaz `runStarter`, impl `runnerStarter` (Start → goroutine Execute), `runLock` por-slug, `hasRecentRunningManifest` (heuristica 60s), `handleCreateRun` (200 LOC con 10 casos cubiertos).
- `internal/dash/runs.go`: dispatcher case 2 router por metodo (GET → list, POST → create).
- `internal/dash/dash.go`: instancia `runnerStarter` + `runLock` y los pasa al dispatcher.
- `internal/dash/assets/dash.html`: restaura `RunModal` (con disclaimer "datos mock" para pickers pr/issue), boton "Run pipeline", shortcut `R` (skip cuando hay input focused), state `modalOpen`/`modalError`/`modalPending`, handlers `requestRun`/`closeModal`/`confirmRun` con `fetch POST` + error inline para 400/404/409/500.

## Criterios cubiertos
- [x] AC #1 body vacio → 201 (`TestCreateRun_HappyPathNoInput`)
- [x] AC #2 body con input propaga al runner (`TestCreateRun_HappyPathWithInput`)
- [x] AC #3 400 input requerido (`TestCreateRun_InputRequired`)
- [x] AC #4 404 slug inexistente (`TestCreateRun_NotFound`)
- [x] AC #5 409 manifest reciente / lock activo (`TestCreateRun_ConflictRecentManifest`, `TestCreateRun_ConflictLockHeldByMemory`)
- [x] AC #6 bus + SSE intactos (no se tocaron `bus.go`/`sse.go`/`sse_global.go`)
- [x] AC #7 boton + shortcut `R` con guard de pipeline ready
- [x] AC #8 errores inline en modal sin cerrarlo
- [x] AC #9 runs_test.go cubre 10 casos (happy paths + errores + 409 con lock + 409 con manifest + invalid JSON + starter error + manifest viejo no bloquea)
- [x] AC #10 runner_headless_test.go smoke con manifest=done
- [x] AC #11 go vet + go test ./internal/dash/... ./internal/runner/... OK
- [x] AC #12 handler hereda bind 127.0.0.1 de `Serve()`

## Notas de ejecucion
**Plan AC #1 inconsistencia:** el plan dice "POST a `che-funnel` con body vacio responde 201", pero `internal/wizard/embedded/che-funnel.yaml` declara `input: text` en el primer step — el handler responde 400 (correcto). El happy-path "body vacio → 201" lo verifica el test con un fixture `no-input-pipe`. Para verificacion manual con `che-funnel`, pasar body `{"input":"..."}`.

**Headless parallel a runStep:** el plan #1 propuso reusar la maquina `enterRunning`/`startStep`/`handleStepDone`. Esos handlers son `tea.Cmd`-coupled con `runState`/`lineCh` — extraerlos limpio salia del budget del risk #1 (~200 LOC). El path tomado: nuevo `runStepHeadless` sincronico con `cmd.Run()` blocking + multi-writer a archivo + buffer. La TUI queda 100% intacta. Total `headless.go` ~260 LOC (comentarios incluidos).

**Lock no se libera en happy-path:** `runLock` se libera solo si `starter.Start` falla. Cuando arranca OK, el lock queda activo hasta restart del server. Trade-off documentado en el plan; el reemplazo con heartbeat + watcher de status terminal queda para epico #50.

**Shortcut `R` con guard de foco:** ignora la tecla si el target es `INPUT`/`TEXTAREA`/contentEditable — evita que tipear "r" en el drawer de notes abra el modal.

**Smoke browser manual:** no ejecutado en este draft — lo cubre el reviewer humano (AC final del plan).

Closes #130
