### PR TITLE
fix(dash): parsear stream-json al emitir step:stdout

### DIFF
--- a/internal/dash/format.go
+++ b/internal/dash/format.go
@@ -1,0 +1,51 @@
+// Package dash — format.go: formateo de stdout crudo a lineas humanas.
+//
+// Los archivos step-NN.stdout.log persisten el output crudo del CLI (para
+// claude: stream-json una linea por evento). El TUI tiene su propio
+// renderer; el dash usa este helper para convertir esas lineas a algo
+// legible antes de emitirlas por SSE o servirlas al frontend.
+//
+// Reutilizamos internal/runner/parser para mantener un unico mapeo
+// stream-json → humano. CLIs sin parser (gemini text mode, etc) caen al
+// parser raw — pass-through linea a linea, sin perdida.
+package dash
+
+import (
+	"strings"
+
+	"github.com/chichex/che/internal/runner/parser"
+)
+
+// formatRawLine convierte una linea cruda del stdout.log en 0..N lineas
+// humanas segun el parser del CLI. Devuelve nil para eventos que el parser
+// considera sin valor visual (system_init claude, ping, etc) — el caller
+// los descarta (no emite SSE, no incrementa ordinal).
+//
+// Si el parser emite varias lineas para un mismo evento (caso tipico:
+// assistant.message.content con texto multi-linea), se devuelven todas;
+// el caller decide si las une con \n en un solo evento SSE o las emite
+// por separado.
+func formatRawLine(cli, raw string) []string {
+	p := parser.ForCLI(cli)
+	lines, _ := p.Parse(raw)
+	if len(lines) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(lines))
+	for _, l := range lines {
+		out = append(out, l.Text)
+	}
+	return out
+}
+
+// formatRawLineJoined es el helper que usa el watcher / SSE replay: une
+// las lineas humanas con \n y devuelve "" si el parser no aporto nada.
+// El caller emite un solo step:stdout por linea cruda — asi el frontend
+// no tiene que cambiar su modelo de eventos.
+func formatRawLineJoined(cli, raw string) string {
+	parts := formatRawLine(cli, raw)
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "\n")
+}

