### PR TITLE
feat(runner): permitir 'model:' por step en YAML para los 4 CLIs

### DIFF
--- a/internal/runner/models.go
+++ b/internal/runner/models.go
@@ -1,0 +1,113 @@
+package runner
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// modelsByCLI es el whitelist hardcoded de modelos aceptados por cada CLI
+// soportado por el runner. Cualquier `model:` declarado en el YAML que no
+// matchee se rechaza en preflight con un error claro ANTES de spawnear.
+//
+// La tabla se actualiza por PR cuando salen modelos nuevos — no hay
+// autodescubrimiento. Cuando un CLI saca un alias nuevo, agregar la entry
+// aca y bumpear el slice en orden alfabetico para que el remedy del
+// preflight liste los validos de forma estable.
+//
+// opencode no esta en la tabla: no soporta override de modelo desde el
+// YAML (el flag --model no es estable en su CLI). ValidateModel maneja el
+// case especial: si un step con cli=opencode trae model: distinto de "",
+// rebota con un mensaje accionable.
+var modelsByCLI = map[string][]string{
+	"claude": {
+		// Aliases cortos (preferidos para escribir en YAML).
+		"opus",
+		"sonnet",
+		"haiku",
+		"opusplan",
+		// Nombres completos.
+		"claude-opus-4-7",
+		"claude-sonnet-4-6",
+		"claude-haiku-4-5",
+	},
+	"codex": {
+		"gpt-5.5",
+		"gpt-5.4",
+		"gpt-5.4-mini",
+		"gpt-5.3-codex-spark",
+		"gpt-5.2",
+		"gpt-5.2-codex",
+		"gpt-5.1-codex-max",
+		"gpt-5.1-codex-mini",
+	},
+	"gemini": {
+		"gemini-2.5-pro",
+		"gemini-2.5-flash",
+		"gemini-2.5-flash-lite",
+	},
+}
+
+// defaultModelByCLI es el modelo que el runner pasa cuando un step no
+// declara `model:` en el YAML. Para opencode el default es "" (no se setea
+// flag — queda el que tenga configurado el propio CLI).
+var defaultModelByCLI = map[string]string{
+	"claude":   "opus",
+	"codex":    "gpt-5.5",
+	"gemini":   "gemini-2.5-pro",
+	"opencode": "",
+}
+
+// DefaultModel devuelve el modelo default para el CLI dado. Para CLIs
+// desconocidos devuelve "" (el caller normalmente termina pasando este
+// valor sin flag — los CLIs nuevos no soportan override desde YAML hasta
+// que se agreguen al whitelist).
+func DefaultModel(cli string) string {
+	return defaultModelByCLI[cli]
+}
+
+// ValidateModel verifica que el modelo declarado en el YAML sea aceptado
+// por el CLI. Reglas:
+//
+//   - model == "" siempre pasa (la rama "sin override" cae al default por
+//     CLI; compat con YAMLs viejos que no declaran el campo).
+//   - cli == "opencode" + model != "" siempre rechaza con un mensaje
+//     accionable. El YAML no es el lugar para configurar el modelo de
+//     opencode.
+//   - Para claude/codex/gemini, el modelo tiene que matchear el whitelist
+//     exactamente (case-sensitive). Si no, error con la lista de aceptados.
+//   - CLIs desconocidos (no en modelsByCLI ni "opencode") pasan: el runner
+//     no opina sobre overrides para CLIs que no soporta como ciudadano
+//     primer-class. Si despues alguien quiere whitelist para un CLI nuevo,
+//     se agrega aca.
+func ValidateModel(cli, model string) error {
+	if model == "" {
+		return nil
+	}
+	if cli == "opencode" {
+		return fmt.Errorf("opencode no soporta override de modelo desde YAML; usá la config del propio CLI")
+	}
+	allowed, known := modelsByCLI[cli]
+	if !known {
+		return nil
+	}
+	for _, m := range allowed {
+		if m == model {
+			return nil
+		}
+	}
+	return fmt.Errorf("modelo %q no soportado para cli=%s; aceptados: %s",
+		model, cli, strings.Join(sortedCopy(allowed), ", "))
+}
+
+// sortedCopy devuelve una copia ordenada del slice (no muta el original).
+// La lista en modelsByCLI ya esta razonablemente ordenada por estabilidad
+// (alias cortos primero, despues nombres completos / versiones), pero el
+// error message lo mostramos alfabeticamente para que el usuario pueda
+// scannearlo rapido.
+func sortedCopy(in []string) []string {
+	out := make([]string, len(in))
+	copy(out, in)
+	sort.Strings(out)
+	return out
+}

