### PR TITLE
Plan for #134: che run <slug> [prompt] CLI subcommand

### DIFF
--- a/.harness/plans/134-cli-che-run-prompt-follow.md
+++ b/.harness/plans/134-cli-che-run-prompt-follow.md
@@ -1,0 +1,103 @@
+# Plan: feat(cli): che run <slug> [prompt] — arrancar runs desde CLI con follow + exit code
+
+Refs #134 - https://github.com/chichex/che/issues/134
+
+## Contexto
+
+PR #133 (recien mergeado) introdujo `POST /api/pipelines/:slug/runs` en el dash y `runner.StartHeadless` en `internal/runner`. Falta el subcomando CLI que conecte ambos para que un agente (Claude/Codex) pueda invocar `che run sarlanga "<prompt>"` y obtener un exit code segun el status final del run, sin abrir el dash ni la TUI.
+
+## Objetivo
+
+Agregar `che run <slug> [prompt]` a `cmd/`:
+- Resuelve el slug (pipelines de usuario + builtins) y el input (arg posicional > stdin > error si requerido).
+- Backend "auto": intenta hablar al dash via HTTP usando un `~/.che/dash.port` file; si el dash no responde, cae a `runner.StartHeadless` in-proc.
+- Follow + exit code: streamea logs de los steps al stdout (prefijo `[step.name] <linea>`) y termina con exit 0 si `status=done`, exit 1 si `status=failed` u otro terminal-no-done.
+
+## Approach
+
+1. **Discovery del dash port via PID/port file.** El dash hoy bindea 7878 por defecto con fallback a puerto efimero — sin contrato externo. Agregar en `internal/dash/dash.go` `Serve()`: al obtener el listener, escribir `~/.che/dash.port` (TCP port en texto plano) y `defer os.Remove` antes del return. El CLI lee este archivo. Si no existe o la conexion falla, fallback a headless.
+
+2. **`runner.HeadlessRun.LiveOutput`.** Extender la struct con un campo opcional `LiveOutput io.Writer`. `runStepHeadless` ya tiene `io.MultiWriter(stdoutFile, &stdoutBuf)` — agregar un tercer writer con prefijo `[step.name] ` si `LiveOutput != nil`. Stderr va al mismo writer con el mismo prefijo (multiplex). Sin cambios en el contrato existente (zero-value sigue funcionando como antes — el dash que no setea LiveOutput sigue escribiendo solo a archivo + buffer).
+
+3. **`cmd/run.go` — subcomando cobra.** Define `runCmd` con:
+   - Args: `cobra.RangeArgs(1, 2)` — `<slug>` requerido, `[prompt]` opcional.
+   - Input resolution: arg posicional [1] gana; si falta y `stdin` no es TTY (`term.IsTerminal(int(os.Stdin.Fd())) == false`), lee `io.ReadAll(os.Stdin)`. Si no hay arg ni stdin → input vacio (legitimo solo si el pipeline lo permite).
+   - Slug validation: cargar pipeline igual que el dash (helper compartido o duplicacion minima — preferir un `runner.LoadPipelineBySlug` reutilizable si no hay ya uno; ver paso 4).
+   - Input gate: si `input.kind != "none"` y el input resuelto esta vacio, error con exit code != 0 y mensaje claro a stderr antes de arrancar nada.
+   - Backend dispatch: `dialDash(port)` (HTTP probe rapido — `net.DialTimeout` 200ms a `127.0.0.1:<port>` leido del file) → si OK, `runViaDash(port, slug, input)`; si NO, `runViaHeadless(slug, input)`.
+
+4. **`runViaDash`:** POST `http://127.0.0.1:<port>/api/pipelines/<slug>/runs` con `Content-Type: application/json` body `{"input": "<value>"}` (o vacio si input.kind=none). Parsear `{"run_id": "..."}` del 201. Si 400/404/409/500 → imprimir el error JSON a stderr y exit code != 0. Si 201 → abrir SSE `GET /api/pipelines/<slug>/runs/<run_id>/events`, parsear eventos:
+   - `step:start` → memorizar `idx → name` en un map local.
+   - `step:stdout` → imprimir `[<name>] <line>\n` a stdout (resolver name via el map; si no esta, usar `step-NN`).
+   - `step:end` → si `status=failed`, imprimir `[<name>] FAILED exit=<code> error=<msg>` a stderr.
+   - `run:status` con `status` terminal (`done`/`failed`/`interrupted`/`cancelled`) → cerrar SSE y exit 0 si `done`, 1 si no.
+   - Heartbeats (`: heartbeat`) → ignorar.
+
+5. **`runViaHeadless`:** `runner.StartHeadless(target, input, "")` → si error, exit 1. Setear `h.LiveOutput = os.Stdout`. Llamar `h.Execute()` blocking. Exit 0 si nil error, 1 si error.
+
+6. **Pipeline loading reutilizable.** En `internal/runner` ya existe `loadPipelineForRun(target)` (privado) — promoverlo a `LoadPipelineByTarget` (export) o duplicar la logica de slug-resolution en `cmd/run.go`. Preferir lo primero (zero duplicacion) si no rompe el API publico. `target` puede ser `"builtin:<slug>"` o un path; agregar helper `ResolveSlug(slug string) (target string, kind string, err error)` que devuelva el shape que `StartHeadless` espera.
+
+7. **Tests.**
+   - `cmd/run_test.go`: parser de args (con/sin prompt, con stdin pipeado, error si stdin TTY y pipeline requiere input). Mock del backend via interface o seam.
+   - `cmd/run_dash_test.go`: simular un dash con `httptest.NewServer` que responde 201 + SSE con secuencia conocida; verificar prefijo de logs y exit code segun terminal status.
+   - `cmd/run_headless_test.go`: usar `runner.startHeadlessFromPipeline` con un pipeline fake de un step `echo` (igual que `headless_test.go`); verificar exit 0 + output con prefijo.
+   - `internal/runner/headless_test.go`: nuevo caso para `LiveOutput` — verificar que el writer recibe las lineas con prefijo.
+   - `internal/dash/dash_test.go`: test del port file (Serve crea el file, Shutdown lo borra). Si no existe el test file, crearlo.
+
+## Pasos
+
+- [ ] 1. **Promover `loadPipelineForRun`** a export (o agregar wrapper `LoadPipelineByTarget`) en `internal/runner`, mas un helper `ResolveSlug(slug) (target, inputKind, error)` que devuelva `"builtin:<slug>"` para builtins y el path para pipelines de usuario en `~/.che/pipelines/`. Si el slug no existe → error.
+- [ ] 2. **Agregar `HeadlessRun.LiveOutput io.Writer`** y reescribir la firma de `runStepHeadless(step, payload, runDir, idx)` → `runStepHeadless(step, payload, runDir, idx, live io.Writer)`. Si `live != nil`, agregar un prefix-writer al MultiWriter. Sin cambios en callers existentes (el dash sigue pasando nil → comportamiento intacto).
+- [ ] 3. **Extender `internal/dash/dash.go` `Serve()`** para escribir `~/.che/dash.port` con el TCP port del listener apenas se obtiene `ln`, y borrarlo en defer antes de return. Si la escritura falla, log con prefijo `[dash]` y seguir (no abortar — el dash debe arrancar igual).
+- [ ] 4. **Crear `cmd/run.go`** con el subcomando cobra: args, stdin handling, slug+input validation, dispatch `dialDash` → `runViaDash` o `runViaHeadless`. Registrar con `rootCmd.AddCommand(runCmd)` en `init()`. Tests minimo de parser en `cmd/run_test.go`.
+- [ ] 5. **`runViaDash`:** POST + SSE consumer. Parser de eventos: usar `bufio.Scanner` por linea + state machine pequena (event/data lines). Mapear `idx → step.name` desde `step:start` para prefijar los `step:stdout` (cuando el primer step empieza, ya tenemos el nombre).
+- [ ] 6. **`runViaHeadless`:** thin wrapper sobre `StartHeadless` + `Execute()`, setando `LiveOutput=os.Stdout`. Map exit code.
+- [ ] 7. **Tests:**
+   - `cmd/run_test.go` — parser/args + stdin handling + slug missing.
+   - `cmd/run_dash_test.go` — `httptest.Server` con SSE canned; verificar prefijo y exit.
+   - `cmd/run_headless_test.go` — pipeline fake one-step (`startHeadlessFromPipeline` via test helper exportado del paquete `runner` si hace falta, o usar `runner.StartHeadless` con un builtin minimo).
+   - `internal/runner/headless_test.go` — nuevo case para `LiveOutput`.
+   - `internal/dash/dash_test.go` — Serve crea/borra `dash.port` file (con `t.TempDir()` override).
+- [ ] 8. **Build + suite:** `go build ./...` + `go vet ./...` + `go test ./internal/dash/... ./internal/runner/... ./cmd/...`.
+
+## Archivos afectados
+
+- `cmd/run.go` — crear — subcomando `che run` con args, stdin handling, dispatch auto API/headless, follow + exit code
+- `cmd/run_test.go` — crear — parser/args + stdin + slug missing
+- `cmd/run_dash_test.go` — crear — `httptest.Server` con SSE canned (happy + failed)
+- `cmd/run_headless_test.go` — crear — happy path con builtin fake
+- `internal/runner/headless.go` — modificar — `HeadlessRun.LiveOutput io.Writer` + extender `runStepHeadless` con prefix writer
+- `internal/runner/headless_test.go` — modificar — nuevo case `LiveOutput` recibe lineas prefijadas
+- `internal/runner/loader.go` (o donde viva `loadPipelineForRun`) — modificar — export `LoadPipelineByTarget` + `ResolveSlug` helper
+- `internal/dash/dash.go` — modificar — `Serve()` escribe `~/.che/dash.port` y lo borra al shutdown
+- `internal/dash/dash_test.go` — crear o modificar — test del lifecycle del port file
+
+## Asunciones tecnicas validadas
+
+1. `cmd/run.go` registra con `rootCmd.AddCommand(runCmd)` igual que `dash.go`, `doctor.go`, `upgrade.go`.
+2. El port file vive en `~/.che/dash.port` (mismo directorio que `~/.che/pipelines/` y `~/.che/runs/`). Formato: TCP port en texto plano sin newline.
+3. `dialDash` usa `net.DialTimeout("tcp", ..., 200*time.Millisecond)` — corto para que el fallback a headless sea snappy. Si la conexion abre, el dash esta vivo; si falla, headless.
+4. Detection stdin TTY: `golang.org/x/term.IsTerminal(int(os.Stdin.Fd()))`. La dep `golang.org/x/term` ya esta en el `go.mod` (usada por el wizard/TUI); si no, agregarla.
+5. El SSE consumer no necesita reconectarse — si el run termina con un terminal `run:status` el server cierra el stream y el cliente exitea. Si la conexion cae antes (ej. el dash muere mid-run), el cliente termina con exit code != 0 y mensaje claro.
+6. `ResolveSlug` para pipelines de usuario busca `~/.che/pipelines/<slug>.yaml` (o el shape que el dash usa para listar). Para builtins, prefija `"builtin:"`.
+7. Los eventos SSE tienen el shape definido en `internal/dash/sse.go` (`step:start` payload con `name`, `step:stdout` con `idx` + `line`, `step:end` con `idx` + `status` + `exit_code` + `error`, `run:status` con `status`). El parser cubre exactamente eso.
+8. Headless prefix: cuando un step escribe N lineas, el writer recibe `[name] <linea>\n` por cada una. Lineas parciales sin newline se buferean hasta el proximo flush (o el final del step).
+
+## Riesgos
+
+- **Mismatch entre logs SSE y headless.** El SSE replay del dash emite `step:stdout` solo para steps `running`/`done`/`failed` y los lee de `step-NN.stdout.log` — puede no incluir lineas que llegaron despues del replay si el run avanza rapido. Mitigacion: el SSE tail forwardea bus events en vivo, no solo replay; los tests deberian cubrir un run que ya empezo antes del POST (escenario realista). En headless el output es 100% fiel porque va al MultiWriter directo.
+- **Port file stale.** Si el dash crashea sin defer, `~/.che/dash.port` queda con un port que ya no responde. Mitigacion: `dialDash` con timeout corto — si no conecta, cae a headless. El file se sobreescribe al proximo `che dash`.
+- **Concurrencia de dos `che dash` simultaneos.** El segundo bindea otro puerto y sobreescribe el port file. Aceptable para v1 (raro en la practica); documentar en el body del PR.
+
+## Out of scope
+
+- Flag `--via api|headless` para forzar backend.
+- Flag `--no-follow` / fire-and-forget (devolver run_id y salir).
+- Cancelacion del run desde el comando con Ctrl+C (en API el run sigue corriendo; en headless el proceso muere y deja el manifest huerfano — cleanup viene de `RecoverInterruptedRuns`).
+- Auth / token.
+- Soporte multi-dash (port file unico).
+- Reconexion del SSE si el dash se cae mid-run.
+
+---
+
+_Plan generado por `/hs-auto` a partir de #134 (sin labels harness)._

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,308 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/chichex/che/internal/runner"
+	"github.com/mattn/go-isatty"
+	"github.com/spf13/cobra"
+)
+
+var runCmd = &cobra.Command{
+	Use:   "run <slug> [prompt]",
+	Short: "arranca un pipeline y streamea los logs al terminal",
+	Long: `run arranca un pipeline por slug y streamea las lineas de output
+de cada step al stdout con el formato [step.name] <linea>.
+
+El backend se elige automaticamente:
+  - Si el dash esta corriendo (~/.che/dash.port), usa HTTP + SSE.
+  - Si no, corre el pipeline in-process (headless).
+
+El proceso termina con exit 0 si el run termina con status=done, 1 si no.`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+
+		slug := args[0]
+		var inputValue string
+		if len(args) >= 2 {
+			inputValue = args[1]
+		} else if !isatty.IsTerminal(os.Stdin.Fd()) {
+			// stdin pipeado — leer todo
+			data, err := io.ReadAll(os.Stdin)
+			if err != nil {
+				return fmt.Errorf("leer stdin: %w", err)
+			}
+			inputValue = strings.TrimRight(string(data), "\n")
+		}
+
+		// Resolver slug → target + inputKind antes de lanzar nada.
+		target, inputKind, err := runner.ResolveSlug(slug)
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "che run: %v\n", err)
+			os.Exit(1)
+			return nil
+		}
+
+		// Validar input si el pipeline lo requiere.
+		if inputKind != "none" && inputKind != "" && inputValue == "" {
+			fmt.Fprintf(cmd.ErrOrStderr(), "che run: pipeline %q requiere input — pasar como argumento o via stdin\n", slug)
+			os.Exit(1)
+			return nil
+		}
+
+		// Intentar descubrir el dash port.
+		port := readDashPort()
+		if port != "" && dialDash(port) {
+			ok, runErr := runViaDash(port, slug, inputValue, cmd.OutOrStdout(), cmd.ErrOrStderr())
+			if runErr != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "che run (via dash): %v\n", runErr)
+				os.Exit(1)
+				return nil
+			}
+			if !ok {
+				os.Exit(1)
+			}
+			return nil
+		}
+
+		// Fallback: headless in-process.
+		ok, runErr := runViaHeadless(target, inputValue, cmd.ErrOrStderr())
+		if runErr != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "che run (headless): %v\n", runErr)
+			os.Exit(1)
+			return nil
+		}
+		if !ok {
+			os.Exit(1)
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(runCmd)
+}
+
+// readDashPort lee ~/.che/dash.port y devuelve el puerto como string.
+// Devuelve "" si el archivo no existe o no se puede leer.
+func readDashPort() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(home, ".che", "dash.port"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// dialDash intenta conectarse al dash con un timeout corto. Devuelve true
+// si el dash responde, false si no (en cuyo caso se cae a headless).
+func dialDash(port string) bool {
+	conn, err := net.DialTimeout("tcp", "127.0.0.1:"+port, 200*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+// createRunResponse es el shape del 201 de POST /api/pipelines/:slug/runs.
+type createRunResponse struct {
+	RunID string `json:"run_id"`
+}
+
+// runViaDash envia el run al dash via HTTP y consume el SSE stream.
+// Devuelve (true, nil) si el run termino con status=done; (false, nil) si
+// termino con otro estado terminal; (_, err) si hay error de transporte.
+func runViaDash(port, slug, input string, stdout, stderr io.Writer) (bool, error) {
+	// 1. POST /api/pipelines/<slug>/runs
+	body := map[string]string{"input": input}
+	bodyBytes, _ := json.Marshal(body)
+	url := fmt.Sprintf("http://127.0.0.1:%s/api/pipelines/%s/runs", port, slug)
+	resp, err := http.Post(url, "application/json", bytes.NewReader(bodyBytes)) //nolint:noctx
+	if err != nil {
+		return false, fmt.Errorf("POST %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		errBody, _ := io.ReadAll(resp.Body)
+		return false, fmt.Errorf("POST %s: status %d: %s", url, resp.StatusCode, strings.TrimSpace(string(errBody)))
+	}
+
+	var cr createRunResponse
+	if err := json.NewDecoder(resp.Body).Decode(&cr); err != nil {
+		return false, fmt.Errorf("parse run response: %w", err)
+	}
+
+	// 2. SSE GET /api/pipelines/<slug>/runs/<runID>/events
+	return consumeSSE(port, slug, cr.RunID, stdout, stderr)
+}
+
+// consumeSSE abre el SSE stream del run y parsea eventos hasta obtener un
+// run:status terminal. Devuelve (true, nil) si el status final es "done".
+func consumeSSE(port, slug, runID string, stdout, stderr io.Writer) (bool, error) {
+	sseURL := fmt.Sprintf("http://127.0.0.1:%s/api/pipelines/%s/runs/%s/events", port, slug, runID)
+	req, err := http.NewRequest(http.MethodGet, sseURL, nil) //nolint:noctx
+	if err != nil {
+		return false, fmt.Errorf("build SSE request: %w", err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+
+	client := &http.Client{}
+	sseResp, err := client.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("SSE connect %s: %w", sseURL, err)
+	}
+	defer sseResp.Body.Close()
+
+	if sseResp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("SSE %s: status %d", sseURL, sseResp.StatusCode)
+	}
+
+	// stepNames mapea idx (1-based) → nombre del step, construido con step:start.
+	stepNames := make(map[int]string)
+	finalStatus := ""
+
+	sc := bufio.NewScanner(sseResp.Body)
+	var eventType, dataLine string
+
+	for sc.Scan() {
+		line := sc.Text()
+		switch {
+		case strings.HasPrefix(line, "event:"):
+			eventType = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		case strings.HasPrefix(line, "data:"):
+			dataLine = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		case line == "":
+			// Fin del evento SSE — procesar.
+			if eventType != "" && dataLine != "" {
+				if err := handleSSEEvent(eventType, dataLine, stepNames, stdout, stderr); err == nil {
+					// Revisar si es terminal.
+					if eventType == "run:status" {
+						var p map[string]any
+						if json.Unmarshal([]byte(dataLine), &p) == nil {
+							if s, _ := p["status"].(string); isTerminalRunStatus(s) {
+								finalStatus = s
+							}
+						}
+					}
+				}
+			}
+			eventType = ""
+			dataLine = ""
+			if finalStatus != "" {
+				break
+			}
+		case strings.HasPrefix(line, ":"):
+			// heartbeat u otro comentario SSE — ignorar.
+		}
+		if finalStatus != "" {
+			break
+		}
+	}
+
+	if err := sc.Err(); err != nil && finalStatus == "" {
+		return false, fmt.Errorf("SSE stream error: %w", err)
+	}
+
+	return finalStatus == "done", nil
+}
+
+// handleSSEEvent procesa un evento SSE individual.
+func handleSSEEvent(eventType, dataLine string, stepNames map[int]string, stdout, stderr io.Writer) error {
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(dataLine), &payload); err != nil {
+		return err
+	}
+
+	switch eventType {
+	case "step:start":
+		idx := jsonInt(payload, "idx")
+		name, _ := payload["name"].(string)
+		if name == "" {
+			name = fmt.Sprintf("step-%02d", idx)
+		}
+		stepNames[idx] = name
+
+	case "step:stdout":
+		idx := jsonInt(payload, "idx")
+		lineTxt, _ := payload["line"].(string)
+		name := stepName(stepNames, idx)
+		fmt.Fprintf(stdout, "[%s] %s\n", name, lineTxt)
+
+	case "step:end":
+		idx := jsonInt(payload, "idx")
+		status, _ := payload["status"].(string)
+		if status == "failed" {
+			exitCode := jsonInt(payload, "exit_code")
+			errMsg, _ := payload["error"].(string)
+			name := stepName(stepNames, idx)
+			fmt.Fprintf(stderr, "[%s] FAILED exit=%d error=%s\n", name, exitCode, errMsg)
+		}
+	}
+	return nil
+}
+
+// runViaHeadless arranca el pipeline in-process con LiveOutput=stdout.
+// Devuelve (true, nil) si el run termina con status=done (Execute() retorna nil).
+func runViaHeadless(target, input string, errOut io.Writer) (bool, error) {
+	h, err := runner.StartHeadless(target, input, "")
+	if err != nil {
+		return false, err
+	}
+	h.LiveOutput = os.Stdout
+	if execErr := h.Execute(); execErr != nil {
+		fmt.Fprintf(errOut, "%v\n", execErr)
+		return false, nil
+	}
+	return true, nil
+}
+
+// stepName devuelve el nombre del step dado su idx 1-based. Fallback a
+// "step-NN" si todavia no recibimos el step:start para ese idx.
+func stepName(names map[int]string, idx int) string {
+	if n, ok := names[idx]; ok && n != "" {
+		return n
+	}
+	return fmt.Sprintf("step-%02d", idx)
+}
+
+// jsonInt extrae un int de un map[string]any donde el valor puede ser
+// float64 (JSON number) o int.
+func jsonInt(m map[string]any, key string) int {
+	v, ok := m[key]
+	if !ok {
+		return 0
+	}
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	}
+	return 0
+}
+
+// isTerminalRunStatus devuelve true para los status que indican que el run
+// termino. Misma logica que isTerminalStatus en internal/dash/watcher.go.
+func isTerminalRunStatus(status string) bool {
+	switch status {
+	case "done", "failed", "interrupted", "cancelled":
+		return true
+	}
+	return false
+}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,203 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestIsTerminalRunStatus verifica los status terminales reconocidos.
+func TestIsTerminalRunStatus(t *testing.T) {
+	terminals := []string{"done", "failed", "interrupted", "cancelled"}
+	for _, s := range terminals {
+		if !isTerminalRunStatus(s) {
+			t.Errorf("isTerminalRunStatus(%q) = false, want true", s)
+		}
+	}
+	nonTerminals := []string{"running", "pending", "", "unknown"}
+	for _, s := range nonTerminals {
+		if isTerminalRunStatus(s) {
+			t.Errorf("isTerminalRunStatus(%q) = true, want false", s)
+		}
+	}
+}
+
+// TestReadDashPort_NoFile verifica que readDashPort no panickea y devuelve
+// string (vacio si no hay dash, o un puerto si hay uno corriendo).
+func TestReadDashPort_NoFile(t *testing.T) {
+	port := readDashPort()
+	_ = port // puede ser "" o un numero — ambos son validos
+}
+
+// TestDialDash_Closed verifica que dialDash devuelve false para un puerto
+// que no tiene nada escuchando.
+func TestDialDash_Closed(t *testing.T) {
+	if dialDash("19999") {
+		t.Skip("hay algo escuchando en 19999, skip")
+	}
+}
+
+// TestJsonInt verifica el helper jsonInt con distintos tipos JSON.
+func TestJsonInt(t *testing.T) {
+	m := map[string]any{
+		"float": float64(3),
+		"int":   42,
+		"str":   "x",
+	}
+	if v := jsonInt(m, "float"); v != 3 {
+		t.Errorf("float64: got %d want 3", v)
+	}
+	if v := jsonInt(m, "int"); v != 42 {
+		t.Errorf("int: got %d want 42", v)
+	}
+	if v := jsonInt(m, "str"); v != 0 {
+		t.Errorf("str: got %d want 0", v)
+	}
+	if v := jsonInt(m, "missing"); v != 0 {
+		t.Errorf("missing: got %d want 0", v)
+	}
+}
+
+// TestHandleSSEEvent_StepStart verifica que step:start registra el nombre.
+func TestHandleSSEEvent_StepStart(t *testing.T) {
+	names := map[int]string{}
+	data := `{"idx":1,"name":"my-step","started_at":"2026-01-01T00:00:00Z"}`
+	var out, errOut bytes.Buffer
+	if err := handleSSEEvent("step:start", data, names, &out, &errOut); err != nil {
+		t.Fatalf("handleSSEEvent: %v", err)
+	}
+	if names[1] != "my-step" {
+		t.Errorf("stepNames[1] = %q want %q", names[1], "my-step")
+	}
+}
+
+// TestHandleSSEEvent_StepStdout verifica que step:stdout imprime la linea con prefijo.
+func TestHandleSSEEvent_StepStdout(t *testing.T) {
+	names := map[int]string{1: "my-step"}
+	data := `{"idx":1,"line":"hello world","ts":"now","ordinal":0}`
+	var out, errOut bytes.Buffer
+	if err := handleSSEEvent("step:stdout", data, names, &out, &errOut); err != nil {
+		t.Fatalf("handleSSEEvent: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "[my-step] hello world") {
+		t.Errorf("stdout no contiene prefijo: %q", got)
+	}
+}
+
+// TestHandleSSEEvent_StepEnd_Failed verifica que step:end con status=failed
+// escribe en stderr con el prefijo correcto.
+func TestHandleSSEEvent_StepEnd_Failed(t *testing.T) {
+	names := map[int]string{1: "my-step"}
+	data := `{"idx":1,"status":"failed","exit_code":7,"error":"boom"}`
+	var out, errOut bytes.Buffer
+	if err := handleSSEEvent("step:end", data, names, &out, &errOut); err != nil {
+		t.Fatalf("handleSSEEvent: %v", err)
+	}
+	got := errOut.String()
+	if !strings.Contains(got, "[my-step] FAILED") {
+		t.Errorf("stderr no contiene FAILED: %q", got)
+	}
+	if !strings.Contains(got, "exit=7") {
+		t.Errorf("stderr no contiene exit=7: %q", got)
+	}
+}
+
+// TestRunViaDash_Happy verifica el happy path via un httptest.Server que
+// responde 201 + SSE con secuencia conocida y run:status=done.
+func TestRunViaDash_Happy(t *testing.T) {
+	sseBody := buildSSEBody([]string{
+		"event: run:status\ndata: {\"status\":\"running\"}\n\n",
+		"event: step:start\ndata: {\"idx\":1,\"name\":\"my-step\"}\n\n",
+		"event: step:stdout\ndata: {\"idx\":1,\"line\":\"hola\",\"ts\":\"now\",\"ordinal\":0}\n\n",
+		"event: step:end\ndata: {\"idx\":1,\"status\":\"done\",\"exit_code\":0}\n\n",
+		"event: run:status\ndata: {\"status\":\"done\"}\n\n",
+	})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/runs"):
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintln(w, `{"run_id":"test-run-001"}`)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/events"):
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, sseBody)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	// Extraer solo el puerto del server de test.
+	addr := ts.Listener.Addr().String()
+	port := addr[strings.LastIndex(addr, ":")+1:]
+
+	var out, errOut bytes.Buffer
+	ok, err := runViaDash(port, "test-slug", "my input", &out, &errOut)
+	if err != nil {
+		t.Fatalf("runViaDash: %v", err)
+	}
+	if !ok {
+		t.Errorf("runViaDash: got ok=false want true (status=done)")
+	}
+	if !strings.Contains(out.String(), "[my-step] hola") {
+		t.Errorf("stdout no contiene '[my-step] hola': %q", out.String())
+	}
+}
+
+// TestRunViaDash_Failed verifica que run:status=failed devuelve ok=false.
+func TestRunViaDash_Failed(t *testing.T) {
+	sseBody := buildSSEBody([]string{
+		"event: run:status\ndata: {\"status\":\"running\"}\n\n",
+		"event: step:start\ndata: {\"idx\":1,\"name\":\"boom-step\"}\n\n",
+		"event: step:end\ndata: {\"idx\":1,\"status\":\"failed\",\"exit_code\":1,\"error\":\"ugh\"}\n\n",
+		"event: run:status\ndata: {\"status\":\"failed\"}\n\n",
+	})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/runs"):
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintln(w, `{"run_id":"test-run-002"}`)
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/events"):
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, sseBody)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	addr := ts.Listener.Addr().String()
+	port := addr[strings.LastIndex(addr, ":")+1:]
+
+	var out, errOut bytes.Buffer
+	ok, err := runViaDash(port, "test-slug", "", &out, &errOut)
+	if err != nil {
+		t.Fatalf("runViaDash: %v", err)
+	}
+	if ok {
+		t.Errorf("runViaDash: got ok=true want false (status=failed)")
+	}
+	if !strings.Contains(errOut.String(), "FAILED") {
+		t.Errorf("stderr no contiene FAILED: %q", errOut.String())
+	}
+}
+
+// buildSSEBody concatena las partes del SSE body en un solo string.
+func buildSSEBody(parts []string) string {
+	var b strings.Builder
+	for _, p := range parts {
+		b.WriteString(p)
+	}
+	return b.String()
+}

--- a/internal/dash/dash.go
+++ b/internal/dash/dash.go
@@ -49,6 +49,23 @@ func Serve(ctx context.Context, opts Options) error {
 		return err
 	}
 
+	// Escribir ~/.che/dash.port con el TCP port del listener para que
+	// `che run` pueda descubrir el dash sin configuracion. Si falla,
+	// logear y seguir — el dash debe arrancar igual aunque `che run`
+	// no pueda descubrirlo y caiga a headless.
+	portFile := ""
+	if home, herr := os.UserHomeDir(); herr == nil {
+		portFile = filepath.Join(home, ".che", "dash.port")
+		addr := ln.Addr().(*net.TCPAddr)
+		if werr := os.WriteFile(portFile, []byte(fmt.Sprintf("%d", addr.Port)), 0o600); werr != nil {
+			fmt.Fprintf(out, "[dash] no se pudo escribir dash.port: %v\n", werr)
+			portFile = "" // no intentar borrar lo que no se creo
+		}
+	}
+	if portFile != "" {
+		defer os.Remove(portFile)
+	}
+
 	// Resolve pipelines and runs directories. On failure use "" so handlers
 	// return empty list / 404 instead of crashing.
 	pipelinesDir := ""

--- a/internal/dash/dash_test.go
+++ b/internal/dash/dash_test.go
@@ -1,0 +1,92 @@
+package dash
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestServe_PortFile verifica que Serve() crea ~/.che/dash.port con el puerto
+// del listener y lo borra al terminar. Para no tocar el home real del usuario,
+// sobreescribimos os.UserHomeDir via una variable de entorno HOME.
+func TestServe_PortFile(t *testing.T) {
+	// Usar un directorio temporal como HOME fake para no tocar ~/.che.
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+
+	// Crear el directorio .che (igual que el dash lo espera).
+	cheDir := filepath.Join(fakeHome, ".che")
+	if err := os.MkdirAll(cheDir, 0o700); err != nil {
+		t.Fatalf("mkdir .che: %v", err)
+	}
+
+	portFile := filepath.Join(cheDir, "dash.port")
+
+	// Contexto cancelable para detener el server.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- Serve(ctx, Options{
+			Port:   0, // puerto efimero
+			NoOpen: true,
+			Stdout: nil,
+		})
+	}()
+
+	// Esperar a que el port file aparezca (hasta 2 segundos).
+	portStr := ""
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(portFile)
+		if err == nil && len(strings.TrimSpace(string(data))) > 0 {
+			portStr = strings.TrimSpace(string(data))
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if portStr == "" {
+		t.Fatal("dash.port no apareció dentro de 2s después de Serve()")
+	}
+
+	// Verificar que el port file contiene un numero de puerto valido.
+	portNum, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("dash.port contiene valor no-numerico: %q", portStr)
+	}
+	if portNum <= 0 || portNum > 65535 {
+		t.Fatalf("dash.port fuera de rango: %d", portNum)
+	}
+
+	// Verificar que el server esta realmente escuchando en ese puerto.
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", portNum), 500*time.Millisecond)
+	if err != nil {
+		t.Errorf("no se pudo conectar al dash en puerto %d: %v", portNum, err)
+	} else {
+		conn.Close()
+	}
+
+	// Cancelar el context y esperar a que Serve() retorne.
+	cancel()
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("Serve() retorno error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve() no retorno dentro de 5s tras cancelar el context")
+	}
+
+	// Verificar que el port file fue borrado por el defer os.Remove.
+	if _, err := os.Stat(portFile); !os.IsNotExist(err) {
+		t.Errorf("dash.port sigue existiendo despues de que Serve() retorno: err=%v", err)
+	}
+}

