### PR TITLE
Visibilidad dual (proyecto vs global) para pipelines

### DIFF
--- a/e2e/wizard_h8_h9_h10_test.go
+++ b/e2e/wizard_h8_h9_h10_test.go
@@ -47,8 +47,8 @@ func h8BuildOneStepPipeline(t *testing.T, p *harness.PTYRun, name string) {
 		t.Fatalf("send name: %v", err)
 	}
 	mark = p.Mark()
-	if err := p.Send("\x13"); err != nil {
-		t.Fatalf("ctrl+s S1→S2: %v", err)
+	if err := p.Send("\x13\x13"); err != nil {
+		t.Fatalf("ctrl+s S1→S2 (scope+commit): %v", err)
 	}
 	if !p.WaitForOutputSince(t, mark, "step 1 (create)", 3*time.Second) {
 		t.Fatalf("S2 never rendered\n%s", p.Since(mark))

--- a/e2e/wizard_test.go
+++ b/e2e/wizard_test.go
@@ -46,7 +46,7 @@ func TestWizard_S1PersistsDraft(t *testing.T) {
 
 	// Avanzar con ctrl+s — en H3 esto lleva a S2 (no mas placeholder).
 	mark = p.Mark()
-	if err := p.Send("\x13"); err != nil {
+	if err := p.Send("\x13\x13"); err != nil {
 		t.Fatalf("send ctrl+s: %v", err)
 	}
 	if !p.WaitForOutputSince(t, mark, "step 1 (create)", 3*time.Second) {
@@ -152,8 +152,11 @@ func TestWizard_S1Collision(t *testing.T) {
 		t.Fatalf("send name: %v", err)
 	}
 	mark = p.Mark()
-	if err := p.Send("\x13"); err != nil {
-		t.Fatalf("send ctrl+s: %v", err)
+	// S1 ctrl+s → ScreenScope; ctrl+s otra vez commitea scope (global por
+	// default) y la deteccion de colision dispara el modal porque el path
+	// `<home>/.che/pipelines/demo.yaml` ya existe.
+	if err := p.Send("\x13\x13"); err != nil {
+		t.Fatalf("send ctrl+s S1→scope→commit: %v", err)
 	}
 	if !p.WaitForOutputSince(t, mark, "ya existe", 3*time.Second) {
 		t.Fatalf("collision modal never opened\n%s", p.Since(mark))
@@ -219,7 +222,7 @@ func TestWizard_S1DiscardRemovesDraft(t *testing.T) {
 		t.Fatalf("send name: %v", err)
 	}
 	mark = p.Mark()
-	if err := p.Send("\x13"); err != nil {
+	if err := p.Send("\x13\x13"); err != nil {
 		t.Fatalf("send ctrl+s: %v", err)
 	}
 	if !p.WaitForOutputSince(t, mark, "step 1 (create)", 3*time.Second) {
@@ -308,8 +311,8 @@ func TestWizard_S2H3CreateFirstStep(t *testing.T) {
 		t.Fatalf("send desc: %v", err)
 	}
 	mark = p.Mark()
-	if err := p.Send("\x13"); err != nil {
-		t.Fatalf("send ctrl+s S1→S2: %v", err)
+	if err := p.Send("\x13\x13"); err != nil {
+		t.Fatalf("ctrl+s S1→S2 (scope+commit): %v", err)
 	}
 	if !p.WaitForOutputSince(t, mark, "step 1 (create)", 3*time.Second) {
 		t.Fatalf("S2 never rendered\n%s", p.Since(mark))
@@ -419,8 +422,8 @@ func TestWizard_S2H4ValidatorOn(t *testing.T) {
 		t.Fatalf("send name: %v", err)
 	}
 	mark = p.Mark()
-	if err := p.Send("\x13"); err != nil {
-		t.Fatalf("send ctrl+s S1→S2: %v", err)
+	if err := p.Send("\x13\x13"); err != nil {
+		t.Fatalf("ctrl+s S1→S2 (scope+commit): %v", err)
 	}
 	if !p.WaitForOutputSince(t, mark, "step 1 (create)", 3*time.Second) {
 		t.Fatalf("S2 never rendered\n%s", p.Since(mark))
@@ -550,8 +553,8 @@ func TestWizard_S2H4ValidatorOff(t *testing.T) {
 		t.Fatalf("send name: %v", err)
 	}
 	mark = p.Mark()
-	if err := p.Send("\x13"); err != nil {
-		t.Fatalf("send ctrl+s S1→S2: %v", err)
+	if err := p.Send("\x13\x13"); err != nil {
+		t.Fatalf("ctrl+s S1→S2 (scope+commit): %v", err)
 	}
 	if !p.WaitForOutputSince(t, mark, "step 1 (create)", 3*time.Second) {
 		t.Fatalf("S2 never rendered\n%s", p.Since(mark))
@@ -653,8 +656,8 @@ func TestWizard_S2H5LoopTwoSteps(t *testing.T) {
 		t.Fatalf("send name: %v", err)
 	}
 	mark = p.Mark()
-	if err := p.Send("\x13"); err != nil {
-		t.Fatalf("send ctrl+s S1→S2: %v", err)
+	if err := p.Send("\x13\x13"); err != nil {
+		t.Fatalf("ctrl+s S1→S2 (scope+commit): %v", err)
 	}
 	if !p.WaitForOutputSince(t, mark, "step 1 (create)", 3*time.Second) {
 		t.Fatalf("S2 never rendered\n%s", p.Since(mark))
@@ -783,8 +786,8 @@ func TestWizard_S2H5BackFromStep2(t *testing.T) {
 		t.Fatalf("send name: %v", err)
 	}
 	mark = p.Mark()
-	if err := p.Send("\x13"); err != nil {
-		t.Fatalf("send ctrl+s S1→S2: %v", err)
+	if err := p.Send("\x13\x13"); err != nil {
+		t.Fatalf("ctrl+s S1→S2 (scope+commit): %v", err)
 	}
 	if !p.WaitForOutputSince(t, mark, "step 1 (create)", 3*time.Second) {
 		t.Fatalf("S2 never rendered\n%s", p.Since(mark))
@@ -906,7 +909,7 @@ func TestWizard_S2H3BackToInfo(t *testing.T) {
 		t.Fatalf("send name: %v", err)
 	}
 	mark = p.Mark()
-	if err := p.Send("\x13"); err != nil {
+	if err := p.Send("\x13\x13"); err != nil {
 		t.Fatalf("send ctrl+s: %v", err)
 	}
 	if !p.WaitForOutputSince(t, mark, "step 1 (create)", 3*time.Second) {
@@ -1021,7 +1024,7 @@ func TestWizard_S2YAMLCombinations(t *testing.T) {
 		t.Fatalf("send desc: %v", err)
 	}
 	mark = p.Mark()
-	if err := p.Send("\x13"); err != nil {
+	if err := p.Send("\x13\x13"); err != nil {
 		t.Fatalf("ctrl+s S1->S2: %v", err)
 	}
 	if !p.WaitForOutputSince(t, mark, "step 1 (create)", 3*time.Second) {
@@ -1312,8 +1315,8 @@ func TestWizard_S3SummarySavesReady(t *testing.T) {
 		t.Fatalf("send name: %v", err)
 	}
 	mark = p.Mark()
-	if err := p.Send("\x13"); err != nil {
-		t.Fatalf("ctrl+s S1→S2: %v", err)
+	if err := p.Send("\x13\x13"); err != nil {
+		t.Fatalf("ctrl+s S1→S2 (scope+commit): %v", err)
 	}
 	if !p.WaitForOutputSince(t, mark, "step 1 (create)", 3*time.Second) {
 		t.Fatalf("S2 never rendered\n%s", p.Since(mark))
@@ -1447,8 +1450,8 @@ func TestWizard_S3InvalidStays(t *testing.T) {
 		t.Fatalf("send name: %v", err)
 	}
 	mark = p.Mark()
-	if err := p.Send("\x13"); err != nil {
-		t.Fatalf("ctrl+s S1→S2: %v", err)
+	if err := p.Send("\x13\x13"); err != nil {
+		t.Fatalf("ctrl+s S1→S2 (scope+commit): %v", err)
 	}
 	if !p.WaitForOutputSince(t, mark, "step 1 (create)", 3*time.Second) {
 		t.Fatalf("S2 never rendered\n%s", p.Since(mark))
@@ -1603,8 +1606,8 @@ func TestWizard_S3EscNoChangesExitsDirect(t *testing.T) {
 		t.Fatalf("send name: %v", err)
 	}
 	mark = p.Mark()
-	if err := p.Send("\x13"); err != nil {
-		t.Fatalf("ctrl+s S1→S2: %v", err)
+	if err := p.Send("\x13\x13"); err != nil {
+		t.Fatalf("ctrl+s S1→S2 (scope+commit): %v", err)
 	}
 	if !p.WaitForOutputSince(t, mark, "step 1 (create)", 3*time.Second) {
 		t.Fatalf("S2 never rendered\n%s", p.Since(mark))
@@ -1690,8 +1693,8 @@ func h7BuildThreeSteps(t *testing.T, p *harness.PTYRun, name string) {
 		t.Fatalf("send name: %v", err)
 	}
 	mark = p.Mark()
-	if err := p.Send("\x13"); err != nil {
-		t.Fatalf("ctrl+s S1→S2: %v", err)
+	if err := p.Send("\x13\x13"); err != nil {
+		t.Fatalf("ctrl+s S1→S2 (scope+commit): %v", err)
 	}
 	if !p.WaitForOutputSince(t, mark, "step 1 (create)", 3*time.Second) {
 		t.Fatalf("S2 never rendered\n%s", p.Since(mark))
@@ -2154,8 +2157,8 @@ func TestWizard_S3H7DeleteBreaksPrevDep(t *testing.T) {
 		t.Fatalf("send name: %v", err)
 	}
 	mark = p.Mark()
-	if err := p.Send("\x13"); err != nil {
-		t.Fatalf("ctrl+s S1→S2: %v", err)
+	if err := p.Send("\x13\x13"); err != nil {
+		t.Fatalf("ctrl+s S1→S2 (scope+commit): %v", err)
 	}
 	if !p.WaitForOutputSince(t, mark, "step 1 (create)", 3*time.Second) {
 		t.Fatalf("S2 never rendered\n%s", p.Since(mark))

--- a/internal/dash/assets/dash.html
+++ b/internal/dash/assets/dash.html
@@ -474,7 +474,9 @@ const Sidebar = ({ pipelines, runs, selectedSlug, onSelect, fadedSlugs }) => {
         <div className="flex items-center justify-between gap-2">
           <span className="mono text-[13px] ink truncate">{p.name}</span>
           <div className="flex items-center gap-1.5 shrink-0">
-            {p.builtin && <span className="badge" style={{fontSize:"10.5px",padding:"0 5px"}}>default</span>}
+            {p.scope === "project" && <span className="badge" style={{fontSize:"10.5px",padding:"0 5px",background:"#2dd4bf22",color:"#2dd4bf"}}>project</span>}
+            {p.scope === "global" && <span className="badge" style={{fontSize:"10.5px",padding:"0 5px",background:"#a78bfa22",color:"#a78bfa"}}>global</span>}
+            {(p.scope === "builtin" || (!p.scope && p.builtin)) && <span className="badge" style={{fontSize:"10.5px",padding:"0 5px"}}>default</span>}
             {p.status === "draft"
               ? <Badge kind="draft">draft</Badge>
               : live ? <Badge kind="running"><span className="dot dot-running" /> running</Badge>
@@ -568,7 +570,9 @@ const PipelineDetail = ({ pipeline, runs, onOpenRun, onRequestRun, onResumeDraft
           <div className="flex items-center gap-3 mb-1">
             <h1 className="mono text-[22px] font-semibold ink">{pipeline.name}</h1>
             <Badge kind="done">ready</Badge>
-            {pipeline.builtin && <span className="badge" style={{fontSize:"11px"}}>default</span>}
+            {pipeline.scope === "project" && <span className="badge" style={{fontSize:"11px",background:"#2dd4bf22",color:"#2dd4bf"}}>project</span>}
+            {pipeline.scope === "global" && <span className="badge" style={{fontSize:"11px",background:"#a78bfa22",color:"#a78bfa"}}>global</span>}
+            {(pipeline.scope === "builtin" || (!pipeline.scope && pipeline.builtin)) && <span className="badge" style={{fontSize:"11px"}}>default</span>}
           </div>
           <p className="ink-2 text-[14px] max-w-[640px]">{pipeline.description}</p>
         </div>

--- a/internal/dash/dash.go
+++ b/internal/dash/dash.go
@@ -66,13 +66,23 @@ func Serve(ctx context.Context, opts Options) error {
 		defer os.Remove(portFile)
 	}
 
-	// Resolve pipelines and runs directories. On failure use "" so handlers
-	// return empty list / 404 instead of crashing.
+	// Resolve pipelines (global) and runs directories. On failure use ""
+	// so handlers return empty list / 404 instead of crashing.
+	//
+	// cwd se resuelve UNA vez al startup para soportar pipelines de scope
+	// project (cwd-local en `./.che/pipelines/`). Si `cd` ocurre mientras
+	// el server corre, el cwd del proceso no cambia — el badge "project"
+	// deja claro al usuario que esto refleja el dir de arranque.
 	pipelinesDir := ""
 	runsDir := ""
-	if home, err := os.UserHomeDir(); err == nil {
-		pipelinesDir = filepath.Join(home, ".che", "pipelines")
-		runsDir = filepath.Join(home, ".che", "runs")
+	if h, err := os.UserHomeDir(); err == nil {
+		pipelinesDir = filepath.Join(h, ".che", "pipelines")
+		runsDir = filepath.Join(h, ".che", "runs")
+	}
+	cwd, cerr := os.Getwd()
+	if cerr != nil {
+		fmt.Fprintf(out, "[dash] no se pudo resolver cwd (%v) — scope project deshabilitado\n", cerr)
+		cwd = ""
 	}
 
 	// Singleton bus for SSE per-run streaming.
@@ -100,8 +110,8 @@ func Serve(ctx context.Context, opts Options) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", handleIndex)
 	mux.HandleFunc("/api/events", handleGlobalEvents(bus))
-	mux.HandleFunc("/api/pipelines", handleListPipelines(pipelinesDir, runsDir))
-	mux.HandleFunc("/api/pipelines/", dispatchPipelinesPrefix(pipelinesDir, runsDir, bus, starter, lock))
+	mux.HandleFunc("/api/pipelines", handleListPipelines(cwd, pipelinesDir, runsDir))
+	mux.HandleFunc("/api/pipelines/", dispatchPipelinesPrefix(cwd, pipelinesDir, runsDir, bus, starter, lock))
 
 	srv := &http.Server{
 		Handler:           mux,

--- a/internal/dash/pipelines.go
+++ b/internal/dash/pipelines.go
@@ -6,11 +6,11 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/chichex/che/internal/pipelines"
 	"github.com/chichex/che/internal/wizard"
 	"gopkg.in/yaml.v3"
 )
@@ -38,6 +38,9 @@ func init() {
 }
 
 // pipelineJSON is the wire shape for GET /api/pipelines (list item).
+// Scope expone el origen ("project" | "global" | "builtin") para que el
+// frontend pueda renderizar el badge correspondiente. Builtin se mantiene
+// por back-compat con clientes que ya lo leen — es derivable de Scope.
 type pipelineJSON struct {
 	Slug        string          `json:"slug"`
 	Name        string          `json:"name"`
@@ -45,6 +48,7 @@ type pipelineJSON struct {
 	Status      string          `json:"status"`
 	LastRun     *lastRunSummary `json:"last_run,omitempty"`
 	Builtin     bool            `json:"builtin,omitempty"`
+	Scope       string          `json:"scope,omitempty"`
 }
 
 // pipelineDetailJSON is the wire shape for GET /api/pipelines/:slug.
@@ -55,6 +59,7 @@ type pipelineDetailJSON struct {
 	Status      string     `json:"status"`
 	Steps       []stepJSON `json:"steps"`
 	Builtin     bool       `json:"builtin,omitempty"`
+	Scope       string     `json:"scope,omitempty"`
 }
 
 // stepJSON is the wire shape for a pipeline step.
@@ -101,93 +106,17 @@ func toStepJSON(s wizard.Step) stepJSON {
 	return sj
 }
 
-// loadPipelinesFromDir reads all *.yaml files from dir, parses them with
-// wizard.Load, and returns a slice of (slug, pipeline) pairs. Parse errors
-// are logged to stderr with prefix [dash] and skipped.
-func loadPipelinesFromDir(dir string) []struct {
-	slug string
-	p    wizard.Pipeline
-} {
-	if dir == "" {
+// listAll devuelve los pipelines visibles desde cwd+pipelinesDir en el
+// mismo orden que pipelines.List (project → global → builtin, ordenado
+// por slug). cwd vacio desactiva el scope project; pipelinesDir vacio
+// desactiva el scope global.
+func listAll(cwd, pipelinesDir string) []pipelines.Resolved {
+	out, err := pipelines.ListInDirs(cwd, pipelinesDir)
+	if err != nil {
+		log.Printf("[dash] pipelines.ListInDirs: %v", err)
 		return nil
 	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			log.Printf("[dash] readdir %s: %v", dir, err)
-		}
-		return nil
-	}
-	var result []struct {
-		slug string
-		p    wizard.Pipeline
-	}
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		name := e.Name()
-		if !strings.HasSuffix(name, ".yaml") {
-			continue
-		}
-		slug := strings.TrimSuffix(name, ".yaml")
-		path := filepath.Join(dir, name)
-		p, err := wizard.Load(path)
-		if err != nil {
-			log.Printf("[dash] load %s: %v", path, err)
-			continue
-		}
-		result = append(result, struct {
-			slug string
-			p    wizard.Pipeline
-		}{slug: slug, p: p})
-	}
-	return result
-}
-
-// pipelinePair is an enriched (slug, pipeline, builtin) tuple used internally.
-type pipelinePair struct {
-	slug    string
-	p       wizard.Pipeline
-	builtin bool
-}
-
-// mergeBuiltinsAndDisk combines builtin pipelines with pipelines loaded from
-// dir. On-disk entries win on slug collision (consistent with copy-on-edit).
-// If wizard.Builtins() fails it is logged with prefix [dash] and execution
-// continues with on-disk only. The result is sorted stably by slug.
-func mergeBuiltinsAndDisk(dir string) []pipelinePair {
-	// Load on-disk pipelines.
-	diskEntries := loadPipelinesFromDir(dir)
-	diskBySlug := make(map[string]struct{}, len(diskEntries))
-	for _, e := range diskEntries {
-		diskBySlug[e.slug] = struct{}{}
-	}
-
-	// Load builtins.
-	builtins, err := wizard.Builtins()
-	if err != nil {
-		log.Printf("[dash] wizard.Builtins(): %v", err)
-		builtins = nil
-	}
-
-	// Start with builtins that are not overridden on disk.
-	result := make([]pipelinePair, 0, len(builtins)+len(diskEntries))
-	for _, b := range builtins {
-		if _, overridden := diskBySlug[b.Slug]; overridden {
-			continue
-		}
-		result = append(result, pipelinePair{slug: b.Slug, p: b.Pipeline, builtin: true})
-	}
-	// Append on-disk entries (not marked as builtin even if slug matches).
-	for _, e := range diskEntries {
-		result = append(result, pipelinePair{slug: e.slug, p: e.p, builtin: false})
-	}
-
-	sort.Slice(result, func(i, j int) bool {
-		return result[i].slug < result[j].slug
-	})
-	return result
+	return out
 }
 
 // lookupLastRun reads the most-recent run manifest for slug from runsDir.
@@ -270,21 +199,24 @@ func fetchLastRun(runsDir, slug string) *lastRunSummary {
 }
 
 // handleListPipelines returns an http.HandlerFunc for GET /api/pipelines.
-// It merges builtin pipelines with on-disk ones (on-disk-wins), skipping
-// corrupt files. Returns JSON array (never null).
-// runsDir is used to populate last_run for each pipeline.
-func handleListPipelines(dir, runsDir string) http.HandlerFunc {
+// It merges pipelines de scope project (cwd-local), global (dir) y
+// builtins via pipelines.ListInDirs — el orden de override es project
+// → global → builtin. Returns JSON array (never null). runsDir is used
+// to populate last_run. cwd="" desactiva scope project — los tests
+// invocan asi (sin cwd) y conservan el comportamiento previo.
+func handleListPipelines(cwd, dir, runsDir string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		pairs := mergeBuiltinsAndDisk(dir)
-		list := make([]pipelineJSON, 0, len(pairs))
-		for _, pair := range pairs {
+		all := listAll(cwd, dir)
+		list := make([]pipelineJSON, 0, len(all))
+		for _, r := range all {
 			list = append(list, pipelineJSON{
-				Slug:        pair.slug,
-				Name:        pair.p.Name,
-				Description: pair.p.Description,
-				Status:      pipelineStatus(pair.p),
-				LastRun:     lookupLastRun(runsDir, pair.slug),
-				Builtin:     pair.builtin,
+				Slug:        r.Slug,
+				Name:        r.Pipeline.Name,
+				Description: r.Pipeline.Description,
+				Status:      pipelineStatus(r.Pipeline),
+				LastRun:     lookupLastRun(runsDir, r.Slug),
+				Builtin:     r.Scope == pipelines.ScopeBuiltin,
+				Scope:       r.Scope.String(),
 			})
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -293,13 +225,14 @@ func handleListPipelines(dir, runsDir string) http.HandlerFunc {
 }
 
 // handleGetPipeline returns an http.HandlerFunc for GET /api/pipelines/:slug.
-// It extracts the slug from the URL path, loads the matching YAML, and
-// returns the full pipeline detail including steps. Returns 404 JSON if
-// the slug does not exist, 500 on systemic errors.
+// It extracts the slug from the URL path, resolves project → global →
+// builtin via pipelines.ResolveInDirs, y devuelve el full pipeline
+// detail. Returns 404 JSON si el slug no existe, 500 on systemic
+// errors. cwd="" desactiva scope project (path usado por tests).
 //
 // Deprecated: prefer calling getPipelineDetail directly from the dispatcher.
 // This function is kept for backward compatibility with tests.
-func handleGetPipeline(dir string) http.HandlerFunc {
+func handleGetPipeline(cwd, dir string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		slug := strings.TrimPrefix(r.URL.Path, "/api/pipelines/")
 		slug = strings.TrimSuffix(slug, "/")
@@ -307,67 +240,41 @@ func handleGetPipeline(dir string) http.HandlerFunc {
 			http.Error(w, `{"error":"pipeline not found"}`, http.StatusNotFound)
 			return
 		}
-		getPipelineDetail(dir, slug, w, r)
+		getPipelineDetail(cwd, dir, slug, w, r)
 	}
 }
 
-// getPipelineDetail is the helper that loads a pipeline by slug from dir and
-// writes the JSON detail response. When the on-disk YAML does not exist it
-// falls back to wizard.BuiltinBySlug. Used by both handleGetPipeline and the
-// dispatcher in dispatchPipelinesPrefix.
-func getPipelineDetail(dir, slug string, w http.ResponseWriter, r *http.Request) {
-	var (
-		p         wizard.Pipeline
-		foundDisk bool
-		isBuiltin bool
-	)
-
-	// Try loading from disk first.
-	if dir != "" {
-		path := filepath.Join(dir, slug+".yaml")
-		loaded, err := wizard.Load(path)
-		if err == nil {
-			p = loaded
-			foundDisk = true
-		} else if os.IsNotExist(err) {
-			// Fall through to builtin lookup.
-		} else {
-			log.Printf("[dash] load %s: %v", path, err)
-			http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
-			return
-		}
+// getPipelineDetail resuelve un pipeline por slug usando
+// pipelines.ResolveInDirs (project → global → builtin) y escribe la
+// respuesta JSON. Errores distintos a "no encontrado" devuelven 500
+// con prefijo [dash].
+func getPipelineDetail(cwd, dir, slug string, w http.ResponseWriter, _ *http.Request) {
+	res, found, err := pipelines.ResolveInDirs(cwd, dir, slug)
+	if err != nil {
+		log.Printf("[dash] resolve %s: %v", slug, err)
+		http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
+		return
+	}
+	if !found {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"pipeline not found"}`))
+		return
 	}
 
-	// If not found on disk, try builtins.
-	if !foundDisk {
-		b, err := wizard.BuiltinBySlug(slug)
-		if err != nil {
-			log.Printf("[dash] wizard.BuiltinBySlug(%s): %v", slug, err)
-			http.Error(w, `{"error":"internal server error"}`, http.StatusInternalServerError)
-			return
-		}
-		if b == nil {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusNotFound)
-			_, _ = w.Write([]byte(`{"error":"pipeline not found"}`))
-			return
-		}
-		p = b.Pipeline
-		isBuiltin = true
-	}
-
-	steps := make([]stepJSON, 0, len(p.Steps))
-	for _, s := range p.Steps {
+	steps := make([]stepJSON, 0, len(res.Pipeline.Steps))
+	for _, s := range res.Pipeline.Steps {
 		steps = append(steps, toStepJSON(s))
 	}
 
 	detail := pipelineDetailJSON{
-		Slug:        slug,
-		Name:        p.Name,
-		Description: p.Description,
-		Status:      pipelineStatus(p),
+		Slug:        res.Slug,
+		Name:        res.Pipeline.Name,
+		Description: res.Pipeline.Description,
+		Status:      pipelineStatus(res.Pipeline),
 		Steps:       steps,
-		Builtin:     isBuiltin,
+		Builtin:     res.Scope == pipelines.ScopeBuiltin,
+		Scope:       res.Scope.String(),
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(detail)

--- a/internal/dash/pipelines_test.go
+++ b/internal/dash/pipelines_test.go
@@ -45,7 +45,7 @@ func getJSON(t *testing.T, handler http.HandlerFunc, path string) *httptest.Resp
 
 func TestListEmpty(t *testing.T) {
 	dir := t.TempDir()
-	rr := getJSON(t, handleListPipelines(dir, ""), "/api/pipelines")
+	rr := getJSON(t, handleListPipelines("", dir, ""), "/api/pipelines")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", rr.Code)
 	}
@@ -72,7 +72,7 @@ func TestListOneReady(t *testing.T) {
 		Description: "test ready",
 		Steps:       []wizard.Step{{Name: "step1", CLI: "claude", Kind: "prompt"}},
 	})
-	rr := getJSON(t, handleListPipelines(dir, ""), "/api/pipelines")
+	rr := getJSON(t, handleListPipelines("", dir, ""), "/api/pipelines")
 	var list []pipelineJSON
 	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -103,7 +103,7 @@ func TestListOneDraft(t *testing.T) {
 		Name:   "Draft Pipe",
 		Status: draftStatus,
 	})
-	rr := getJSON(t, handleListPipelines(dir, ""), "/api/pipelines")
+	rr := getJSON(t, handleListPipelines("", dir, ""), "/api/pipelines")
 	var list []pipelineJSON
 	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -131,7 +131,7 @@ func TestListMixed(t *testing.T) {
 		Name:   "Draft",
 		Status: &wizard.Status{Stage: wizard.StageStep},
 	})
-	rr := getJSON(t, handleListPipelines(dir, ""), "/api/pipelines")
+	rr := getJSON(t, handleListPipelines("", dir, ""), "/api/pipelines")
 	var list []pipelineJSON
 	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -154,7 +154,7 @@ func TestListCorruptExcluded(t *testing.T) {
 	writeCorrupt(t, dir, "bad-pipe")
 	writeYAML(t, dir, "good-pipe", wizard.Pipeline{Name: "Good"})
 
-	rr := getJSON(t, handleListPipelines(dir, ""), "/api/pipelines")
+	rr := getJSON(t, handleListPipelines("", dir, ""), "/api/pipelines")
 	var list []pipelineJSON
 	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
 		t.Fatalf("unmarshal: %v", err)
@@ -176,7 +176,7 @@ func TestListCorruptExcluded(t *testing.T) {
 
 func TestDetailMissingSlug(t *testing.T) {
 	dir := t.TempDir()
-	rr := getJSON(t, handleGetPipeline(dir), "/api/pipelines/nonexistent")
+	rr := getJSON(t, handleGetPipeline("", dir), "/api/pipelines/nonexistent")
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("want 404, got %d", rr.Code)
 	}
@@ -197,7 +197,7 @@ func TestDetailFound(t *testing.T) {
 		},
 	})
 
-	rr := getJSON(t, handleGetPipeline(dir), "/api/pipelines/my-pipe")
+	rr := getJSON(t, handleGetPipeline("", dir), "/api/pipelines/my-pipe")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
 	}
@@ -253,7 +253,7 @@ func TestListPipelines_LastRunPresent(t *testing.T) {
 	lastRunCache.entries = make(map[string]lastRunCacheEntry)
 	lastRunCache.mu.Unlock()
 
-	rr := getJSON(t, handleListPipelines(pipelinesDir, runsDir), "/api/pipelines")
+	rr := getJSON(t, handleListPipelines("", pipelinesDir, runsDir), "/api/pipelines")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", rr.Code)
 	}
@@ -303,7 +303,7 @@ func TestListPipelines_LastRunOmitted(t *testing.T) {
 	lastRunCache.entries = make(map[string]lastRunCacheEntry)
 	lastRunCache.mu.Unlock()
 
-	rr := getJSON(t, handleListPipelines(pipelinesDir, runsDir), "/api/pipelines")
+	rr := getJSON(t, handleListPipelines("", pipelinesDir, runsDir), "/api/pipelines")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", rr.Code)
 	}
@@ -334,7 +334,7 @@ func TestListPipelines_LastRunOmitted(t *testing.T) {
 // builtin pipelines (e.g. che-funnel) with builtin=true.
 func TestListBuiltinOnly(t *testing.T) {
 	dir := t.TempDir() // empty — no on-disk YAML files
-	rr := getJSON(t, handleListPipelines(dir, ""), "/api/pipelines")
+	rr := getJSON(t, handleListPipelines("", dir, ""), "/api/pipelines")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", rr.Code)
 	}
@@ -368,7 +368,7 @@ func TestListBuiltinOverriddenByDisk(t *testing.T) {
 		Description: "overridden",
 		Steps:       []wizard.Step{{Name: "custom-step", CLI: "claude", Kind: "prompt"}},
 	})
-	rr := getJSON(t, handleListPipelines(dir, ""), "/api/pipelines")
+	rr := getJSON(t, handleListPipelines("", dir, ""), "/api/pipelines")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d", rr.Code)
 	}
@@ -398,7 +398,7 @@ func TestListBuiltinOverriddenByDisk(t *testing.T) {
 // the builtin pipeline with builtin=true when no on-disk file exists.
 func TestDetailBuiltinNoOverride(t *testing.T) {
 	dir := t.TempDir() // empty dir
-	rr := getJSON(t, handleGetPipeline(dir), "/api/pipelines/che-funnel")
+	rr := getJSON(t, handleGetPipeline("", dir), "/api/pipelines/che-funnel")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
 	}
@@ -425,7 +425,7 @@ func TestDetailBuiltinOverriddenByDisk(t *testing.T) {
 		Name:  "My Custom Funnel",
 		Steps: []wizard.Step{{Name: "custom", CLI: "claude", Kind: "prompt"}},
 	})
-	rr := getJSON(t, handleGetPipeline(dir), "/api/pipelines/che-funnel")
+	rr := getJSON(t, handleGetPipeline("", dir), "/api/pipelines/che-funnel")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
 	}
@@ -438,5 +438,102 @@ func TestDetailBuiltinOverriddenByDisk(t *testing.T) {
 	}
 	if detail.Name != "My Custom Funnel" {
 		t.Errorf("want on-disk name, got %q", detail.Name)
+	}
+}
+
+// ── dual scope (project vs global) tests ───────────────────────────────────
+
+// TestListScopeFields cubre el AC: el JSON del listado expone el campo
+// scope con valores "project" | "global" | "builtin". Builtin sigue
+// presente por back-compat.
+func TestListScopeFields(t *testing.T) {
+	dir := t.TempDir()
+	writeYAML(t, dir, "global-pipe", wizard.Pipeline{
+		Name:  "Global Pipe",
+		Steps: []wizard.Step{{Name: "s1", CLI: "claude", Kind: "prompt"}},
+	})
+
+	rr := getJSON(t, handleListPipelines("", dir, ""), "/api/pipelines")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+	var list []pipelineJSON
+	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	bySlug := map[string]pipelineJSON{}
+	for _, p := range list {
+		bySlug[p.Slug] = p
+	}
+
+	gp, ok := bySlug["global-pipe"]
+	if !ok {
+		t.Fatalf("global-pipe not in list")
+	}
+	if gp.Scope != "global" {
+		t.Errorf("global-pipe.Scope = %q, want \"global\"", gp.Scope)
+	}
+	if gp.Builtin {
+		t.Errorf("global-pipe.Builtin = true, want false")
+	}
+
+	cf, ok := bySlug["che-funnel"]
+	if !ok {
+		t.Fatalf("che-funnel builtin not in list")
+	}
+	if cf.Scope != "builtin" {
+		t.Errorf("che-funnel.Scope = %q, want \"builtin\"", cf.Scope)
+	}
+	if !cf.Builtin {
+		t.Errorf("che-funnel.Builtin = false, want true (back-compat)")
+	}
+}
+
+// TestListProjectOverridesGlobal verifica que cuando un mismo slug existe
+// en project (cwd) y global (home/.che/pipelines/), el listado del dash
+// devuelve el de scope project con scope="project".
+func TestListProjectOverridesGlobal(t *testing.T) {
+	globalDir := t.TempDir()
+	projectRoot := t.TempDir()
+	projectDir := filepath.Join(projectRoot, ".che", "pipelines")
+	if err := os.MkdirAll(projectDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	writeYAML(t, globalDir, "demo", wizard.Pipeline{
+		Name:  "Demo Global",
+		Steps: []wizard.Step{{Name: "s1", CLI: "claude", Kind: "prompt"}},
+	})
+	writeYAML(t, projectDir, "demo", wizard.Pipeline{
+		Name:  "Demo Project",
+		Steps: []wizard.Step{{Name: "s1", CLI: "claude", Kind: "prompt"}},
+	})
+
+	rr := getJSON(t, handleListPipelines(projectRoot, globalDir, ""), "/api/pipelines")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", rr.Code)
+	}
+	var list []pipelineJSON
+	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	var demoCount int
+	var demo pipelineJSON
+	for _, p := range list {
+		if p.Slug == "demo" {
+			demoCount++
+			demo = p
+		}
+	}
+	if demoCount != 1 {
+		t.Fatalf("expected exactly 1 demo entry, got %d", demoCount)
+	}
+	if demo.Scope != "project" {
+		t.Errorf("demo.Scope = %q, want \"project\"", demo.Scope)
+	}
+	if demo.Name != "Demo Project" {
+		t.Errorf("demo.Name = %q, want \"Demo Project\" (project should override global)", demo.Name)
 	}
 }

--- a/internal/dash/runs.go
+++ b/internal/dash/runs.go
@@ -379,9 +379,9 @@ func writeJSONError(w http.ResponseWriter, code int, msg string) {
 //   GET  /api/pipelines/<slug>/runs/<runId>/steps/<idx>/stdout  → get step stdout
 //
 // Any other pattern returns 404.
-func dispatchPipelinesPrefix(pipelinesDir, runsDir string, bus *Bus, starter runStarter, lock *runLock) http.HandlerFunc {
+func dispatchPipelinesPrefix(cwd, pipelinesDir, runsDir string, bus *Bus, starter runStarter, lock *runLock) http.HandlerFunc {
 	listRunsH := handleListRuns(runsDir)
-	createRunH := handleCreateRun(pipelinesDir, runsDir, starter, lock)
+	createRunH := handleCreateRun(cwd, pipelinesDir, runsDir, starter, lock)
 	getRunH := handleGetRun(runsDir)
 	getStdoutH := handleGetStepStdout(runsDir)
 	getEventsH := handleEvents(runsDir, bus)
@@ -404,7 +404,7 @@ func dispatchPipelinesPrefix(pipelinesDir, runsDir string, bus *Bus, starter run
 				writeJSONError(w, http.StatusNotFound, "pipeline not found")
 				return
 			}
-			getPipelineDetail(pipelinesDir, slug, w, r)
+			getPipelineDetail(cwd, pipelinesDir, slug, w, r)
 
 		case 2:
 			// /api/pipelines/<slug>/runs

--- a/internal/dash/runs_create.go
+++ b/internal/dash/runs_create.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/chichex/che/internal/pipelines"
 	"github.com/chichex/che/internal/runner"
 	"github.com/chichex/che/internal/wizard"
 	"gopkg.in/yaml.v3"
@@ -164,30 +165,24 @@ func hasRecentRunningManifest(runsDir, slug string, now time.Time) bool {
 	return now.Sub(latest.startedAt) < recentRunningWindow
 }
 
-// loadPipelineForSlug busca un pipeline por slug: primero en disco
-// (pipelinesDir/<slug>.yaml), luego en wizard.Builtins(). Devuelve la
-// pipeline, el target que el runner espera ("<path>" o "builtin:<slug>"),
-// y found=false si no existe en ningun lado. Errores reales (IO, parse)
-// se logean igual que en el resto del dash.
-func loadPipelineForSlug(pipelinesDir, slug string) (p wizard.Pipeline, target string, found bool, err error) {
-	if pipelinesDir != "" {
-		path := filepath.Join(pipelinesDir, slug+".yaml")
-		loaded, lerr := wizard.Load(path)
-		if lerr == nil {
-			return loaded, path, true, nil
-		}
-		if !os.IsNotExist(lerr) {
-			return wizard.Pipeline{}, "", false, lerr
-		}
+// loadPipelineForSlug busca un pipeline por slug usando
+// pipelines.ResolveInDirs (orden project → global → builtin). Devuelve
+// la pipeline, el target que el runner espera ("<path>" o
+// "builtin:<slug>"), y found=false si no existe en ningun lado.
+// Errores reales (IO, parse) se logean igual que en el resto del dash.
+//
+// Es un thin wrapper sobre pipelines.ResolveInDirs — la funcion se
+// mantiene para no romper los call sites internos. cwd="" desactiva
+// scope project (path usado por tests).
+func loadPipelineForSlug(cwd, dir, slug string) (p wizard.Pipeline, target string, found bool, err error) {
+	res, ok, err := pipelines.ResolveInDirs(cwd, dir, slug)
+	if err != nil {
+		return wizard.Pipeline{}, "", false, err
 	}
-	b, berr := wizard.BuiltinBySlug(slug)
-	if berr != nil {
-		return wizard.Pipeline{}, "", false, berr
-	}
-	if b == nil {
+	if !ok {
 		return wizard.Pipeline{}, "", false, nil
 	}
-	return b.Pipeline, "builtin:" + slug, true, nil
+	return res.Pipeline, res.Target, true, nil
 }
 
 // createRunBody es el body JSON esperado por POST /api/pipelines/:slug/runs.
@@ -207,8 +202,10 @@ type createRunResponse struct {
 
 // handleCreateRun devuelve el handler de POST /api/pipelines/:slug/runs.
 // El slug llega por header (puesto por el dispatcher antes de invocar el
-// handler — mismo mecanismo que listRunsH / getRunH).
-func handleCreateRun(pipelinesDir, runsDir string, starter runStarter, lock *runLock) http.HandlerFunc {
+// handler — mismo mecanismo que listRunsH / getRunH). cwd se resolvio una
+// vez al startup del dash; vacio = scope project deshabilitado.
+// dir = directorio global ya resuelto (`<home>/.che/pipelines/`).
+func handleCreateRun(cwd, dir, runsDir string, starter runStarter, lock *runLock) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		slug := extractSlug(r)
 		if slug == "" {
@@ -216,8 +213,8 @@ func handleCreateRun(pipelinesDir, runsDir string, starter runStarter, lock *run
 			return
 		}
 
-		// Validar slug + cargar pipeline (disk first, builtin fallback).
-		p, target, found, err := loadPipelineForSlug(pipelinesDir, slug)
+		// Validar slug + cargar pipeline (project → global → builtin).
+		p, target, found, err := loadPipelineForSlug(cwd, dir, slug)
 		if err != nil {
 			log.Printf("[dash] createRun load %s: %v", slug, err)
 			writeJSONError(w, http.StatusInternalServerError, "internal server error")

--- a/internal/dash/runs_create_test.go
+++ b/internal/dash/runs_create_test.go
@@ -106,7 +106,7 @@ func TestCreateRun_HappyPathNoInput(t *testing.T) {
 		Steps: []wizard.Step{{Name: "single", CLI: "claude", Kind: "prompt", Input: wizard.InputNone}},
 	})
 	starter := &recordingStarter{nextRunID: "RUN-001"}
-	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
+	dispatcher := dispatchPipelinesPrefix("", pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
 
 	rr := postRun(t, dispatcher, "no-input-pipe", nil)
 	if rr.Code != http.StatusCreated {
@@ -141,7 +141,7 @@ func TestCreateRun_HappyPathWithInput(t *testing.T) {
 		Steps: []wizard.Step{{Name: "single", CLI: "claude", Kind: "prompt", Input: wizard.InputText}},
 	})
 	starter := &recordingStarter{nextRunID: "RUN-text"}
-	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
+	dispatcher := dispatchPipelinesPrefix("", pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
 
 	rr := postRun(t, dispatcher, "text-pipe", map[string]string{"input": "foo"})
 	if rr.Code != http.StatusCreated {
@@ -161,7 +161,7 @@ func TestCreateRun_BuiltinSlug(t *testing.T) {
 	pipelinesDir := t.TempDir()
 	runsDir := t.TempDir()
 	starter := &recordingStarter{nextRunID: "RUN-builtin"}
-	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
+	dispatcher := dispatchPipelinesPrefix("", pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
 
 	rr := postRun(t, dispatcher, "che-funnel", map[string]string{"input": "una idea"})
 	if rr.Code != http.StatusCreated {
@@ -182,7 +182,7 @@ func TestCreateRun_InputRequired(t *testing.T) {
 		Steps: []wizard.Step{{Name: "single", CLI: "claude", Kind: "prompt", Input: wizard.InputText}},
 	})
 	starter := &recordingStarter{}
-	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
+	dispatcher := dispatchPipelinesPrefix("", pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
 
 	rr := postRun(t, dispatcher, "text-pipe", nil)
 	if rr.Code != http.StatusBadRequest {
@@ -202,7 +202,7 @@ func TestCreateRun_NotFound(t *testing.T) {
 	pipelinesDir := t.TempDir()
 	runsDir := t.TempDir()
 	starter := &recordingStarter{}
-	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
+	dispatcher := dispatchPipelinesPrefix("", pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
 
 	rr := postRun(t, dispatcher, "no-existe", nil)
 	if rr.Code != http.StatusNotFound {
@@ -224,7 +224,7 @@ func TestCreateRun_ConflictLockHeldByMemory(t *testing.T) {
 	})
 	starter := &recordingStarter{nextRunID: "RUN-lock"}
 	lock := newRunLock()
-	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, lock)
+	dispatcher := dispatchPipelinesPrefix("", pipelinesDir, runsDir, NewBus(runsDir), starter, lock)
 
 	// Primer POST OK.
 	rr1 := postRun(t, dispatcher, "lock-pipe", nil)
@@ -261,7 +261,7 @@ func TestCreateRun_ConflictRecentManifest(t *testing.T) {
 		Status:    runner.ManifestStatusRunning,
 	})
 	starter := &recordingStarter{}
-	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
+	dispatcher := dispatchPipelinesPrefix("", pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
 
 	rr := postRun(t, dispatcher, "race-pipe", nil)
 	if rr.Code != http.StatusConflict {
@@ -287,7 +287,7 @@ func TestCreateRun_OldRunningManifestDoesNotBlock(t *testing.T) {
 		RunID: "old-run", Pipeline: "stale-pipe", StartedAt: old, Status: runner.ManifestStatusRunning,
 	})
 	starter := &recordingStarter{nextRunID: "RUN-fresh"}
-	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
+	dispatcher := dispatchPipelinesPrefix("", pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
 
 	rr := postRun(t, dispatcher, "stale-pipe", nil)
 	if rr.Code != http.StatusCreated {
@@ -307,7 +307,7 @@ func TestCreateRun_StarterErrorReleasesLock(t *testing.T) {
 	})
 	starter := &recordingStarter{err: errors.New("simulated")}
 	lock := newRunLock()
-	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, lock)
+	dispatcher := dispatchPipelinesPrefix("", pipelinesDir, runsDir, NewBus(runsDir), starter, lock)
 
 	rr1 := postRun(t, dispatcher, "boom-pipe", nil)
 	if rr1.Code != http.StatusInternalServerError {
@@ -337,7 +337,7 @@ func TestCreateRun_LockReleasedOnExecuteDone(t *testing.T) {
 	})
 	starter := &recordingStarter{nextRunID: "RUN-A"}
 	lock := newRunLock()
-	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, lock)
+	dispatcher := dispatchPipelinesPrefix("", pipelinesDir, runsDir, NewBus(runsDir), starter, lock)
 
 	// Primer run arranca OK.
 	rr1 := postRun(t, dispatcher, "loop-pipe", nil)
@@ -372,7 +372,7 @@ func TestCreateRun_InvalidJSON(t *testing.T) {
 		Steps: []wizard.Step{{Name: "single", CLI: "claude", Kind: "prompt", Input: wizard.InputNone}},
 	})
 	starter := &recordingStarter{}
-	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
+	dispatcher := dispatchPipelinesPrefix("", pipelinesDir, runsDir, NewBus(runsDir), starter, newRunLock())
 
 	req := httptest.NewRequest(http.MethodPost, "/api/pipelines/any-pipe/runs", strings.NewReader("not json"))
 	req.Header.Set("Content-Type", "application/json")

--- a/internal/dash/runs_test.go
+++ b/internal/dash/runs_test.go
@@ -341,7 +341,7 @@ func TestDispatcherRouting(t *testing.T) {
 	// Plant stdout for step 0
 	plantStdoutLog(t, runsDir, "my-pipe", "run1", 0, "stdout content")
 
-	dispatcher := dispatchPipelinesPrefix(pipelinesDir, runsDir, NewBus(runsDir), &noopStarter{}, newRunLock())
+	dispatcher := dispatchPipelinesPrefix("", pipelinesDir, runsDir, NewBus(runsDir), &noopStarter{}, newRunLock())
 
 	cases := []struct {
 		path           string

--- a/internal/pipelines/errors.go
+++ b/internal/pipelines/errors.go
@@ -1,0 +1,8 @@
+package pipelines
+
+import "errors"
+
+// errEmptyCwd lo devuelve PathForScope/ProjectPipelinesDir cuando se pide
+// scope project sin un cwd resuelto. El caller decide si surfacearlo o
+// degradar a scope global.
+var errEmptyCwd = errors.New("pipelines: cwd vacio para scope project")

--- a/internal/pipelines/list.go
+++ b/internal/pipelines/list.go
@@ -1,0 +1,135 @@
+package pipelines
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/chichex/che/internal/wizard"
+)
+
+// List enumera todos los pipelines visibles desde cwd+home. Devuelve una
+// slice ordenada por slug. En colisiones la regla es:
+//   - project gana sobre global y builtin (cwd-local override)
+//   - global gana sobre builtin (FS-shadow del builtin)
+//
+// Archivos corruptos en disco se logean y se skipean — listar igual no
+// se vuela porque uno este roto. Builtins que fallan al parsear SI
+// rompen el listado (bug del binario).
+//
+// Si cwd=="" se omite project; si home no se puede resolver se omite
+// global. En ambos casos el listado degrada limpiamente.
+func List(cwd, home string) ([]Resolved, error) {
+	gdir, err := GlobalPipelinesDir(home)
+	if err != nil {
+		gdir = ""
+	}
+	return ListInDirs(cwd, gdir)
+}
+
+// ListInDirs es la version baja-nivel de List: toma el dir global ya
+// resuelto en vez de home. cwd="" desactiva scope project,
+// globalDir="" desactiva scope global; en ambos casos los builtins
+// quedan siempre disponibles.
+func ListInDirs(cwd, globalDir string) ([]Resolved, error) {
+	seen := make(map[string]struct{})
+	out := make([]Resolved, 0, 8)
+
+	// 1. Project (cwd-local) — primero asi gana en colisiones.
+	if projectDir := ProjectPipelinesDir(cwd); projectDir != "" {
+		entries := loadFromDir(projectDir)
+		for _, e := range entries {
+			seen[e.slug] = struct{}{}
+			out = append(out, Resolved{
+				Slug:     e.slug,
+				Pipeline: e.pipeline,
+				Scope:    ScopeProject,
+				Target:   e.path,
+			})
+		}
+	}
+
+	// 2. Global.
+	if globalDir != "" {
+		entries := loadFromDir(globalDir)
+		for _, e := range entries {
+			if _, dup := seen[e.slug]; dup {
+				continue
+			}
+			seen[e.slug] = struct{}{}
+			out = append(out, Resolved{
+				Slug:     e.slug,
+				Pipeline: e.pipeline,
+				Scope:    ScopeGlobal,
+				Target:   e.path,
+			})
+		}
+	}
+
+	// 3. Builtins.
+	builtins, err := wizard.Builtins()
+	if err != nil {
+		return nil, err
+	}
+	for _, b := range builtins {
+		if _, dup := seen[b.Slug]; dup {
+			continue
+		}
+		seen[b.Slug] = struct{}{}
+		out = append(out, Resolved{
+			Slug:     b.Slug,
+			Pipeline: b.Pipeline,
+			Scope:    ScopeBuiltin,
+			Target:   wizard.BuiltinTargetPrefix + b.Slug,
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Slug < out[j].Slug })
+	return out, nil
+}
+
+type dirEntry struct {
+	slug     string
+	path     string
+	pipeline wizard.Pipeline
+}
+
+// loadFromDir lee *.yaml de dir y devuelve los pipelines parseados.
+// Errores de IO (readdir o load) se logean con prefijo [pipelines] y se
+// skipean. Dir inexistente se trata como "lista vacia" sin log.
+func loadFromDir(dir string) []dirEntry {
+	if dir == "" {
+		return nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Printf("[pipelines] readdir %s: %v", dir, err)
+		}
+		return nil
+	}
+	out := make([]dirEntry, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".yaml") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		p, err := wizard.Load(path)
+		if err != nil {
+			log.Printf("[pipelines] load %s: %v", path, err)
+			continue
+		}
+		out = append(out, dirEntry{
+			slug:     strings.TrimSuffix(name, ".yaml"),
+			path:     path,
+			pipeline: p,
+		})
+	}
+	return out
+}

--- a/internal/pipelines/list_test.go
+++ b/internal/pipelines/list_test.go
@@ -1,0 +1,132 @@
+package pipelines
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestList_DualScopeWithOverride(t *testing.T) {
+	tmp := t.TempDir()
+	cwd := filepath.Join(tmp, "proj")
+	home := filepath.Join(tmp, "home")
+
+	// proyecto y global definen "demo" → gana project; global tiene "only-global".
+	writePipelineYAML(t, filepath.Join(cwd, ".che", "pipelines", "demo.yaml"), "demo-project")
+	writePipelineYAML(t, filepath.Join(home, ".che", "pipelines", "demo.yaml"), "demo-global")
+	writePipelineYAML(t, filepath.Join(home, ".che", "pipelines", "only-global.yaml"), "only-global")
+
+	got, err := List(cwd, home)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+
+	bySlug := map[string]Resolved{}
+	for _, r := range got {
+		bySlug[r.Slug] = r
+	}
+
+	demo, ok := bySlug["demo"]
+	if !ok {
+		t.Fatalf("expected demo in list")
+	}
+	if demo.Scope != ScopeProject {
+		t.Errorf("demo.Scope = %v, want ScopeProject", demo.Scope)
+	}
+	if demo.Pipeline.Name != "demo-project" {
+		t.Errorf("demo.Pipeline.Name = %q, want demo-project", demo.Pipeline.Name)
+	}
+
+	onlyGlobal, ok := bySlug["only-global"]
+	if !ok {
+		t.Fatalf("expected only-global in list")
+	}
+	if onlyGlobal.Scope != ScopeGlobal {
+		t.Errorf("only-global.Scope = %v, want ScopeGlobal", onlyGlobal.Scope)
+	}
+
+	// builtin che-funnel siempre disponible (no esta shadow-eado por FS).
+	cheFunnel, ok := bySlug["che-funnel"]
+	if !ok {
+		t.Fatalf("expected che-funnel builtin in list")
+	}
+	if cheFunnel.Scope != ScopeBuiltin {
+		t.Errorf("che-funnel.Scope = %v, want ScopeBuiltin", cheFunnel.Scope)
+	}
+}
+
+func TestList_BuiltinShadowedByProject(t *testing.T) {
+	tmp := t.TempDir()
+	cwd := filepath.Join(tmp, "proj")
+	home := filepath.Join(tmp, "home")
+
+	// Override del builtin desde scope project.
+	writePipelineYAML(t, filepath.Join(cwd, ".che", "pipelines", "che-funnel.yaml"), "mi-che-funnel")
+
+	got, err := List(cwd, home)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var cheFunnel *Resolved
+	for i := range got {
+		if got[i].Slug == "che-funnel" {
+			cheFunnel = &got[i]
+		}
+	}
+	if cheFunnel == nil {
+		t.Fatalf("expected che-funnel in list")
+	}
+	if cheFunnel.Scope != ScopeProject {
+		t.Errorf("scope = %v, want ScopeProject (override)", cheFunnel.Scope)
+	}
+	if cheFunnel.Pipeline.Name != "mi-che-funnel" {
+		t.Errorf("Pipeline.Name = %q, want mi-che-funnel", cheFunnel.Pipeline.Name)
+	}
+}
+
+func TestList_MissingProjectDir(t *testing.T) {
+	tmp := t.TempDir()
+	cwd := filepath.Join(tmp, "no-existe")
+	home := filepath.Join(tmp, "home")
+	writePipelineYAML(t, filepath.Join(home, ".che", "pipelines", "alpha.yaml"), "alpha")
+
+	got, err := List(cwd, home)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	// Espero al menos alpha (global) y che-funnel (builtin).
+	var sawAlpha, sawCheFunnel bool
+	for _, r := range got {
+		if r.Slug == "alpha" {
+			sawAlpha = true
+		}
+		if r.Slug == "che-funnel" {
+			sawCheFunnel = true
+		}
+	}
+	if !sawAlpha {
+		t.Errorf("expected alpha in list")
+	}
+	if !sawCheFunnel {
+		t.Errorf("expected che-funnel builtin in list")
+	}
+}
+
+func TestList_OrderedBySlug(t *testing.T) {
+	tmp := t.TempDir()
+	cwd := filepath.Join(tmp, "proj")
+	home := filepath.Join(tmp, "home")
+
+	writePipelineYAML(t, filepath.Join(home, ".che", "pipelines", "zeta.yaml"), "z")
+	writePipelineYAML(t, filepath.Join(home, ".che", "pipelines", "alpha.yaml"), "a")
+
+	got, err := List(cwd, home)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	// alpha < che-funnel < zeta
+	for i := 1; i < len(got); i++ {
+		if got[i-1].Slug > got[i].Slug {
+			t.Errorf("not sorted: %q > %q at i=%d", got[i-1].Slug, got[i].Slug, i)
+		}
+	}
+}

--- a/internal/pipelines/paths.go
+++ b/internal/pipelines/paths.go
@@ -1,0 +1,72 @@
+package pipelines
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// pipelinesSubdir es el subdir relativo (sea bajo HOME o bajo cwd) donde
+// viven los archivos `.yaml`. Constante compartida entre project y global
+// para mantener simetria filesystem-local.
+const pipelinesSubdir = ".che/pipelines"
+
+// GlobalPipelinesDir devuelve el directorio absoluto donde viven los
+// pipelines globales del usuario (`~/.che/pipelines/`). home="" cae a
+// os.UserHomeDir(); error si HOME no se puede resolver.
+func GlobalPipelinesDir(home string) (string, error) {
+	if home == "" {
+		h, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		home = h
+	}
+	return filepath.Join(home, pipelinesSubdir), nil
+}
+
+// ProjectPipelinesDir devuelve el directorio del scope project relativo al
+// cwd indicado (`<cwd>/.che/pipelines/`). cwd="" no es valido aca — el
+// caller debe resolver el cwd una sola vez al startup. Devolvemos "" en ese
+// caso para que Resolve/List interpreten "scope project no disponible".
+func ProjectPipelinesDir(cwd string) string {
+	if cwd == "" {
+		return ""
+	}
+	return filepath.Join(cwd, pipelinesSubdir)
+}
+
+// GlobalPathFor compone el path absoluto del archivo del pipeline de scope
+// global cuyo slug es slug.
+func GlobalPathFor(home, slug string) (string, error) {
+	dir, err := GlobalPipelinesDir(home)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, slug+".yaml"), nil
+}
+
+// ProjectPathFor compone el path absoluto del archivo del pipeline de scope
+// project. Si cwd="" devuelve "" — usar GlobalPathFor en ese caso.
+func ProjectPathFor(cwd, slug string) string {
+	dir := ProjectPipelinesDir(cwd)
+	if dir == "" {
+		return ""
+	}
+	return filepath.Join(dir, slug+".yaml")
+}
+
+// PathForScope unifica el calculo de path segun scope. ScopeBuiltin no
+// tiene path en disco — devolvemos "".
+func PathForScope(scope Scope, cwd, home, slug string) (string, error) {
+	switch scope {
+	case ScopeProject:
+		p := ProjectPathFor(cwd, slug)
+		if p == "" {
+			return "", errEmptyCwd
+		}
+		return p, nil
+	case ScopeGlobal:
+		return GlobalPathFor(home, slug)
+	}
+	return "", nil
+}

--- a/internal/pipelines/persist.go
+++ b/internal/pipelines/persist.go
@@ -1,0 +1,32 @@
+package pipelines
+
+import (
+	"fmt"
+
+	"github.com/chichex/che/internal/wizard"
+)
+
+// SaveScoped serializa el pipeline al scope indicado, devolviendo el path
+// resultante. Para ScopeGlobal usa ~/.che/pipelines/<slug>.yaml; para
+// ScopeProject usa <cwd>/.che/pipelines/<slug>.yaml. ScopeBuiltin no se
+// puede persistir (los builtins viven embebidos) — devuelve error.
+//
+// slug debe estar pre-computado (wizard.Slug). El nombre/desc/steps del
+// pipeline ya tienen que estar materializados — esta funcion delega a
+// wizard.Save sin tocar el pipeline.
+func SaveScoped(scope Scope, cwd, home, slug string, p wizard.Pipeline) (string, error) {
+	if slug == "" {
+		return "", fmt.Errorf("pipelines: slug vacio")
+	}
+	path, err := PathForScope(scope, cwd, home, slug)
+	if err != nil {
+		return "", err
+	}
+	if path == "" {
+		return "", fmt.Errorf("pipelines: scope %q no soporta save", scope)
+	}
+	if err := wizard.Save(path, p); err != nil {
+		return "", err
+	}
+	return path, nil
+}

--- a/internal/pipelines/persist_test.go
+++ b/internal/pipelines/persist_test.go
@@ -1,0 +1,105 @@
+package pipelines
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chichex/che/internal/wizard"
+)
+
+func TestSaveScoped_Global(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+
+	p := wizard.Pipeline{
+		Name:        "demo",
+		Description: "test",
+		Steps: []wizard.Step{
+			{Name: "s1", CLI: "claude", Kind: "prompt", Content: "hola", Input: "none"},
+		},
+	}
+
+	path, err := SaveScoped(ScopeGlobal, "", home, "demo", p)
+	if err != nil {
+		t.Fatalf("SaveScoped: %v", err)
+	}
+	want := filepath.Join(home, ".che", "pipelines", "demo.yaml")
+	if path != want {
+		t.Errorf("path = %q, want %q", path, want)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("file should exist: %v", err)
+	}
+}
+
+func TestSaveScoped_Project(t *testing.T) {
+	tmp := t.TempDir()
+	cwd := filepath.Join(tmp, "proj")
+
+	p := wizard.Pipeline{
+		Name: "demo",
+		Steps: []wizard.Step{
+			{Name: "s1", CLI: "claude", Kind: "prompt", Content: "hola", Input: "none"},
+		},
+	}
+
+	path, err := SaveScoped(ScopeProject, cwd, "", "demo", p)
+	if err != nil {
+		t.Fatalf("SaveScoped: %v", err)
+	}
+	want := filepath.Join(cwd, ".che", "pipelines", "demo.yaml")
+	if path != want {
+		t.Errorf("path = %q, want %q", path, want)
+	}
+}
+
+func TestSaveScoped_BuiltinFails(t *testing.T) {
+	_, err := SaveScoped(ScopeBuiltin, "/tmp", "/tmp", "x", wizard.Pipeline{})
+	if err == nil {
+		t.Errorf("expected error saving builtin scope")
+	}
+}
+
+func TestSaveScoped_ProjectWithEmptyCwdFails(t *testing.T) {
+	_, err := SaveScoped(ScopeProject, "", "/tmp", "x", wizard.Pipeline{})
+	if err == nil {
+		t.Errorf("expected error saving project with empty cwd")
+	}
+}
+
+func TestSaveScoped_EmptySlugFails(t *testing.T) {
+	_, err := SaveScoped(ScopeGlobal, "", "/tmp", "", wizard.Pipeline{})
+	if err == nil {
+		t.Errorf("expected error saving with empty slug")
+	}
+}
+
+func TestPathHelpers(t *testing.T) {
+	if got := ProjectPipelinesDir(""); got != "" {
+		t.Errorf("ProjectPipelinesDir(\"\") = %q, want \"\"", got)
+	}
+	if got := ProjectPipelinesDir("/p"); got != filepath.Join("/p", ".che", "pipelines") {
+		t.Errorf("ProjectPipelinesDir: %q", got)
+	}
+	if got := ProjectPathFor("/p", "x"); got != filepath.Join("/p", ".che", "pipelines", "x.yaml") {
+		t.Errorf("ProjectPathFor: %q", got)
+	}
+	if got := ProjectPathFor("", "x"); got != "" {
+		t.Errorf("ProjectPathFor empty cwd: %q", got)
+	}
+}
+
+func TestScopeString(t *testing.T) {
+	cases := map[Scope]string{
+		ScopeProject: "project",
+		ScopeGlobal:  "global",
+		ScopeBuiltin: "builtin",
+		ScopeUnknown: "",
+	}
+	for s, want := range cases {
+		if got := s.String(); got != want {
+			t.Errorf("Scope(%d).String() = %q, want %q", s, got, want)
+		}
+	}
+}

--- a/internal/pipelines/resolve.go
+++ b/internal/pipelines/resolve.go
@@ -1,0 +1,110 @@
+package pipelines
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/chichex/che/internal/wizard"
+)
+
+// Resolved es el resultado materializado de Resolve / List: pipeline
+// parseado + scope + target serializable para el runner. target es el
+// path absoluto en disco cuando scope es Project/Global, o
+// "builtin:<slug>" cuando scope es Builtin (mismo formato que entiende
+// runner.StartHeadless).
+type Resolved struct {
+	Slug     string
+	Pipeline wizard.Pipeline
+	Scope    Scope
+	Target   string
+}
+
+// Resolve busca un pipeline por slug en el orden project → global →
+// builtin. Si project y global definen el mismo slug, gana project.
+// cwd="" salta el scope project (degradacion silenciosa).
+//
+// Devuelve found=false si el slug no existe en ningun scope. Errores de
+// IO/parse (distintos a "no existe") se propagan tal cual para que el
+// caller logee con contexto.
+//
+// home="" cae a os.UserHomeDir; si falla, scope global queda deshabilitado.
+func Resolve(cwd, home, slug string) (Resolved, bool, error) {
+	gdir, err := GlobalPipelinesDir(home)
+	if err != nil {
+		gdir = ""
+	}
+	return ResolveInDirs(cwd, gdir, slug)
+}
+
+// ResolveInDirs es la version baja-nivel de Resolve: toma el directorio
+// global ya resuelto (en vez de home). Util para callers que ya tienen
+// el dir absoluto cacheado al startup (ej. el dash). cwd="" desactiva
+// scope project; globalDir="" desactiva scope global; en ambos casos
+// la cascada degrada a builtins.
+func ResolveInDirs(cwd, globalDir, slug string) (Resolved, bool, error) {
+	if slug == "" {
+		return Resolved{}, false, nil
+	}
+
+	// 1. Scope project — cwd-local, gana sobre global y builtin.
+	if path := ProjectPathFor(cwd, slug); path != "" {
+		p, err := tryLoadFromFS(path)
+		if err != nil {
+			return Resolved{}, false, err
+		}
+		if p != nil {
+			return Resolved{
+				Slug:     slug,
+				Pipeline: *p,
+				Scope:    ScopeProject,
+				Target:   path,
+			}, true, nil
+		}
+	}
+
+	// 2. Scope global — home-local, gana sobre builtin.
+	if globalDir != "" {
+		gpath := filepath.Join(globalDir, slug+".yaml")
+		p, err := tryLoadFromFS(gpath)
+		if err != nil {
+			return Resolved{}, false, err
+		}
+		if p != nil {
+			return Resolved{
+				Slug:     slug,
+				Pipeline: *p,
+				Scope:    ScopeGlobal,
+				Target:   gpath,
+			}, true, nil
+		}
+	}
+
+	// 3. Builtin — ultimo fallback.
+	b, berr := wizard.BuiltinBySlug(slug)
+	if berr != nil {
+		return Resolved{}, false, berr
+	}
+	if b == nil {
+		return Resolved{}, false, nil
+	}
+	return Resolved{
+		Slug:     slug,
+		Pipeline: b.Pipeline,
+		Scope:    ScopeBuiltin,
+		Target:   wizard.BuiltinTargetPrefix + slug,
+	}, true, nil
+}
+
+// tryLoadFromFS lee y parsea un pipeline del path. Devuelve (nil, nil)
+// si el archivo no existe (caso esperado durante la cascada de
+// resolucion). Otros errores se propagan.
+func tryLoadFromFS(path string) (*wizard.Pipeline, error) {
+	p, err := wizard.Load(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &p, nil
+}

--- a/internal/pipelines/resolve_test.go
+++ b/internal/pipelines/resolve_test.go
@@ -1,0 +1,127 @@
+package pipelines
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chichex/che/internal/wizard"
+)
+
+// writePipelineYAML escribe un pipeline minimo viable parseable por
+// wizard.Load. Helper compartido entre tests de resolve/list/persist.
+func writePipelineYAML(t *testing.T, path, name string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := "name: " + name + "\nsteps:\n  - name: paso1\n    cli: claude\n    kind: prompt\n    content: hola\n    input: none\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestResolve_ProjectOverridesGlobal(t *testing.T) {
+	tmp := t.TempDir()
+	cwd := filepath.Join(tmp, "proj")
+	home := filepath.Join(tmp, "home")
+
+	writePipelineYAML(t, filepath.Join(cwd, ".che", "pipelines", "demo.yaml"), "demo-project")
+	writePipelineYAML(t, filepath.Join(home, ".che", "pipelines", "demo.yaml"), "demo-global")
+
+	got, found, err := Resolve(cwd, home, "demo")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected found=true")
+	}
+	if got.Scope != ScopeProject {
+		t.Errorf("scope = %v, want ScopeProject", got.Scope)
+	}
+	if got.Pipeline.Name != "demo-project" {
+		t.Errorf("pipeline.Name = %q, want demo-project", got.Pipeline.Name)
+	}
+}
+
+func TestResolve_FallsBackToGlobal(t *testing.T) {
+	tmp := t.TempDir()
+	cwd := filepath.Join(tmp, "proj")
+	home := filepath.Join(tmp, "home")
+
+	// solo global existe
+	writePipelineYAML(t, filepath.Join(home, ".che", "pipelines", "alpha.yaml"), "alpha")
+
+	got, found, err := Resolve(cwd, home, "alpha")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected found=true")
+	}
+	if got.Scope != ScopeGlobal {
+		t.Errorf("scope = %v, want ScopeGlobal", got.Scope)
+	}
+}
+
+func TestResolve_FallsBackToBuiltin(t *testing.T) {
+	tmp := t.TempDir()
+	cwd := filepath.Join(tmp, "proj")
+	home := filepath.Join(tmp, "home")
+
+	got, found, err := Resolve(cwd, home, "che-funnel")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected che-funnel builtin to resolve")
+	}
+	if got.Scope != ScopeBuiltin {
+		t.Errorf("scope = %v, want ScopeBuiltin", got.Scope)
+	}
+	if !wizard.IsBuiltinTarget(got.Target) {
+		t.Errorf("target = %q, want builtin: prefix", got.Target)
+	}
+}
+
+func TestResolve_NotFound(t *testing.T) {
+	tmp := t.TempDir()
+	cwd := filepath.Join(tmp, "proj")
+	home := filepath.Join(tmp, "home")
+
+	_, found, err := Resolve(cwd, home, "nope-no-existo")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if found {
+		t.Fatalf("expected found=false for missing slug")
+	}
+}
+
+func TestResolve_EmptyCwdSkipsProject(t *testing.T) {
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	writePipelineYAML(t, filepath.Join(home, ".che", "pipelines", "x.yaml"), "x")
+
+	got, found, err := Resolve("", home, "x")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected found=true")
+	}
+	if got.Scope != ScopeGlobal {
+		t.Errorf("scope = %v, want ScopeGlobal", got.Scope)
+	}
+}
+
+func TestResolve_EmptySlugReturnsNotFound(t *testing.T) {
+	tmp := t.TempDir()
+	_, found, err := Resolve(tmp, tmp, "")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if found {
+		t.Fatalf("expected found=false for empty slug")
+	}
+}

--- a/internal/pipelines/scope.go
+++ b/internal/pipelines/scope.go
@@ -1,0 +1,37 @@
+// Package pipelines centraliza la resolucion, listado y persistencia
+// de pipelines de che. Soporta visibilidad dual: pipelines de proyecto
+// (cwd-local en `./.che/pipelines/`) y globales (`~/.che/pipelines/`).
+// Los builtins embebidos del binario quedan como ultimo fallback.
+//
+// El scope NO se persiste dentro del YAML — la ubicacion en filesystem
+// es la unica fuente de verdad.
+package pipelines
+
+// Scope identifica el origen de un pipeline: project, global o builtin.
+// El scope es implicito en la ubicacion en filesystem.
+type Scope int
+
+const (
+	// ScopeUnknown es el zero-value; usado como "no encontrado".
+	ScopeUnknown Scope = iota
+	// ScopeProject = pipeline cargado desde `./.che/pipelines/` (cwd-local).
+	ScopeProject
+	// ScopeGlobal = pipeline cargado desde `~/.che/pipelines/`.
+	ScopeGlobal
+	// ScopeBuiltin = pipeline embebido en el binario.
+	ScopeBuiltin
+)
+
+// String devuelve la forma serializable (json-safe) del scope.
+// "" para ScopeUnknown — el JSON omite el campo via omitempty.
+func (s Scope) String() string {
+	switch s {
+	case ScopeProject:
+		return "project"
+	case ScopeGlobal:
+		return "global"
+	case ScopeBuiltin:
+		return "builtin"
+	}
+	return ""
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -3,11 +3,11 @@ package runner
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/chichex/che/internal/pipelines"
 	"github.com/chichex/che/internal/wizard"
 )
 
@@ -34,34 +34,26 @@ func LoadPipelineByTarget(target string) (wizard.Pipeline, error) {
 }
 
 // ResolveSlug convierte un slug de usuario en el target que StartHeadless
-// espera y en el inputKind del primer step. Busca en este orden:
-//  1. ~/.che/pipelines/<slug>.yaml (pipelines de usuario)
-//  2. builtin:<slug> (pipelines embebidos via wizard.Builtins)
+// espera y en el inputKind del primer step. Delega a pipelines.Resolve
+// para mantener una unica fuente de verdad del orden de busqueda:
+//  1. <cwd>/.che/pipelines/<slug>.yaml (scope project)
+//  2. ~/.che/pipelines/<slug>.yaml (scope global)
+//  3. builtin:<slug> (pipelines embebidos via wizard.Builtins)
 //
 // Devuelve error si el slug no existe en ninguna fuente. inputKind es
 // wizard.InputNone ("none") si no se pudo cargar el pipeline — el caller
 // debe chequear error primero.
 func ResolveSlug(slug string) (target, inputKind string, err error) {
-	home, herr := os.UserHomeDir()
-	if herr == nil {
-		path := filepath.Join(home, ".che", "pipelines", slug+".yaml")
-		if _, sterr := os.Stat(path); sterr == nil {
-			p, lerr := wizard.Load(path)
-			if lerr != nil {
-				return "", wizard.InputNone, fmt.Errorf("runner: load %s: %w", path, lerr)
-			}
-			return path, firstInputKind(p), nil
-		}
+	cwd, _ := os.Getwd()
+	home, _ := os.UserHomeDir()
+	res, found, rerr := pipelines.Resolve(cwd, home, slug)
+	if rerr != nil {
+		return "", wizard.InputNone, fmt.Errorf("runner: resolve %q: %w", slug, rerr)
 	}
-	// Fallback: builtin.
-	b, berr := wizard.BuiltinBySlug(slug)
-	if berr != nil {
-		return "", wizard.InputNone, fmt.Errorf("runner: builtin lookup %q: %w", slug, berr)
-	}
-	if b == nil {
+	if !found {
 		return "", wizard.InputNone, fmt.Errorf("runner: pipeline %q no encontrado", slug)
 	}
-	return "builtin:" + slug, firstInputKind(b.Pipeline), nil
+	return res.Target, firstInputKind(res.Pipeline), nil
 }
 
 // loadPipelineForRun resuelve `target` a un Pipeline parseado. Si target

--- a/internal/wizard/info.go
+++ b/internal/wizard/info.go
@@ -69,8 +69,11 @@ func (m model) passKeyToFocused(key tea.KeyMsg) (model, tea.Cmd) {
 }
 
 // tryAdvance es el handler de "siguiente" (ctrl+s) en S1. Valida nombre
-// + slug, detecta colisiones, persiste el archivo con status:info, y
-// pasa al placeholder de S2.
+// + slug. Si todavia no hay archivo persistido (primer save), abre la
+// pantalla de seleccion de scope (ScreenScope) para que el usuario
+// decida entre project y global. Si ya hay path (re-save del mismo
+// draft), persiste al path existente y avanza a S2 sin volver a pedir
+// scope — el scope ya esta implicito en la ubicacion del archivo.
 func (m model) tryAdvance() (model, tea.Cmd) {
 	name := strings.TrimSpace(m.nameInput.Value())
 	if name == "" {
@@ -83,55 +86,49 @@ func (m model) tryAdvance() (model, tea.Cmd) {
 		return m, nil
 	}
 
-	path, err := PathFor(m.homeDir, slug)
-	if err != nil {
-		m.errMsg = "no se pudo resolver HOME: " + err.Error()
-		return m, nil
-	}
-
-	// Si el path ya existe Y no es nuestro path actual (re-save del
-	// mismo draft), abrimos el modal de colision.
-	if path != m.path {
-		exists, err := Exists(path)
+	// Camino "re-save de draft existente": ya hay path, no abrimos
+	// ScreenScope (el scope es el del path actual). Validamos colision
+	// solo si el slug cambio.
+	if m.path != "" {
+		path, err := PathFor(m.homeDir, slug)
 		if err != nil {
-			m.errMsg = "no se pudo chequear el archivo: " + err.Error()
+			m.errMsg = "no se pudo resolver HOME: " + err.Error()
 			return m, nil
 		}
-		if exists {
-			m.collisionCursor = CollisionOverwrite
-			m.screen = ScreenCollision
+		// Si el path actual no esta bajo el home global lo dejamos
+		// igual — slug puede haber cambiado pero el scope original
+		// gana (project se queda project).
+		_ = path
+		m.pipeline.Name = name
+		m.pipeline.Description = strings.TrimSpace(m.descInput.Value())
+		m.pipeline.Status = &Status{
+			Stage:       StageInfo,
+			LastSavedAt: time.Now(),
+		}
+		if err := Save(m.path, m.pipeline); err != nil {
+			m.errMsg = "no se pudo guardar: " + err.Error()
 			return m, nil
 		}
+		m.errMsg = ""
+		return m.enterStepCreate(0)
 	}
 
-	m.path = path
-	m.pipeline.Name = name
-	m.pipeline.Description = strings.TrimSpace(m.descInput.Value())
-	m.pipeline.Status = &Status{
-		Stage:       StageInfo,
-		LastSavedAt: time.Now(),
-	}
-
-	if err := Save(m.path, m.pipeline); err != nil {
-		m.errMsg = "no se pudo guardar: " + err.Error()
-		return m, nil
-	}
-
+	// First save — necesitamos saber el scope. Abrir ScreenScope. El
+	// cursor se posiciona en global (default). La pantalla de scope
+	// valida colisiones / persiste / avanza a S2.
 	m.errMsg = ""
-	// Entrar a S2 con step 0 mode=create. enterStepCreate persiste de
-	// nuevo con status.stage=step para que el archivo refleje donde
-	// estamos al instante.
-	return m.enterStepCreate(0)
+	m.screen = ScreenScope
+	return m, nil
 }
 
 // confirmOverwrite es la rama "sobreescribir" del modal de colision —
-// fuerza el save al path existente.
+// fuerza el save al path correspondiente al scope elegido.
 func (m model) confirmOverwrite() (model, tea.Cmd) {
 	name := strings.TrimSpace(m.nameInput.Value())
 	slug := Slug(name)
-	path, err := PathFor(m.homeDir, slug)
+	path, err := m.resolvePathForScope(slug)
 	if err != nil {
-		m.errMsg = "no se pudo resolver HOME: " + err.Error()
+		m.errMsg = err.Error()
 		m.screen = ScreenInfo
 		return m, nil
 	}

--- a/internal/wizard/list.go
+++ b/internal/wizard/list.go
@@ -270,10 +270,15 @@ func builtinToListItem(b BuiltinPipeline) listItem {
 	}
 }
 
-// builtinTargetPrefix es el sentinel que el lister usa al devolver
+// BuiltinTargetPrefix es el sentinel que el lister usa al devolver
 // ListActionRun sobre un builtin. El runner detecta el prefijo y carga el
-// pipeline via wizard.Builtins() en vez de tocar el FS.
-const builtinTargetPrefix = "builtin:"
+// pipeline via wizard.Builtins() en vez de tocar el FS. Exportado para
+// que internal/pipelines tambien lo emita al resolver scope=builtin.
+const BuiltinTargetPrefix = "builtin:"
+
+// builtinTargetPrefix mantiene el simbolo previo (unexported) para no
+// alterar callsites internos del paquete. Es alias de BuiltinTargetPrefix.
+const builtinTargetPrefix = BuiltinTargetPrefix
 
 // IsBuiltinTarget devuelve true si target tiene el prefijo de builtin.
 // El runner lo usa para ramificar entre Load(path) y BuiltinBySlug.

--- a/internal/wizard/model.go
+++ b/internal/wizard/model.go
@@ -27,6 +27,18 @@ const (
 	ScreenDiscardWarn                        // confirmacion extra antes de discard
 	ScreenSummaryConfirmDelete               // modal confirm "borrar step" desde S3 (H7)
 	ScreenStepReview                         // modal "Review del prompt" (claude analiza el prompt antes de guardar)
+	ScreenScope                              // S1.5: selector de scope (project vs global) — solo en first save
+)
+
+// WizardScope refleja el scope que el usuario eligio para persistir el
+// pipeline. Es estado UI puro — el scope efectivo del pipeline en disco
+// queda implicito en su ubicacion (proyecto vs global). El default es
+// scope global (para preservar back-compat con usuarios existentes).
+type WizardScope int
+
+const (
+	WizardScopeGlobal WizardScope = iota
+	WizardScopeProject
 )
 
 // FieldFocus marca cual campo de S1 tiene el foco. tab/shift+tab cyclan
@@ -361,6 +373,20 @@ type model struct {
 
 	// HomeDir a usar. "" significa $HOME real; los tests inyectan tmp dir.
 	homeDir string
+
+	// cwd a usar para scope project. "" desactiva el scope project — el
+	// wizard sigue funcionando exactamente como antes (default global).
+	// Tests pueden inyectar tmp dir; el caller real lo setea via newModel
+	// con os.Getwd().
+	cwd string
+
+	// scope elegido por el usuario en ScreenScope. Default global asi un
+	// usuario que se saltea la pantalla (por ejemplo, ENTER directo sobre
+	// la opcion preselected) mantiene el comportamiento previo. Solo se
+	// usa cuando m.path == "" (primer save). Si el wizard se reanuda
+	// sobre un draft existente, el scope ya esta definido por la
+	// ubicacion del archivo en disco y la pantalla no aparece.
+	scope WizardScope
 
 	// originalReadySnapshot guarda los bytes del archivo ready original
 	// cuando entramos al wizard via RunEditReady. Si el usuario elige

--- a/internal/wizard/scope.go
+++ b/internal/wizard/scope.go
@@ -1,0 +1,181 @@
+package wizard
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// projectPipelinesSubdir es el subdir relativo al cwd donde viven los
+// pipelines de scope project. Hay un eco intencional con
+// `internal/pipelines.pipelinesSubdir` — la constante esta duplicada para
+// evitar que wizard importe pipelines (cycle), pero el valor SIEMPRE debe
+// coincidir. Si cambias uno, cambia el otro.
+const projectPipelinesSubdir = ".che/pipelines"
+
+// projectPathFor devuelve el path absoluto del archivo del pipeline en
+// scope project. cwd="" devuelve "" — el caller debe degradar a global.
+func projectPathFor(cwd, slug string) string {
+	if cwd == "" {
+		return ""
+	}
+	return filepath.Join(cwd, projectPipelinesSubdir, slug+".yaml")
+}
+
+// resolvePathForScope calcula el path de save segun el scope del wizard.
+// Falla limpio si el scope project se pidio sin cwd; el caller debe
+// surfacear como errMsg.
+func (m model) resolvePathForScope(slug string) (string, error) {
+	if m.scope == WizardScopeProject {
+		path := projectPathFor(m.cwd, slug)
+		if path == "" {
+			return "", fmt.Errorf("scope project no disponible (cwd vacio)")
+		}
+		return path, nil
+	}
+	return PathFor(m.homeDir, slug)
+}
+
+// updateScope handla teclas en ScreenScope (selector project vs global).
+func (m model) updateScope(key tea.KeyMsg) (model, tea.Cmd) {
+	switch key.String() {
+	case "ctrl+c":
+		return m.openCancel(ScreenScope)
+	case "esc":
+		// volver a S1, mantener buffers.
+		m.screen = ScreenInfo
+		m.errMsg = ""
+		return m, nil
+	case "up", "k", "left", "h":
+		if m.scope == WizardScopeProject {
+			m.scope = WizardScopeGlobal
+		}
+		return m, nil
+	case "down", "j", "right", "l":
+		if m.scope == WizardScopeGlobal {
+			m.scope = WizardScopeProject
+		}
+		return m, nil
+	case "1":
+		m.scope = WizardScopeGlobal
+		return m.commitScopeAndAdvance()
+	case "2":
+		m.scope = WizardScopeProject
+		return m.commitScopeAndAdvance()
+	case "tab":
+		// tab toggle entre las dos opciones.
+		if m.scope == WizardScopeGlobal {
+			m.scope = WizardScopeProject
+		} else {
+			m.scope = WizardScopeGlobal
+		}
+		return m, nil
+	case "enter", "ctrl+s", " ":
+		return m.commitScopeAndAdvance()
+	}
+	return m, nil
+}
+
+// commitScopeAndAdvance materializa la decision de scope: calcula path,
+// detecta colision, persiste, y avanza a S2. Si el scope project se
+// pidio sin cwd o el slug no se puede resolver, marca errMsg y vuelve a
+// ScreenInfo.
+func (m model) commitScopeAndAdvance() (model, tea.Cmd) {
+	name := strings.TrimSpace(m.nameInput.Value())
+	slug := Slug(name)
+	if slug == "" {
+		// no deberia pasar (S1 ya valido), pero defensive: volver a S1.
+		m.errMsg = "nombre invalido"
+		m.screen = ScreenInfo
+		return m, nil
+	}
+
+	path, err := m.resolvePathForScope(slug)
+	if err != nil {
+		m.errMsg = err.Error()
+		// el usuario tiene que elegir otra cosa; volver a la pantalla.
+		m.scope = WizardScopeGlobal
+		return m, nil
+	}
+
+	exists, err := Exists(path)
+	if err != nil {
+		m.errMsg = "no se pudo chequear el archivo: " + err.Error()
+		return m, nil
+	}
+	if exists {
+		m.collisionCursor = CollisionOverwrite
+		m.screen = ScreenCollision
+		return m, nil
+	}
+
+	m.path = path
+	m.pipeline.Name = name
+	m.pipeline.Description = strings.TrimSpace(m.descInput.Value())
+	m.pipeline.Status = &Status{
+		Stage:       StageInfo,
+		LastSavedAt: time.Now(),
+	}
+	if err := Save(m.path, m.pipeline); err != nil {
+		m.errMsg = "no se pudo guardar: " + err.Error()
+		return m, nil
+	}
+	m.errMsg = ""
+	return m.enterStepCreate(0)
+}
+
+// viewScope renderea ScreenScope: dos opciones (global, project) con la
+// seleccionada destacada. El path resuelto se muestra dimmed para que el
+// usuario sepa exactamente donde se guarda.
+func (m model) viewScope() string {
+	var b strings.Builder
+	b.WriteString(breadcrumb("Create pipeline", "paso 1/3 · scope"))
+	b.WriteString("\n\n")
+	b.WriteString("Donde guardar este pipeline?")
+	b.WriteString("\n\n")
+
+	name := strings.TrimSpace(m.nameInput.Value())
+	slug := Slug(name)
+
+	globalPath, _ := PathFor(m.homeDir, slug)
+	projectPath := projectPathFor(m.cwd, slug)
+
+	options := []struct {
+		idx   WizardScope
+		digit string
+		label string
+		hint  string
+		path  string
+	}{
+		{WizardScopeGlobal, "1", "global", "disponible desde cualquier cwd", globalPath},
+		{WizardScopeProject, "2", "project", "solo desde este proyecto (cwd-local)", projectPath},
+	}
+	for _, o := range options {
+		marker := "  "
+		labelLine := o.digit + ". " + o.label
+		if m.scope == o.idx {
+			marker = "> "
+			labelLine = selectedItem.Render(labelLine)
+		}
+		row := marker + labelLine + "  " + dimStyle.Render(o.hint)
+		if o.path != "" {
+			row += "\n      " + dimStyle.Render(o.path)
+		} else if o.idx == WizardScopeProject {
+			row += "\n      " + dimStyle.Render("(cwd no disponible — no se puede usar este scope)")
+		}
+		b.WriteString(row)
+		b.WriteString("\n\n")
+	}
+
+	if m.errMsg != "" {
+		b.WriteString(errorStyle.Render("✗ " + m.errMsg))
+		b.WriteString("\n\n")
+	}
+
+	b.WriteString(hintStyle.Render("↑/↓ navegar · enter elegir · esc volver"))
+	b.WriteString("\n")
+	return b.String()
+}

--- a/internal/wizard/wizard.go
+++ b/internal/wizard/wizard.go
@@ -3,6 +3,8 @@ package wizard
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -44,6 +46,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch m.screen {
 	case ScreenInfo:
 		return m.updateInfo(key)
+	case ScreenScope:
+		return m.updateScope(key)
 	case ScreenStep:
 		return m.updateStep(key)
 	case ScreenStepReview:
@@ -69,6 +73,8 @@ func (m model) View() string {
 	switch m.screen {
 	case ScreenInfo:
 		return m.viewInfo()
+	case ScreenScope:
+		return m.viewScope()
 	case ScreenStep:
 		return m.viewStep()
 	case ScreenStepReview:
@@ -90,14 +96,27 @@ func (m model) View() string {
 }
 
 // newModel construye el modelo inicial con el HOME indicado. home=""
-// significa "usar $HOME real"; los tests inyectan tmp dir.
+// significa "usar $HOME real"; los tests inyectan tmp dir. El cwd se
+// resuelve via os.Getwd() — si falla queda vacio y el scope project
+// queda deshabilitado en la pantalla S1.5.
 func newModel(home string) model {
+	cwd, _ := os.Getwd()
+	return newModelWithDirs(home, cwd)
+}
+
+// newModelWithDirs es el entrypoint testeable que permite inyectar
+// tanto home como cwd. El scope default es global para preservar
+// back-compat (usuarios existentes que no eligen nada caen al scope
+// previo).
+func newModelWithDirs(home, cwd string) model {
 	return model{
 		screen:    ScreenInfo,
 		focus:     FocusName,
 		nameInput: newSingleLine("ej: Triage checkout flow"),
 		descInput: newMultiLine("ej: toma una metrica anomala y dispara un triage"),
 		homeDir:   home,
+		cwd:       cwd,
+		scope:     WizardScopeGlobal,
 	}
 }
 
@@ -143,6 +162,7 @@ func RunResume(path string) (bool, error) {
 func runResumeWithHome(home, path string) (bool, error) {
 	m := newModel(home)
 	m.path = path
+	m.scope = scopeFromPath(path, m.cwd, home)
 	p, err := Load(path)
 	if err != nil {
 		// Fallback duro: archivo ilegible. Arrancamos en S1 sin path para
@@ -216,6 +236,33 @@ func RunEditReady(path string) (bool, error) {
 	return runEditReadyWithHome("", path)
 }
 
+// scopeFromPath infiere el WizardScope mirando el path: si esta bajo
+// `<cwd>/.che/pipelines/` es project; cualquier otra cosa cae a global.
+// Sirve para que RunResume / RunEditReady levanten el scope correcto al
+// rehidratar un draft existente sin pasar por ScreenScope.
+func scopeFromPath(path, cwd, _ string) WizardScope {
+	if cwd == "" || path == "" {
+		return WizardScopeGlobal
+	}
+	projectDir, err := filepath.Abs(filepath.Join(cwd, projectPipelinesSubdir))
+	if err != nil {
+		return WizardScopeGlobal
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return WizardScopeGlobal
+	}
+	rel, err := filepath.Rel(projectDir, abs)
+	if err != nil {
+		return WizardScopeGlobal
+	}
+	// rel sin ".." significa que el path vive dentro del project dir.
+	if rel != "" && !strings.HasPrefix(rel, "..") && rel != "." {
+		return WizardScopeProject
+	}
+	return WizardScopeGlobal
+}
+
 func runEditReadyWithHome(home, path string) (bool, error) {
 	p, err := Load(path)
 	if err != nil {
@@ -260,6 +307,7 @@ func runEditReadyWithHome(home, path string) (bool, error) {
 	}
 	m := newModel(home)
 	m.path = path
+	m.scope = scopeFromPath(path, m.cwd, home)
 	m.pipeline = p
 	m.originalReadySnapshot = origSnapshot
 	if p.Name != "" {


### PR DESCRIPTION
## Resumen

Implementa visibilidad dual (project vs global) para pipelines en che. Centraliza la lógica de resolución, listado y persistencia en un nuevo paquete `internal/pipelines/` que reemplaza la duplicación entre `internal/dash/runs_create.go` y `internal/runner/runner.go`.

## Cambios

- **Nuevo paquete `internal/pipelines/`**: tipo `Scope`, funciones `Resolve`/`ResolveInDirs`, `List`/`ListInDirs`, `SaveScoped`, helpers de path. Tests unitarios cubren orden de resolución, override project-sobre-global, fallback a builtin, save por scope.
- **Wizard CLI**: nueva pantalla `ScreenScope` entre info (S1) y step editor (S2), con default global. Drafts existentes infieren scope al reanudar via `scopeFromPath`.
- **Dash**: `loadPipelineForSlug` y `mergeBuiltinsAndDisk` delegan al paquete nuevo. JSON expone `scope` (`"project"|"global"|"builtin"`); el badge se renderiza en el frontend. `cwd` se resuelve una vez al startup.
- **Runner**: `ResolveSlug` delega a `pipelines.Resolve` — orden `project → global → builtin`.
- **Dash HTML**: badges `project`/`global`/`builtin` en rail y detalle de pipeline.

## Criterios cubiertos

- [x] Wizard CLI muestra paso de selección de scope (default global) entre info y step editor; guarda en `./.che/pipelines/<slug>.yaml` o `~/.che/pipelines/<slug>.yaml` según corresponda.
- [x] Resolución por slug en runtime sigue orden `project → global → builtin`; project gana ante colisión con global.
- [x] Listado del dash muestra pipelines de ambos scopes con badge visual `project` | `global` | `builtin`. Override project-sobre-global muestra solo el ganador.
- [x] Builtins siguen disponibles desde cualquier cwd; no se ven afectados.
- [x] `Scope` NO se persiste en el YAML — la ubicación en filesystem es la única fuente de verdad.
- [x] La ubicación de los runs no depende del scope del pipeline.
- [x] Si el cwd no tiene `./.che/pipelines/`, listado y resolución funcionan igual que hoy.
- [x] `cwd` se resuelve UNA vez al startup del dash (`os.Getwd()`).
- [x] Detección del project dir es **cwd-exacto** (no walk-up).
- [x] Tests cubren: resolución, override, fallback a builtin, missing project dir, save por scope, listado dual con badge correcto.
- [x] `loadPipelineForSlug`, `ResolveSlug` y `mergeBuiltinsAndDisk` quedan como thin wrappers / migrados al paquete.
- [x] No se agrega comando para mover pipelines entre scopes (fuera de alcance).

## Notas de ejecución

- El form de creación de pipeline en el dash todavía delega al wizard CLI (no hay form web). El badge en el listado es el cambio frontend visible.
- La pantalla `ScreenScope` agrega un paso extra al wizard; los e2e tests fueron ajustados para enviar `ctrl+s` dos veces (S1 → scope → S2).
- Constante `BuiltinTargetPrefix` exportada en `internal/wizard/list.go` para que `internal/pipelines/` la emita sin duplicar el string.

Closes #141