--- a/internal/runner/models_test.go
+++ b/internal/runner/models_test.go
@@ -1,0 +1,131 @@
+package runner
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDefaultModel cubre los 4 CLIs primer-class + uno desconocido.
+func TestDefaultModel(t *testing.T) {
+	cases := []struct {
+		cli  string
+		want string
+	}{
+		{"claude", "opus"},
+		{"codex", "gpt-5.5"},
+		{"gemini", "gemini-2.5-pro"},
+		{"opencode", ""},
+		{"future-cli", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.cli, func(t *testing.T) {
+			if got := DefaultModel(tc.cli); got != tc.want {
+				t.Errorf("DefaultModel(%q) = %q, want %q", tc.cli, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestValidateModel_EmptyAlwaysPasses garantiza que model=="" pasa para
+// cualquier CLI (rama "sin override" → cae al default).
+func TestValidateModel_EmptyAlwaysPasses(t *testing.T) {
+	for _, cli := range []string{"claude", "codex", "gemini", "opencode", "future-cli"} {
+		t.Run(cli, func(t *testing.T) {
+			if err := ValidateModel(cli, ""); err != nil {
+				t.Errorf("ValidateModel(%q, \"\") = %v, want nil", cli, err)
+			}
+		})
+	}
+}
+
+// TestValidateModel_OpencodeRejectsAnyModel garantiza que opencode rechaza
+// cualquier modelo declarado en YAML (regla del body de #142).
+func TestValidateModel_OpencodeRejectsAnyModel(t *testing.T) {
+	err := ValidateModel("opencode", "claude-3-7-sonnet")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "opencode no soporta override") {
+		t.Errorf("error message debe explicar la regla; got: %v", err)
+	}
+}
+
+// TestValidateModel_WhitelistedClaude cubre los aliases + nombres completos
+// declarados en modelsByCLI.
+func TestValidateModel_WhitelistedClaude(t *testing.T) {
+	valid := []string{"opus", "sonnet", "haiku", "opusplan", "claude-opus-4-7", "claude-sonnet-4-6", "claude-haiku-4-5"}
+	for _, m := range valid {
+		t.Run(m, func(t *testing.T) {
+			if err := ValidateModel("claude", m); err != nil {
+				t.Errorf("ValidateModel(claude, %q) = %v, want nil", m, err)
+			}
+		})
+	}
+}
+
+// TestValidateModel_WhitelistedCodex cubre los modelos codex declarados.
+func TestValidateModel_WhitelistedCodex(t *testing.T) {
+	valid := []string{"gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark", "gpt-5.2", "gpt-5.2-codex", "gpt-5.1-codex-max", "gpt-5.1-codex-mini"}
+	for _, m := range valid {
+		t.Run(m, func(t *testing.T) {
+			if err := ValidateModel("codex", m); err != nil {
+				t.Errorf("ValidateModel(codex, %q) = %v, want nil", m, err)
+			}
+		})
+	}
+}
+
+// TestValidateModel_WhitelistedGemini cubre los modelos gemini declarados.
+func TestValidateModel_WhitelistedGemini(t *testing.T) {
+	valid := []string{"gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.5-flash-lite"}
+	for _, m := range valid {
+		t.Run(m, func(t *testing.T) {
+			if err := ValidateModel("gemini", m); err != nil {
+				t.Errorf("ValidateModel(gemini, %q) = %v, want nil", m, err)
+			}
+		})
+	}
+}
+
+// TestValidateModel_InvalidPerCLI cubre rechazo de modelo no listado para
+// claude/codex/gemini. El error debe mencionar el CLI + el modelo + la
+// lista de aceptados para que el remedy del preflight sea accionable.
+func TestValidateModel_InvalidPerCLI(t *testing.T) {
+	cases := []struct {
+		cli   string
+		model string
+	}{
+		{"claude", "gpt-4o"},     // modelo de otro CLI
+		{"codex", "opus"},        // alias de claude
+		{"gemini", "gpt-5.5"},    // modelo de codex
+		{"claude", "OPUS"},       // case-sensitive — debe rechazar
+		{"gemini", "gemini-pro"}, // nombre viejo no listado
+	}
+	for _, tc := range cases {
+		t.Run(tc.cli+"/"+tc.model, func(t *testing.T) {
+			err := ValidateModel(tc.cli, tc.model)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, tc.cli) {
+				t.Errorf("error debe mencionar cli %q; got: %v", tc.cli, err)
+			}
+			if !strings.Contains(msg, tc.model) {
+				t.Errorf("error debe mencionar modelo %q; got: %v", tc.model, err)
+			}
+			if !strings.Contains(msg, "aceptados") {
+				t.Errorf("error debe listar modelos aceptados; got: %v", err)
+			}
+		})
+	}
+}
+
+// TestValidateModel_UnknownCLIPasses garantiza que CLIs no listados en
+// modelsByCLI (y distintos de opencode) pasan sin chequeo — abre la puerta
+// a CLIs custom sin tocar la tabla.
+func TestValidateModel_UnknownCLIPasses(t *testing.T) {
+	if err := ValidateModel("future-cli", "any-model"); err != nil {
+		t.Errorf("ValidateModel(future-cli, any-model) = %v, want nil", err)
+	}
+}

--- a/internal/runner/preflight.go
+++ b/internal/runner/preflight.go
@@ -146,6 +146,17 @@ func buildPreflightChecks(p wizard.Pipeline, inputKind, inputValue string) []Pre
 		})
 	}
 
+	// Model whitelist: un row por cada (cli, model) declarado explicito en
+	// step.Model o step.Validator.Model. Rechaza modelos desconocidos por
+	// CLI ANTES de spawnear (issue #142). Steps sin `model:` no aportan
+	// rows aca — caen al default por CLI sin chequeo.
+	for _, r := range distinctModelRefs(p) {
+		checks = append(checks, PreflightCheck{
+			Label:  fmt.Sprintf("model %s para cli %s", r.Model, r.CLI),
+			Status: PreflightPending,
+		})
+	}
+
 	// gh auth + git repo context: ambos solo aplican si algun step usa
 	// input pr|issue. El row de repo aparece antes que el de auth porque
 	// "no estas en un repo" es un fail mas estructural que "no estas
@@ -208,6 +219,41 @@ func distinctCLIs(p wizard.Pipeline) []string {
 		out = append(out, c)
 	}
 	sort.Strings(out)
+	return out
+}
+
+// modelRef es una tupla cli+model declarada en el YAML (step.Model o
+// step.Validator.Model). El preflight la usa para chequear que el modelo
+// matchea el whitelist por CLI ANTES de spawnear (issue #142).
+type modelRef struct {
+	CLI   string
+	Model string
+}
+
+// distinctModelRefs deduplica + ordena los pares (cli, model) para steps y
+// validators que declaran `model:` explicito. Steps con model=="" caen al
+// default por CLI y no necesitan validacion. Para cli=="" defensivamente
+// skipeamos — IsValid del wizard ya deberia haberlo rechazado.
+func distinctModelRefs(p wizard.Pipeline) []modelRef {
+	seen := map[modelRef]struct{}{}
+	for _, st := range p.Steps {
+		if st.CLI != "" && strings.TrimSpace(st.Model) != "" {
+			seen[modelRef{CLI: st.CLI, Model: st.Model}] = struct{}{}
+		}
+		if st.Validator != nil && st.Validator.CLI != "" && strings.TrimSpace(st.Validator.Model) != "" {
+			seen[modelRef{CLI: st.Validator.CLI, Model: st.Validator.Model}] = struct{}{}
+		}
+	}
+	out := make([]modelRef, 0, len(seen))
+	for r := range seen {
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CLI != out[j].CLI {
+			return out[i].CLI < out[j].CLI
+		}
+		return out[i].Model < out[j].Model
+	})
 	return out
 }
 