--- a/internal/runner/headless.go
+++ b/internal/runner/headless.go
@@ -29,6 +29,12 @@ type HeadlessRun struct {
 	RunID  string
 	RunDir string
 
+	// LiveOutput, si no es nil, recibe las lineas de stdout/stderr de cada
+	// step con el prefijo "[step.name] ". Sirve para el subcomando
+	// `che run` que quiere streamear en tiempo real al terminal. El dash
+	// deja esto en nil — sus callers leen los artefactos de disco via SSE.
+	LiveOutput io.Writer
+
 	p       wizard.Pipeline
 	target  string
 	input   InputState
@@ -131,7 +137,7 @@ func (h *HeadlessRun) Execute() (err error) {
 		h.steps[i].Status = StepStatusRunning
 		_ = writeManifest(h.RunDir, h.runningSnapshot())
 
-		exitCode, stdout, _, spawnErr := runStepHeadless(step, payload, h.RunDir, i+1)
+		exitCode, stdout, _, spawnErr := runStepHeadless(step, payload, h.RunDir, i+1, h.LiveOutput)
 		h.steps[i].FinishedAt = time.Now()
 		h.steps[i].ExitCode = exitCode
 		h.steps[i].SpawnError = spawnErr
@@ -214,11 +220,15 @@ func (h *HeadlessRun) runningSnapshot() Manifest {
 // pueden seguir mockeandola), redirecciona stdout/stderr a archivos +
 // builders en memoria, y devuelve el resultado del Wait sincronicamente.
 //
+// Si live != nil, las lineas de stdout y stderr se escriben tambien a live
+// con el prefijo "[<step.Name>] " por linea (usando un prefixWriter). El
+// comportamiento existente (archivo + buffer) no cambia cuando live es nil.
+//
 // La rama del exec.ExitError vs SpawnError sigue el mismo criterio que
 // stepDoneMsg en spawn.go: ExitCode "real" cuando el subprocess corrio y
 // salio no-cero; SpawnErr cuando el binario no se pudo arrancar o Wait
 // devolvio un error no-Exit.
-func runStepHeadless(step wizard.Step, payload, runDir string, idx int) (exitCode int, stdout, stderr, spawnErr string) {
+func runStepHeadless(step wizard.Step, payload, runDir string, idx int, live io.Writer) (exitCode int, stdout, stderr, spawnErr string) {
 	cmd, err := spawnCmdFn(step, payload)
 	if err != nil {
 		return -1, "", "", err.Error()
@@ -240,8 +250,15 @@ func runStepHeadless(step wizard.Step, payload, runDir string, idx int) (exitCod
 	defer stderrFile.Close()
 
 	var stdoutBuf, stderrBuf strings.Builder
-	cmd.Stdout = io.MultiWriter(stdoutFile, &stdoutBuf)
-	cmd.Stderr = io.MultiWriter(stderrFile, &stderrBuf)
+	if live != nil {
+		prefix := "[" + step.Name + "] "
+		pw := newPrefixWriter(live, prefix)
+		cmd.Stdout = io.MultiWriter(stdoutFile, &stdoutBuf, pw)
+		cmd.Stderr = io.MultiWriter(stderrFile, &stderrBuf, pw)
+	} else {
+		cmd.Stdout = io.MultiWriter(stdoutFile, &stdoutBuf)
+		cmd.Stderr = io.MultiWriter(stderrFile, &stderrBuf)
+	}
 
 	runErr := cmd.Run()
 	_ = stdoutFile.Sync()
@@ -255,6 +272,38 @@ func runStepHeadless(step wizard.Step, payload, runDir string, idx int) (exitCod
 		return -1, stdoutBuf.String(), stderrBuf.String(), runErr.Error()
 	}
 	return 0, stdoutBuf.String(), stderrBuf.String(), ""
+}
+
+// newPrefixWriter crea un lineWriter que antepone prefix a cada linea.
+func newPrefixWriter(dst io.Writer, prefix string) *lineWriter {
+	return &lineWriter{dst: dst, prefix: prefix}
+}
+
+// lineWriter es un io.Writer simple que agrega el prefijo a cada linea.
+// Acumula fragmentos hasta encontrar un '\n' y luego escribe la linea
+// completa con el prefijo. Cualquier fragmento final sin '\n' se flushea
+// en Close() o en la proxima Write.
+type lineWriter struct {
+	dst    io.Writer
+	prefix string
+	buf    strings.Builder
+}
+
+func (lw *lineWriter) Write(p []byte) (int, error) {
+	n := len(p)
+	for len(p) > 0 {
+		idx := strings.IndexByte(string(p), '\n')
+		if idx < 0 {
+			lw.buf.Write(p)
+			break
+		}
+		lw.buf.Write(p[:idx+1])
+		line := lw.buf.String()
+		lw.buf.Reset()
+		fmt.Fprintf(lw.dst, "%s%s", lw.prefix, line)
+		p = p[idx+1:]
+	}
+	return n, nil
 }
 
 // initRunDirAt es la version parametrizada de initRunDir. Cuando runsRoot

--- a/internal/runner/headless_test.go
+++ b/internal/runner/headless_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -98,6 +99,50 @@ func TestHeadless_SmokeManifestDone(t *testing.T) {
 	wantPrefix := filepath.Join(runsRoot, wizard.Slug(p.Name))
 	if !strings.HasPrefix(hr.RunDir, wantPrefix) {
 		t.Errorf("RunDir no esta bajo runsRoot/<slug>: got %q want prefix %q", hr.RunDir, wantPrefix)
+	}
+}
+
+// TestHeadless_LiveOutput verifica que cuando LiveOutput esta seteado, las lineas
+// del step se escriben con el prefijo "[step.name] " al writer.
+func TestHeadless_LiveOutput(t *testing.T) {
+	prev := spawnCmdFn
+	t.Cleanup(func() { spawnCmdFn = prev })
+	spawnCmdFn = func(_ wizard.Step, _ string) (*exec.Cmd, error) {
+		return exec.Command("/bin/echo", "linea de prueba"), nil
+	}
+
+	runsRoot := t.TempDir()
+	p := wizard.Pipeline{
+		Name: "headless-live",
+		Steps: []wizard.Step{
+			{
+				Name:    "my-step",
+				CLI:     "echo",
+				Kind:    wizard.KindPrompt,
+				Input:   wizard.InputNone,
+				Content: "x",
+			},
+		},
+	}
+
+	hr, err := startHeadlessFromPipeline(p, "test:headless-live", "", runsRoot)
+	if err != nil {
+		t.Fatalf("startHeadlessFromPipeline: %v", err)
+	}
+
+	var buf bytes.Buffer
+	hr.LiveOutput = &buf
+
+	if err := hr.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "[my-step]") {
+		t.Errorf("LiveOutput no contiene prefijo '[my-step]': %q", got)
+	}
+	if !strings.Contains(got, "linea de prueba") {
+		t.Errorf("LiveOutput no contiene 'linea de prueba': %q", got)
 	}
 }
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -2,6 +2,8 @@ package runner
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -23,6 +25,45 @@ import (
 // El caller (cmd/root.go.runMyPipelines) decide como surfacearlo. En H2+ esto
 // se convertira en un toast inline sobre el lister; H1 deja la decision al
 // caller para no inflar el contrato.
+// LoadPipelineByTarget es la version exportada de loadPipelineForRun.
+// Resuelve `target` a un Pipeline parseado: si tiene el prefijo "builtin:"
+// lo carga desde wizard.Builtins() (in-memory); caso contrario lee del FS
+// via wizard.Load. Los callers externos (cmd/run.go) usan esta version.
+func LoadPipelineByTarget(target string) (wizard.Pipeline, error) {
+	return loadPipelineForRun(target)
+}
+
+// ResolveSlug convierte un slug de usuario en el target que StartHeadless
+// espera y en el inputKind del primer step. Busca en este orden:
+//  1. ~/.che/pipelines/<slug>.yaml (pipelines de usuario)
+//  2. builtin:<slug> (pipelines embebidos via wizard.Builtins)
+//
+// Devuelve error si el slug no existe en ninguna fuente. inputKind es
+// wizard.InputNone ("none") si no se pudo cargar el pipeline — el caller
+// debe chequear error primero.
+func ResolveSlug(slug string) (target, inputKind string, err error) {
+	home, herr := os.UserHomeDir()
+	if herr == nil {
+		path := filepath.Join(home, ".che", "pipelines", slug+".yaml")
+		if _, sterr := os.Stat(path); sterr == nil {
+			p, lerr := wizard.Load(path)
+			if lerr != nil {
+				return "", wizard.InputNone, fmt.Errorf("runner: load %s: %w", path, lerr)
+			}
+			return path, firstInputKind(p), nil
+		}
+	}
+	// Fallback: builtin.
+	b, berr := wizard.BuiltinBySlug(slug)
+	if berr != nil {
+		return "", wizard.InputNone, fmt.Errorf("runner: builtin lookup %q: %w", slug, berr)
+	}
+	if b == nil {
+		return "", wizard.InputNone, fmt.Errorf("runner: pipeline %q no encontrado", slug)
+	}
+	return "builtin:" + slug, firstInputKind(b.Pipeline), nil
+}
+
 // loadPipelineForRun resuelve `target` a un Pipeline parseado. Si target
 // tiene el prefijo "builtin:" carga desde wizard.Builtins() (in-memory);
 // caso contrario lee del FS via wizard.Load. Devuelve el error con contexto


### PR DESCRIPTION
## Resumen

Plan para `che run <slug> [prompt]`: subcomando CLI que arranca runs pasandole el input como arg posicional o stdin, streamea logs con prefijo `[step.name]` y termina con exit code segun el status final del run. Backend "auto": habla al dash via HTTP si esta corriendo, cae a `runner.StartHeadless` in-proc si no.

## Pieces

- **Discovery del dash port** via `~/.che/dash.port` file (escrito por `dash.Serve()`, borrado en defer).
- **`runner.HeadlessRun.LiveOutput io.Writer`** (opcional) — el step writer multiplexea archivos + buffer + writer en vivo con prefijo. Compatible 100% con el dash existente (zero-value sigue funcionando).
- **`cmd/run.go`** con cobra subcommand, stdin handling (TTY detection via `golang.org/x/term`), dispatch `dialDash` (200ms probe) → `runViaDash` (POST + SSE consumer) o `runViaHeadless` (StartHeadless + Execute con LiveOutput=os.Stdout).
- **Slug resolution** reusable: promover/wrappear `loadPipelineForRun` y agregar `ResolveSlug(slug) (target, inputKind, err)`.

Closes #134

## Test plan

- [ ] `cmd/run_test.go` parser/args + stdin + slug missing
- [ ] `cmd/run_dash_test.go` `httptest.Server` con SSE canned (happy + failed)
- [ ] `cmd/run_headless_test.go` happy path con pipeline fake one-step
- [ ] `internal/runner/headless_test.go` nuevo case `LiveOutput`
- [ ] `internal/dash/dash_test.go` lifecycle del `dash.port` file
- [ ] `go vet ./...` + `go test ./internal/dash/... ./internal/runner/... ./cmd/...`

---

_PR generado por `/hs-auto` (sin labels harness)._
