### PR TITLE
TUI: mostrar versión en ejecución

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,7 @@ var rootCmd = &cobra.Command{
 		// esc desde el listado de skills) re-entran al menu principal. Las
 		// que piden exit total (q/ctrl+c) cortan el loop.
 		for {
-			action, err := tui.Run()
+			action, err := tui.Run(Version)
 			if err != nil {
 				return err
 			}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -41,6 +41,7 @@ var menu = []item{
 type model struct {
 	cursor   int
 	selected *item
+	version  string
 }
 
 func (m model) Init() tea.Cmd { return nil }
@@ -119,14 +120,17 @@ func (m model) View() string {
 		b.WriteString("  " + digitStyle.Render(it.digit+".") + " " + itemStyle.Render(it.label) + "\n")
 	}
 	b.WriteString("\n" + hintStyle.Render("↑/↓ navigate · enter select · 0-4 jump · q quit") + "\n")
+	b.WriteString(dimStyle.Render("v"+m.version) + "\n")
 	return b.String()
 }
 
 // Run levanta el menu interactivo. Devuelve la Action elegida o ActionExit
 // si el usuario salio (ctrl+c, q, esc, o item 0). El error solo aparece si
-// bubbletea no pudo arrancar (p.ej. stdout no es TTY).
-func Run() (Action, error) {
-	final, err := tea.NewProgram(model{}, tea.WithAltScreen()).Run()
+// bubbletea no pudo arrancar (p.ej. stdout no es TTY). version se renderiza
+// como linea dim al pie del menu para que el usuario sepa que build esta
+// corriendo; el caller la pasa desde cmd.Version (inyectada via ldflag).
+func Run(version string) (Action, error) {
+	final, err := tea.NewProgram(model{version: version}, tea.WithAltScreen()).Run()
 	if err != nil {
 		return ActionExit, err
 	}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1,0 +1,19 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestViewIncludesVersion verifica que el menu principal renderiza la
+// version recibida por parametro como "v<version>" — asi el usuario sabe
+// que binario esta corriendo sin salir del TUI. El render usa dimStyle, que
+// emite secuencias ANSI; el sub-string "v1.2.3" igual aparece literal en el
+// output porque dimStyle no transforma el contenido.
+func TestViewIncludesVersion(t *testing.T) {
+	m := model{version: "1.2.3"}
+	out := m.View()
+	if !strings.Contains(out, "v1.2.3") {
+		t.Fatalf("View() output no contiene la version esperada %q; got:\n%s", "v1.2.3", out)
+	}
+}


### PR DESCRIPTION
## Resumen
Renderizar la versión del binario `che` (variable `cmd.Version`, ya inyectada por ldflag en build) como línea dim al pie del menú principal del TUI, pasándola por parámetro a `tui.Run` para evitar ciclos de import.

## Cambios
- `internal/tui/tui.go`: nuevo campo `version` en el `model`, firma `Run(version string)`, render de `v<version>` con `dimStyle` tras la línea de hint.
- `cmd/root.go`: el call site al menú raíz pasa la variable global `Version`.
- `internal/tui/tui_test.go`: test unit `TestViewIncludesVersion` que valida que el output del `View()` contiene `v<version>`.

## Criterios cubiertos
- [x] Al ejecutar `che` (sin args), el menú principal muestra una línea con la versión (formato `vX.Y.Z` o `vdev` para builds locales).
- [x] La versión renderizada coincide con `cmd.Version` (no hardcoded en el paquete tui).
- [x] `che --version` sigue imprimiendo la versión como antes (Cobra autoexpuesta sobre `rootCmd.Version`).
- [x] `go build ./...` y `go vet ./...` pasan sin errores.
- [x] Test unit en `internal/tui` que invoca `View()` sobre un `model` con `version="1.2.3"` y verifica que el output contiene `"v1.2.3"`.

## Notas de ejecución
—

Closes #136