@@ -285,6 +331,8 @@ func resolveCheck(c PreflightCheck, p wizard.Pipeline, inputKind, inputValue str
 		return resolveCliCheck(c, cliInstalled)
 	case strings.HasPrefix(c.Label, "skill "):
 		return resolveSkillCheck(c, cliSkills)
+	case strings.HasPrefix(c.Label, "model "):
+		return resolveModelCheck(c)
 	case c.Label == "git repo context":
 		info := repoctx.Detect()
 		if info.InGitHubRepo {
@@ -345,6 +393,34 @@ func resolveCliCheck(c PreflightCheck, cliInstalled map[string]bool) PreflightCh
 	}
 	c.Status = PreflightFail
 	c.Remedy = fmt.Sprintf("instalar %s o cambiar el step a otro CLI", name)
+	return c
+}
+
+// resolveModelCheck valida (cli, model) contra el whitelist hardcoded en
+// models.go. Label format: "model <X> para cli <Y>". El preflight es el
+// unico punto donde se chequea el whitelist; el runner asume que cualquier
+// model que llegue a buildSpawnArgs ya pasó este filtro.
+func resolveModelCheck(c PreflightCheck) PreflightCheck {
+	// Label format: "model <model> para cli <cli>". Splitteamos por " para cli "
+	// para tolerar nombres de modelo con espacios (defensive — el whitelist
+	// actual no los tiene, pero el separador es univoco).
+	const sep = " para cli "
+	body := strings.TrimPrefix(c.Label, "model ")
+	idx := strings.Index(body, sep)
+	if idx < 0 {
+		c.Status = PreflightFail
+		c.Remedy = "label model malformado"
+		return c
+	}
+	model := body[:idx]
+	cli := body[idx+len(sep):]
+	if err := ValidateModel(cli, model); err != nil {
+		c.Status = PreflightFail
+		c.Remedy = err.Error()
+		return c
+	}
+	c.Status = PreflightOK
+	c.Remedy = ""
 	return c
 }
 