--- a/internal/dash/runs.go
+++ b/internal/dash/runs.go
@@ -248,7 +248,10 @@ func handleGetRun(runsDir string) http.HandlerFunc {
 
 // handleGetStepStdout returns an http.HandlerFunc for
 // GET /api/pipelines/:slug/runs/:runId/steps/:idx/stdout.
-// Serves the step-NN.stdout.log file (NN = 1-indexed, 2-padded).
+// Serves the step-NN.stdout.log file (NN = 1-indexed, 2-padded), pasandolo
+// por el mismo parser que el SSE en vivo para que el frontend de runs
+// frozen vea el mismo formato humano (stream-json → lineas legibles).
+// Soporta ?raw=1 para devolver el log original sin parsear (debug).
 // Returns 404 JSON if missing.
 func handleGetStepStdout(runsDir string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -258,9 +261,9 @@ func handleGetStepStdout(runsDir string) http.HandlerFunc {
 			return
 		}
 
-		// NN is 1-indexed, 2-padded
+		runDir := filepath.Join(runsDir, slug, runID)
 		nn := fmt.Sprintf("%02d", stepIdx+1)
-		logPath := filepath.Join(runsDir, slug, runID, "step-"+nn+".stdout.log")
+		logPath := filepath.Join(runDir, "step-"+nn+".stdout.log")
 
 		if _, err := os.Stat(logPath); os.IsNotExist(err) {
 			writeJSONError(w, http.StatusNotFound, "stdout not found")
@@ -268,7 +271,50 @@ func handleGetStepStdout(runsDir string) http.HandlerFunc {
 		}
 
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-		http.ServeFile(w, r, logPath)
+
+		// Escape hatch para inspeccion cruda (debug, soporte). El parser
+		// es lossy a proposito (oculta system_init, etc); raw=1 muestra
+		// todo lo que escribio el CLI.
+		if r.URL.Query().Get("raw") == "1" {
+			http.ServeFile(w, r, logPath)
+			return
+		}
+
+		// Resolver CLI del step desde el manifest. Si falla (manifest
+		// corrupto, step fuera de rango), caemos a servir el log crudo
+		// — preferimos contenido legible no-formateado a un 500.
+		cli := ""
+		if m, err := parseManifest(filepath.Join(runDir, "manifest.yaml")); err == nil {
+			for _, s := range m.Steps {
+				if s.Idx == stepIdx {
+					cli = s.CLI
+					break
+				}
+			}
+		}
+
+		raw, err := os.ReadFile(logPath)
+		if err != nil {
+			http.ServeFile(w, r, logPath)
+			return
+		}
+		// Split en lineas preservando vacias intermedias; descartamos
+		// solo el ultimo split vacio (trailing \n del file).
+		rawStr := string(raw)
+		rawStr = strings.TrimRight(rawStr, "\n")
+		if rawStr == "" {
+			return
+		}
+		var out strings.Builder
+		for _, line := range strings.Split(rawStr, "\n") {
+			pretty := formatRawLineJoined(cli, line)
+			if pretty == "" {
+				continue
+			}
+			out.WriteString(pretty)
+			out.WriteByte('\n')
+		}
+		_, _ = w.Write([]byte(out.String()))
 	}
 }
 

--- a/internal/dash/sse.go
+++ b/internal/dash/sse.go
@@ -174,15 +174,30 @@ func emitReplay(w http.ResponseWriter, flusher http.Flusher, runDir string, m ru
 		if s.Status == "running" || s.Status == "done" || s.Status == "failed" {
 			lines, err := readStdoutLines(runDir, s.Idx)
 			if err == nil && len(lines) > 0 {
-				for ordinal, line := range lines {
+				// Mismo parser que el watcher: claude → texto humano,
+				// otros CLIs → pass-through. Lineas que el parser
+				// descarta (system_init, ping) no consumen ordinal,
+				// asi el set queda alineado con el del watcher en
+				// vivo (el frontend deduplica por (idx, ordinal)).
+				ordinal := 0
+				emitted := false
+				for _, raw := range lines {
+					pretty := formatRawLineJoined(s.CLI, raw)
+					if pretty == "" {
+						continue
+					}
 					writeSSEEvent(w, Event{Type: EventStepStdout, Payload: map[string]any{
 						"idx":     s.Idx,
-						"line":    line,
+						"line":    pretty,
 						"ts":      now,
 						"ordinal": ordinal,
 					}})
+					ordinal++
+					emitted = true
 				}
-				flusher.Flush()
+				if emitted {
+					flusher.Flush()
+				}
 			}
 		}
 

--- a/internal/dash/watcher.go
+++ b/internal/dash/watcher.go
@@ -271,16 +271,25 @@ func (w *watcher) checkStdout(runDir string, m *runner.Manifest, states map[int]
 		}
 
 		scanner := bufio.NewScanner(f)
+		// Buffer grande para no truncar lineas largas de stream-json
+		// (memory bufio.Scanner 64 KiB default — claude emite >>64K).
+		scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 		ts := time.Now().UTC().Format(time.RFC3339)
 		for scanner.Scan() {
 			line := scanner.Text()
-			// Skip empty lines at EOF (partial last line).
 			if line == "" {
+				continue
+			}
+			// Parser → texto humano. Si devuelve "" el evento no aporta
+			// nada al viewport (system_init, ping, etc) — ni emit ni
+			// ordinal bump.
+			pretty := formatRawLineJoined(s.CLI, line)
+			if pretty == "" {
 				continue
 			}
 			w.publish(EventStepStdout, map[string]any{
 				"idx":     s.Idx,
-				"line":    line,
+				"line":    pretty,
 				"ts":      ts,
 				"ordinal": st.nextOrdinal,
 			})


### PR DESCRIPTION
## Summary
- El dash mostraba `step-NN.stdout.log` crudo: paredes de stream-json de claude con `\n` literales, `tool_use_id`, `cache_creation_input_tokens`, etc. Ilegible.
- El TUI ya tiene un parser (`internal/runner/parser/claude.go`) que convierte esos eventos a lineas humanas (`> assistant text`, `· tool: Bash — desc`), pero solo vivia en RAM del TUI.
- Este PR reusa ese parser desde el dash. Mismo `parser.ForCLI(step.CLI)` que el TUI, aplicado en los 3 puntos donde el dash emite stdout.

## Cambios
- `internal/dash/format.go` (nuevo) — helper `formatRawLineJoined(cli, raw)` que envuelve `parser.ForCLI(...).Parse(...)` y devuelve `""` si el evento no aporta valor visual (`system_init`, ping). El caller descarta esos.
- `internal/dash/watcher.go:checkStdout` — parsea cada linea cruda antes de publicar a la bus. Lineas descartadas no consumen ordinal. Buffer del scanner sube a 1 MiB (matchea `spawn.go`, evita truncate silencioso).
- `internal/dash/sse.go:emitReplay` — mismo tratamiento en el snapshot que ve un cliente al conectarse a un run vivo. Mantiene ordinales monotonos.
- `internal/dash/runs.go:handleGetStepStdout` — el endpoint frozen (`/api/pipelines/:slug/runs/:runId/steps/:idx/stdout`) tambien pasa por el parser. `?raw=1` sirve el log original como escape hatch para debug/soporte. Si el manifest no se puede leer, cae al log crudo (preferimos contenido legible no-formateado a un 500).

## Compatibilidad
- Protocolo SSE intacto (mismos eventos `step:start/end/stdout`, mismo shape de payload).
- `step-NN.stdout.log` y `step-NN.events.jsonl` en disco siguen crudos.
- CLIs sin parser dedicado (gemini text, codex) caen al `parser.Raw()` pass-through — comportamiento identico al actual.
- Frontend (`dash.html`) no cambia.

## Test plan
- [x] `go build ./...` ok
- [x] `go test ./...` ok (full suite verde)
- [ ] Manual: abrir el dash sobre un run de claude (`che dash`) y verificar que el pane de output muestra `> texto del assistant` / `· tool: <name> — desc` en vez del JSON crudo.
- [ ] Manual: abrir un run frozen (terminado) y verificar mismo formato. Probar `?raw=1` para confirmar el escape hatch.
- [ ] Manual: correr un step con CLI != claude (gemini/raw) y confirmar pass-through linea a linea.

🤖 Generated with [Claude Code](https://claude.com/claude-code)