--- a/internal/runner/preflight_test.go
+++ b/internal/runner/preflight_test.go
@@ -350,3 +350,129 @@ func TestResolveFileCheck_HappyPath(t *testing.T) {
 		t.Errorf("got %v, want OK", got.Status)
 	}
 }
+
+// TestBuildPreflightChecks_ModelRowsOnlyWhenDeclared garantiza que el row
+// "model X para cli Y" aparece SOLO si el YAML declara `model:`. Steps sin
+// model caen al default por CLI silenciosamente.
+func TestBuildPreflightChecks_ModelRowsOnlyWhenDeclared(t *testing.T) {
+	pNone := wizard.Pipeline{
+		Name: "p",
+		Steps: []wizard.Step{
+			{Name: "a", CLI: "claude", Kind: wizard.KindPrompt, Input: wizard.InputText},
+		},
+	}
+	for _, c := range buildPreflightChecks(pNone, wizard.InputText, "") {
+		if strings.HasPrefix(c.Label, "model ") {
+			t.Errorf("did not expect model row when step.Model=\"\", got: %v", c)
+		}
+	}
+
+	pDeclared := wizard.Pipeline{
+		Name: "p",
+		Steps: []wizard.Step{
+			{Name: "a", CLI: "claude", Kind: wizard.KindPrompt, Input: wizard.InputText, Model: "sonnet"},
+			{Name: "b", CLI: "codex", Kind: wizard.KindPrompt, Input: wizard.InputPreviousOutput, Model: "gpt-5.4",
+				Validator: &wizard.Validator{CLI: "gemini", Kind: wizard.KindPrompt, Content: "v", Model: "gemini-2.5-flash"}},
+		},
+	}
+	wantLabels := map[string]bool{
+		"model sonnet para cli claude":          false,
+		"model gpt-5.4 para cli codex":          false,
+		"model gemini-2.5-flash para cli gemini": false,
+	}
+	for _, c := range buildPreflightChecks(pDeclared, wizard.InputText, "") {
+		if _, ok := wantLabels[c.Label]; ok {
+			wantLabels[c.Label] = true
+		}
+	}
+	for label, found := range wantLabels {
+		if !found {
+			t.Errorf("expected row %q in preflight checks", label)
+		}
+	}
+}
+
+// TestResolveModelCheck_ValidPasses cubre el happy path: modelo en el
+// whitelist → row OK sin remedio.
+func TestResolveModelCheck_ValidPasses(t *testing.T) {
+	c := PreflightCheck{Label: "model opus para cli claude", Status: PreflightPending}
+	got := resolveModelCheck(c)
+	if got.Status != PreflightOK {
+		t.Errorf("got %v, want OK (remedy=%q)", got.Status, got.Remedy)
+	}
+	if got.Remedy != "" {
+		t.Errorf("expected empty remedy, got %q", got.Remedy)
+	}
+}
+
+// TestResolveModelCheck_InvalidFails cubre el rechazo: modelo fuera del
+// whitelist → row Fail + remedio que cita el CLI, el modelo y la lista.
+func TestResolveModelCheck_InvalidFails(t *testing.T) {
+	c := PreflightCheck{Label: "model gpt-4o para cli claude", Status: PreflightPending}
+	got := resolveModelCheck(c)
+	if got.Status != PreflightFail {
+		t.Errorf("got %v, want Fail", got.Status)
+	}
+	for _, want := range []string{"gpt-4o", "claude", "aceptados"} {
+		if !strings.Contains(got.Remedy, want) {
+			t.Errorf("remedy debe mencionar %q; got %q", want, got.Remedy)
+		}
+	}
+}
+
+// TestResolveModelCheck_OpencodeFails cubre la regla del body: opencode
+// con `model:` falla con mensaje explicito.
+func TestResolveModelCheck_OpencodeFails(t *testing.T) {
+	c := PreflightCheck{Label: "model anything para cli opencode", Status: PreflightPending}
+	got := resolveModelCheck(c)
+	if got.Status != PreflightFail {
+		t.Errorf("got %v, want Fail", got.Status)
+	}
+	if !strings.Contains(got.Remedy, "opencode no soporta override") {
+		t.Errorf("remedy debe explicar la regla opencode; got %q", got.Remedy)
+	}
+}
+
+// TestRunPreflightChecks_ModelInvalidFails integra: un pipeline con un step
+// claude que declara model: gpt-4o cae a verdict=HasFail con el remedy de
+// ValidateModel propagado al row.
+func TestRunPreflightChecks_ModelInvalidFails(t *testing.T) {
+	savedDetect := detectSkills
+	savedDisk := diskFreeFn
+	savedLook := lookPathFn
+	t.Cleanup(func() {
+		detectSkills = savedDetect
+		diskFreeFn = savedDisk
+		lookPathFn = savedLook
+	})
+
+	detectSkills = func() []skills.CLI {
+		return []skills.CLI{{Name: "claude", Installed: true}}
+	}
+	lookPathFn = func(string) (string, error) { return "/usr/bin/claude", nil }
+	diskFreeFn = func(string) uint64 { return 9999 * 1024 * 1024 }
+
+	p := wizard.Pipeline{
+		Name: "p",
+		Steps: []wizard.Step{
+			{Name: "a", CLI: "claude", Kind: wizard.KindPrompt, Input: wizard.InputText, Model: "gpt-4o"},
+		},
+	}
+	checks := buildPreflightChecks(p, wizard.InputText, "")
+	got := runPreflightChecks(checks, p, wizard.InputText, "")
+	if summarizePreflight(got) != preflightVerdictHasFail {
+		t.Errorf("verdict = %v, want HasFail", summarizePreflight(got))
+	}
+	foundModelFail := false
+	for _, c := range got {
+		if strings.HasPrefix(c.Label, "model gpt-4o ") && c.Status == PreflightFail {
+			foundModelFail = true
+			if c.Remedy == "" {
+				t.Errorf("model fail row sin remedy")
+			}
+		}
+	}
+	if !foundModelFail {
+		t.Errorf("expected model row to fail in checks: %v", got)
+	}
+}

--- a/internal/runner/spawn.go
+++ b/internal/runner/spawn.go
@@ -143,18 +143,20 @@ func interpolateInput(content, payload string) string {
 	return strings.ReplaceAll(content, "{{INPUT}}", payload)
 }
 
-// defaultClaudeModel es el modelo por default cuando un step claude no
-// declara `model:` explicito en el YAML. Default global a opus segun decision
-// del usuario (todos los claude del repo usan opus salvo override por step).
-const defaultClaudeModel = "opus"
-
-// claudeModel resuelve el modelo a pasarle a `claude --model`. Si el step
-// declara `model:` explicito en el YAML lo respeta, si no cae al default.
-func claudeModel(step wizard.Step) string {
-	if strings.TrimSpace(step.Model) != "" {
-		return step.Model
+// modelFor resuelve el modelo a pasarle al CLI del step. Si el step declara
+// `model:` explicito en el YAML lo respeta; si no, cae al default por CLI
+// (ver defaultModelByCLI en models.go). Para CLIs sin default y sin override
+// devuelve "" — el caller decide si emitir el flag o no (opencode entra
+// por este path: defaultModelByCLI["opencode"] == "" y buildSpawnArgs no
+// agrega el flag).
+//
+// La validacion del whitelist (rechazar modelos no soportados) ocurre en
+// preflight, no aca: este helper trabaja con el string ya aceptado.
+func modelFor(step wizard.Step) string {
+	if m := strings.TrimSpace(step.Model); m != "" {
+		return m
 	}
-	return defaultClaudeModel
+	return DefaultModel(step.CLI)
 }
 
 // buildSpawnArgs es la parte testeable de defaultSpawnCmd: dado un step,
@@ -164,10 +166,16 @@ func claudeModel(step wizard.Step) string {
 // de internal/runner/parser/claude.go lo consume). codex se mantiene en
 // `exec --json` (parser stub que cae a raw — ver parser/codex.go).
 //
-// Fix #114 extendido: claude ahora omite el content del argv — el prompt
+// Fix #114 extendido: claude/codex omiten el content del argv — el prompt
 // viaja por stdin (ver defaultSpawnCmd) para evitar E2BIG cuando {{INPUT}} se
-// expande a payloads grandes. Ademas se le pasa `--model <X>` explicito
-// (default opus, override por `model:` del step en el YAML).
+// expande a payloads grandes.
+//
+// Issue #142: el flag de modelo se inyecta por CLI cuando hay default o
+// override declarado en el YAML:
+//   - claude → `--model <X>` (default opus)
+//   - codex  → `-m <X>` (default gpt-5.5)
+//   - gemini → `-m <X>` (default gemini-2.5-pro)
+//   - opencode → no se inyecta (la config vive en el CLI propio)
 func buildSpawnArgs(step wizard.Step) ([]string, error) {
 	if step.CLI == "" {
 		return nil, fmt.Errorf("step sin cli")
@@ -175,32 +183,51 @@ func buildSpawnArgs(step wizard.Step) ([]string, error) {
 	if step.Content == "" {
 		return nil, fmt.Errorf("step sin content")
 	}
+	model := modelFor(step)
 	switch step.CLI {
 	case "claude":
 		// Fix #114 extendido: omitir el content del argv — el prompt
 		// viaja por stdin (ver defaultSpawnCmd). claude -p sin arg
 		// posicional lee el prompt de stdin (modo pipe declarado en
 		// `claude --help`: "-p/--print ... useful for pipes").
-		return []string{
+		args := []string{
 			"-p",
 			"--output-format", "stream-json",
 			"--verbose",
-			"--model", claudeModel(step),
-		}, nil
+		}
+		if model != "" {
+			args = append(args, "--model", model)
+		}
+		return args, nil
 	case "codex":
 		// Fix #114: omitir el content como tercer argv — el prompt viaja
 		// por stdin (ver defaultSpawnCmd). Esto elimina E2BIG cuando el
 		// content interpolado supera ARG_MAX (~256 KB en macOS).
 		// codex exec lee el prompt desde stdin cuando se omite el arg
 		// posicional (validado contra `codex exec --help`).
-		return []string{"exec", "--json"}, nil
+		args := []string{"exec", "--json"}
+		if model != "" {
+			args = append(args, "-m", model)
+		}
+		return args, nil
 	case "gemini":
 		// kind=skill se invoca como /<skill> en gemini (alias TOML).
 		if step.Kind == wizard.KindSkill {
-			return []string{"/" + step.Content}, nil
+			args := []string{}
+			if model != "" {
+				args = append(args, "-m", model)
+			}
+			return append(args, "/"+step.Content), nil
 		}
-		return []string{"-p", step.Content}, nil
+		args := []string{}
+		if model != "" {
+			args = append(args, "-m", model)
+		}
+		return append(args, "-p", step.Content), nil
 	case "opencode":
+		// opencode no soporta override de modelo desde YAML — la validacion
+		// del whitelist en preflight rechaza step.Model != "" para este CLI.
+		// Aca no se inyecta flag, queda lo que tenga configurado el propio CLI.
 		return []string{"run", step.Content}, nil
 	default:
 		return nil, fmt.Errorf("cli %q no soportado", step.CLI)

--- a/internal/runner/spawn_test.go
+++ b/internal/runner/spawn_test.go
@@ -65,10 +65,13 @@ func TestBuildSpawnArgs_StepContentInterpolated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("defaultSpawnCmd error: %v", err)
 	}
-	// Fix #114: args = [codex, exec, --json] — sin content en argv.
+	// Fix #114: args = [codex, exec, --json, ...] — sin content en argv.
+	// Issue #142: ahora tambien se inyecta `-m <default>` cuando no hay override.
 	// El content interpolado viaja por stdin.
-	if len(cmd.Args) != 3 {
-		t.Fatalf("expected 3 args (codex exec --json), got %d: %#v", len(cmd.Args), cmd.Args)
+	for _, a := range cmd.Args {
+		if strings.Contains(a, "{{INPUT}}") || strings.Contains(a, "PAYLOAD-X") || strings.Contains(a, "ejecuta:") {
+			t.Errorf("codex argv no debe contener content/payload, got: %q", a)
+		}
 	}
 	// Verificar que stdin contiene el payload sustituido (no el placeholder literal).
 	sr, ok := cmd.Stdin.(*strings.Reader)
@@ -98,16 +101,12 @@ func TestBuildSpawnArgs_CodexExcludesContent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildSpawnArgs error: %v", err)
 	}
-	want := []string{"exec", "--json"}
-	if len(args) != len(want) {
-		t.Fatalf("buildSpawnArgs codex: expected %v, got %v", want, args)
+	// Issue #142: codex sin step.Model recibe `-m <default>` ademas de
+	// `exec --json`. Validamos que los primeros dos sigan siendo exec/--json
+	// y que el content NO aparezca en ningun arg.
+	if len(args) < 2 || args[0] != "exec" || args[1] != "--json" {
+		t.Fatalf("buildSpawnArgs codex: expected prefix [exec --json], got %v", args)
 	}
-	for i, w := range want {
-		if args[i] != w {
-			t.Errorf("args[%d]: expected %q, got %q", i, w, args[i])
-		}
-	}
-	// El content NO debe aparecer en ningún arg.
 	for _, a := range args {
 		if strings.Contains(a, "prompt largo") {
 			t.Errorf("buildSpawnArgs codex incluye el content en argv: %q", a)
@@ -288,10 +287,8 @@ func TestDefaultSpawnCmd_CodexLargePayload(t *testing.T) {
 	if err != nil {
 		t.Fatalf("defaultSpawnCmd con payload grande error: %v", err)
 	}
-	// Args deben ser acotados: [codex, exec, --json] — sin el payload.
-	if len(cmd.Args) != 3 {
-		t.Fatalf("expected 3 args, got %d — el payload no debe viajar por argv", len(cmd.Args))
-	}
+	// Args deben ser acotados: [codex, exec, --json, -m, <default>] — sin el payload.
+	// Issue #142 sumo `-m <default>` por step.
 	for _, a := range cmd.Args {
 		if len(a) > 1000 {
 			t.Errorf("arg demasiado largo (%d bytes) — el payload viajo por argv", len(a))
@@ -389,5 +386,122 @@ func TestRunStep_RotatesEventsAcrossReruns(t *testing.T) {
 	// crearse cuando eventsRun > 0 — el fix garantiza paths versionados.
 	if _, err := os.Stat(filepath.Join(runDir, "step-01.events.jsonl")); !os.IsNotExist(err) {
 		t.Errorf("legacy events.jsonl NO debe existir cuando se rota; stat err=%v", err)
+	}
+}
+
+// findFlagValue busca un flag (ej. "-m" o "--model") en argv y devuelve el
+// valor inmediatamente siguiente. Devuelve "" si el flag no aparece o no
+// tiene valor (defensive — no deberia pasar en los tests porque siempre
+// emitimos pares).
+func findFlagValue(args []string, flag string) string {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+// TestBuildSpawnArgs_CodexInjectsModelFlag valida que codex recibe `-m <X>`
+// cuando hay default o override declarado (issue #142).
+func TestBuildSpawnArgs_CodexInjectsModelFlag(t *testing.T) {
+	cases := []struct {
+		name      string
+		stepModel string
+		wantModel string
+	}{
+		{"default cuando no se declara", "", "gpt-5.5"},
+		{"override valido", "gpt-5.4", "gpt-5.4"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			step := wizard.Step{
+				CLI:     "codex",
+				Kind:    wizard.KindPrompt,
+				Content: "p",
+				Model:   tc.stepModel,
+			}
+			args, err := buildSpawnArgs(step)
+			if err != nil {
+				t.Fatalf("buildSpawnArgs error: %v", err)
+			}
+			got := findFlagValue(args, "-m")
+			if got != tc.wantModel {
+				t.Errorf("buildSpawnArgs codex: expected -m %s, got %v", tc.wantModel, args)
+			}
+		})
+	}
+}
+
+// TestBuildSpawnArgs_GeminiInjectsModelFlag valida que gemini recibe `-m <X>`
+// cuando hay default o override declarado, tanto para kind=prompt como
+// kind=skill.
+func TestBuildSpawnArgs_GeminiInjectsModelFlag(t *testing.T) {
+	cases := []struct {
+		name      string
+		kind      string
+		stepModel string
+		wantModel string
+	}{
+		{"prompt default", wizard.KindPrompt, "", "gemini-2.5-pro"},
+		{"prompt override", wizard.KindPrompt, "gemini-2.5-flash", "gemini-2.5-flash"},
+		{"skill default", wizard.KindSkill, "", "gemini-2.5-pro"},
+		{"skill override", wizard.KindSkill, "gemini-2.5-flash-lite", "gemini-2.5-flash-lite"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			step := wizard.Step{
+				CLI:     "gemini",
+				Kind:    tc.kind,
+				Content: "x",
+				Model:   tc.stepModel,
+			}
+			args, err := buildSpawnArgs(step)
+			if err != nil {
+				t.Fatalf("buildSpawnArgs error: %v", err)
+			}
+			got := findFlagValue(args, "-m")
+			if got != tc.wantModel {
+				t.Errorf("buildSpawnArgs gemini: expected -m %s, got %v", tc.wantModel, args)
+			}
+		})
+	}
+}
+
+// TestBuildSpawnArgs_OpencodeNoModelFlag valida que opencode nunca recibe
+// flag de modelo, ni siquiera cuando el step trae model: (que en realidad
+// preflight ya rechazo — el test es defensivo sobre el contrato de spawn).
+func TestBuildSpawnArgs_OpencodeNoModelFlag(t *testing.T) {
+	step := wizard.Step{
+		CLI:     "opencode",
+		Kind:    wizard.KindPrompt,
+		Content: "p",
+	}
+	args, err := buildSpawnArgs(step)
+	if err != nil {
+		t.Fatalf("buildSpawnArgs error: %v", err)
+	}
+	for _, a := range args {
+		if a == "-m" || a == "--model" {
+			t.Errorf("opencode no debe llevar flag de modelo; got args=%v", args)
+		}
+	}
+}
+
+// TestBuildSpawnArgs_ClaudeUsesDefaultOpus es un sanity check sobre la nueva
+// implementacion via modelFor(): claude sin step.Model debe seguir pasando
+// `--model opus`.
+func TestBuildSpawnArgs_ClaudeUsesDefaultOpus(t *testing.T) {
+	step := wizard.Step{
+		CLI:     "claude",
+		Kind:    wizard.KindPrompt,
+		Content: "p",
+	}
+	args, err := buildSpawnArgs(step)
+	if err != nil {
+		t.Fatalf("buildSpawnArgs error: %v", err)
+	}
+	if got := findFlagValue(args, "--model"); got != "opus" {
+		t.Errorf("expected --model opus, got %v", args)
 	}
 }

--- a/internal/wizard/embedded/che-funnel.yaml
+++ b/internal/wizard/embedded/che-funnel.yaml
@@ -15,10 +15,11 @@
 #   3. El validator de cada step usa claude (mismo CLI que el executor).
 #      Antes se usaba codex como cross-CLI review, pero (a) el rol no se
 #      respetaba bien cuando el contexto crecia y (b) codex tiene un cap
-#      de 1 MB de prompt que reventaba con outputs grandes del step. El
-#      runner pasa `--model opus` por default para que el validator
-#      tenga el headroom necesario; si queres override, agregale `model:`
-#      al bloque validator del YAML.
+#      de 1 MB de prompt que reventaba con outputs grandes del step. Cada
+#      bloque `validator:` declara `model: opus` explicito; si queres otro
+#      modelo, cambialo ahi (issue #142). Los modelos validos por CLI
+#      viven hardcoded en internal/runner/models.go y se chequean en
+#      preflight antes de spawnear.
 #
 # Permisos requeridos por los CLIs invocados:
 #   - gh (issue create / edit / comment / view; pr create / view / diff /
@@ -295,6 +296,7 @@ steps:
     validator:
       cli: claude
       kind: prompt
+      model: opus
       content: |
         Sos un validador técnico senior. Otro agente produjo un PLAN DE
         IMPLEMENTACIÓN para uno o más issues. Tu tarea es revisar el plan
@@ -505,6 +507,7 @@ steps:
     validator:
       cli: claude
       kind: prompt
+      model: opus
       content: |
         Sos un validador técnico senior. Otro agente acaba de correr el step
         `execute` del pipeline che-funnel. Tu tarea es leer la SALIDA REAL


### PR DESCRIPTION
## Resumen
Extiende el soporte de `model:` en YAML del runner a los 4 CLIs (claude/codex/gemini/opencode) con whitelist hardcoded validada en preflight, defaults por CLI, y actualiza `che-funnel.yaml` para declarar `model: opus` explícito en los validators.

## Cambios
- `internal/runner/models.go` (nuevo): tablas `modelsByCLI` / `defaultModelByCLI` + helpers `DefaultModel(cli)` y `ValidateModel(cli, model)`. opencode rechaza el campo con mensaje accionable.
- `internal/runner/spawn.go`: `claudeModel`/`defaultClaudeModel` reemplazados por `modelFor(step)` genérico; `buildSpawnArgs` inyecta `--model X` para claude y `-m X` para codex/gemini (default por CLI o override del step); opencode queda sin flag.
- `internal/runner/preflight.go`: nuevo row `model X para cli Y` por cada `(cli, model)` declarado; falla antes de spawnear con el remedy del whitelist.
- `internal/wizard/embedded/che-funnel.yaml`: los `validator:` de `explore` y `execute` declaran `model: opus` explícito; comment del top actualizado.
- Tests: `models_test.go` cubre la matriz por CLI (default/válido/inválido/opencode-rechaza); `spawn_test.go` valida la inyección del flag para claude/codex/gemini/opencode; `preflight_test.go` cubre rows declarados, resolución OK/Fail, y verdict end-to-end con modelo inválido.

## Criterios cubiertos
- [x] `models.go` define `defaultModelByCLI` y `modelsByCLI` + expone `DefaultModel` y `ValidateModel`
- [x] Whitelist cubre claude (aliases + nombres completos), codex (8 modelos), gemini (3 modelos), opencode (rechaza)
- [x] Defaults: claude→opus, codex→gpt-5.5, gemini→gemini-2.5-pro, opencode→""
- [x] `buildSpawnArgs` inyecta el flag correcto por CLI
- [x] `preflight.go` valida `step.Model` y `step.Validator.Model` antes de spawnear
- [x] Tests unitarios cubren (a) válido por CLI, (b) inválido falla preflight, (c) opencode con model: falla, (d) sin model usa default
- [x] `che-funnel.yaml` actualizado con `model: opus` en los validators
- [x] `go build ./...` + `go test ./...` pasan (suite completa local: ✓)

## Notas de ejecución
- El criterio "Wizard interactivo gana prompt opcional para elegir modelo" del body original quedó **fuera de alcance** de este PR (queda YAML-first, consistente con flow doc H8 `$EDITOR` directo). Si se pide UI, se trackea como issue nuevo. El plan consolidado lo dejó explícito en "Fuera de alcance".
- Issue #65 (editor visual del dash) está CERRADO/MERGEADO desde antes; la dependencia del body original no aplica.
- Los modelos de codex con auth ChatGPT account (`gpt-5`, `gpt-5-codex`, `gpt-5.2-codex`) NO están en el whitelist porque las probes locales del 2026-05-13 fallaron por restricción de auth; si alguien quiere usarlos, debe agregarlos por PR.
- El whitelist se actualiza manualmente por PR cuando salen modelos nuevos (sin autodescubrimiento — el body lo deja explícito).

Closes #142
