### PR TITLE
fix(rc.1): pipelines project visibles + selector de modelo en wizard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 bin/
 .bin/
 dist/
-.che/
+.che/runs/
 .claude/
 .omx/
 .worktrees/

--- a/e2e/wizard_h8_h9_h10_test.go
+++ b/e2e/wizard_h8_h9_h10_test.go
@@ -56,7 +56,7 @@ func h8BuildOneStepPipeline(t *testing.T, p *harness.PTYRun, name string) {
 	if err := p.Send("collect"); err != nil {
 		t.Fatalf("send step name: %v", err)
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("tab #%d: %v", i, err)
 		}

--- a/e2e/wizard_test.go
+++ b/e2e/wizard_test.go
@@ -318,13 +318,13 @@ func TestWizard_S2H3CreateFirstStep(t *testing.T) {
 		t.Fatalf("S2 never rendered\n%s", p.Since(mark))
 	}
 
-	// S2: focus arranca en name. Tipear, tab x3 hasta content (cli y kind
+	// S2: focus arranca en name. Tipear, tab x4 hasta content (cli, model y kind
 	// quedan en default claude/prompt — el harness instala claude como
 	// fake binary, asi que la pill se considera installed).
 	if err := p.Send("collect-signals"); err != nil {
 		t.Fatalf("send step name: %v", err)
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("send tab #%d: %v", i, err)
 		}
@@ -429,11 +429,11 @@ func TestWizard_S2H4ValidatorOn(t *testing.T) {
 		t.Fatalf("S2 never rendered\n%s", p.Since(mark))
 	}
 
-	// S2 — Name → CLI → Kind → Content
+	// S2 — Name → CLI → Model → Kind → Content
 	if err := p.Send("collect-signals"); err != nil {
 		t.Fatalf("send step name: %v", err)
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("send tab #%d: %v", i, err)
 		}
@@ -463,9 +463,9 @@ func TestWizard_S2H4ValidatorOn(t *testing.T) {
 		t.Fatalf("validator block never appeared after toggle\n%s", p.Since(mark))
 	}
 
-	// ValToggle → ValCLI (default claude) → ValKind (default prompt) →
-	// ValContent.
-	for i := 0; i < 3; i++ {
+	// ValToggle → ValCLI (default claude) → ValModel (default opus) →
+	// ValKind (default prompt) → ValContent.
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("send tab into validator block #%d: %v", i, err)
 		}
@@ -563,7 +563,7 @@ func TestWizard_S2H4ValidatorOff(t *testing.T) {
 	if err := p.Send("collect-signals"); err != nil {
 		t.Fatalf("send step name: %v", err)
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("send tab #%d: %v", i, err)
 		}
@@ -667,7 +667,7 @@ func TestWizard_S2H5LoopTwoSteps(t *testing.T) {
 	if err := p.Send("collect"); err != nil {
 		t.Fatalf("send step1 name: %v", err)
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("send tab #%d: %v", i, err)
 		}
@@ -692,7 +692,7 @@ func TestWizard_S2H5LoopTwoSteps(t *testing.T) {
 	if err := p.Send("digest"); err != nil {
 		t.Fatalf("send step2 name: %v", err)
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("send tab step2 #%d: %v", i, err)
 		}
@@ -797,7 +797,7 @@ func TestWizard_S2H5BackFromStep2(t *testing.T) {
 	if err := p.Send("first"); err != nil {
 		t.Fatalf("send step1 name: %v", err)
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("send tab #%d: %v", i, err)
 		}
@@ -1035,7 +1035,7 @@ func TestWizard_S2YAMLCombinations(t *testing.T) {
 	if err := p.Send("fetch-data"); err != nil {
 		t.Fatalf("send step1 name: %v", err)
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("tab #%d step1: %v", i, err)
 		}
@@ -1063,7 +1063,10 @@ func TestWizard_S2YAMLCombinations(t *testing.T) {
 		t.Fatalf("tab name->cli step2: %v", err)
 	}
 	if err := p.Send("\t"); err != nil {
-		t.Fatalf("tab cli->kind step2: %v", err)
+		t.Fatalf("tab cli->model step2: %v", err)
+	}
+	if err := p.Send("\t"); err != nil {
+		t.Fatalf("tab model->kind step2: %v", err)
 	}
 	mark = p.Mark()
 	if err := p.Send("s"); err != nil {
@@ -1095,7 +1098,10 @@ func TestWizard_S2YAMLCombinations(t *testing.T) {
 		t.Fatalf("send 2 valcli=codex step2: %v", err)
 	}
 	if err := p.Send("\t"); err != nil {
-		t.Fatalf("tab valcli->valkind step2: %v", err)
+		t.Fatalf("tab valcli->valmodel step2: %v", err)
+	}
+	if err := p.Send("\t"); err != nil {
+		t.Fatalf("tab valmodel->valkind step2: %v", err)
 	}
 	if err := p.Send("\t"); err != nil {
 		t.Fatalf("tab valkind->valcontent step2: %v", err)
@@ -1134,7 +1140,7 @@ func TestWizard_S2YAMLCombinations(t *testing.T) {
 	if err := p.Send("2"); err != nil {
 		t.Fatalf("send 2 cli=codex step3: %v", err)
 	}
-	for i := 0; i < 2; i++ {
+	for i := 0; i < 3; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("tab into content step3 #%d: %v", i, err)
 		}
@@ -1158,7 +1164,7 @@ func TestWizard_S2YAMLCombinations(t *testing.T) {
 	if !p.WaitForOutputSince(t, mark, "Bloque validator", 3*time.Second) {
 		t.Fatalf("validator block never appeared step3\n%s", p.Since(mark))
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("tab into valcontent step3 #%d: %v", i, err)
 		}
@@ -1326,7 +1332,7 @@ func TestWizard_S3SummarySavesReady(t *testing.T) {
 	if err := p.Send("collect"); err != nil {
 		t.Fatalf("send step name: %v", err)
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("tab #%d: %v", i, err)
 		}
@@ -1461,7 +1467,7 @@ func TestWizard_S3InvalidStays(t *testing.T) {
 	if err := p.Send("first"); err != nil {
 		t.Fatalf("send name: %v", err)
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("tab #%d: %v", i, err)
 		}
@@ -1488,6 +1494,9 @@ func TestWizard_S3InvalidStays(t *testing.T) {
 	// gemini = pill 3 (claude/codex/gemini/opencode).
 	if err := p.Send("3"); err != nil {
 		t.Fatalf("send 3 valcli=gemini: %v", err)
+	}
+	if err := p.Send("\t"); err != nil {
+		t.Fatalf("tab→valmodel: %v", err)
 	}
 	if err := p.Send("\t"); err != nil {
 		t.Fatalf("tab→valkind: %v", err)
@@ -1616,7 +1625,7 @@ func TestWizard_S3EscNoChangesExitsDirect(t *testing.T) {
 	if err := p.Send("only"); err != nil {
 		t.Fatalf("send step name: %v", err)
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("tab #%d: %v", i, err)
 		}
@@ -1704,7 +1713,7 @@ func h7BuildThreeSteps(t *testing.T, p *harness.PTYRun, name string) {
 	if err := p.Send("first"); err != nil {
 		t.Fatalf("send step1 name: %v", err)
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("tab #%d step1: %v", i, err)
 		}
@@ -1724,7 +1733,7 @@ func h7BuildThreeSteps(t *testing.T, p *harness.PTYRun, name string) {
 	if err := p.Send("second"); err != nil {
 		t.Fatalf("send step2 name: %v", err)
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("tab #%d step2: %v", i, err)
 		}
@@ -1744,7 +1753,7 @@ func h7BuildThreeSteps(t *testing.T, p *harness.PTYRun, name string) {
 	if err := p.Send("third"); err != nil {
 		t.Fatalf("send step3 name: %v", err)
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("tab #%d step3: %v", i, err)
 		}
@@ -1790,7 +1799,7 @@ func TestWizard_S3H7EditStep(t *testing.T) {
 	}
 
 	// Foco arranca en Name → 3 tabs hasta Content (cli, kind, content).
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("tab→content #%d: %v", i, err)
 		}
@@ -2062,7 +2071,7 @@ func TestWizard_S3H7AppendStep(t *testing.T) {
 	if err := p.Send("fourth"); err != nil {
 		t.Fatalf("send step4 name: %v", err)
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("tab #%d step4: %v", i, err)
 		}
@@ -2168,7 +2177,7 @@ func TestWizard_S3H7DeleteBreaksPrevDep(t *testing.T) {
 	if err := p.Send("first"); err != nil {
 		t.Fatalf("send step1 name: %v", err)
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("tab #%d step1: %v", i, err)
 		}
@@ -2188,7 +2197,7 @@ func TestWizard_S3H7DeleteBreaksPrevDep(t *testing.T) {
 	if err := p.Send("second"); err != nil {
 		t.Fatalf("send step2 name: %v", err)
 	}
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 4; i++ {
 		if err := p.Send("\t"); err != nil {
 			t.Fatalf("tab #%d step2: %v", i, err)
 		}

--- a/internal/dash/dash.go
+++ b/internal/dash/dash.go
@@ -19,6 +19,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"time"
+
+	"github.com/chichex/che/internal/pipelines"
 )
 
 //go:embed assets/dash.html
@@ -73,6 +75,11 @@ func Serve(ctx context.Context, opts Options) error {
 	// project (cwd-local en `./.che/pipelines/`). Si `cd` ocurre mientras
 	// el server corre, el cwd del proceso no cambia — el badge "project"
 	// deja claro al usuario que esto refleja el dir de arranque.
+	//
+	// Para que el dash arrancado desde una subcarpeta del proyecto igual
+	// vea los pipelines guardados en `<root>/.che/pipelines/`, hacemos
+	// walk-up hasta el primer ancestro con `.che/pipelines/`. Si ningun
+	// ancestro lo tiene, cwd queda como esta y scope project queda vacio.
 	pipelinesDir := ""
 	runsDir := ""
 	if h, err := os.UserHomeDir(); err == nil {
@@ -83,6 +90,8 @@ func Serve(ctx context.Context, opts Options) error {
 	if cerr != nil {
 		fmt.Fprintf(out, "[dash] no se pudo resolver cwd (%v) — scope project deshabilitado\n", cerr)
 		cwd = ""
+	} else {
+		cwd = pipelines.FindProjectRoot(cwd)
 	}
 
 	// Singleton bus for SSE per-run streaming.

--- a/internal/pipelines/paths.go
+++ b/internal/pipelines/paths.go
@@ -35,6 +35,34 @@ func ProjectPipelinesDir(cwd string) string {
 	return filepath.Join(cwd, pipelinesSubdir)
 }
 
+// FindProjectRoot busca el ancestro mas cercano del cwd dado que tenga un
+// directorio `.che/pipelines/` adentro. Devuelve el cwd "efectivo" para
+// scope project — empezando por el cwd mismo y subiendo hasta encontrar
+// uno. Si ninguno tiene `.che/pipelines/`, devuelve cwd tal cual (el
+// caller mantiene el comportamiento previo: scope project vacio).
+//
+// Sirve para que `che dash` arrancado desde una subcarpeta de un proyecto
+// igual vea los pipelines guardados en `<root>/.che/pipelines/` sin
+// obligar al usuario a hacer `cd` exacto. cwd="" devuelve "".
+func FindProjectRoot(cwd string) string {
+	if cwd == "" {
+		return ""
+	}
+	dir := cwd
+	for {
+		candidate := filepath.Join(dir, pipelinesSubdir)
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			// llegamos a la raiz sin encontrar nada.
+			return cwd
+		}
+		dir = parent
+	}
+}
+
 // GlobalPathFor compone el path absoluto del archivo del pipeline de scope
 // global cuyo slug es slug.
 func GlobalPathFor(home, slug string) (string, error) {

--- a/internal/runner/models.go
+++ b/internal/runner/models.go
@@ -1,113 +1,16 @@
 package runner
 
-import (
-	"fmt"
-	"sort"
-	"strings"
-)
+import "github.com/chichex/che/internal/runnermodels"
 
-// modelsByCLI es el whitelist hardcoded de modelos aceptados por cada CLI
-// soportado por el runner. Cualquier `model:` declarado en el YAML que no
-// matchee se rechaza en preflight con un error claro ANTES de spawnear.
-//
-// La tabla se actualiza por PR cuando salen modelos nuevos — no hay
-// autodescubrimiento. Cuando un CLI saca un alias nuevo, agregar la entry
-// aca y bumpear el slice en orden alfabetico para que el remedy del
-// preflight liste los validos de forma estable.
-//
-// opencode no esta en la tabla: no soporta override de modelo desde el
-// YAML (el flag --model no es estable en su CLI). ValidateModel maneja el
-// case especial: si un step con cli=opencode trae model: distinto de "",
-// rebota con un mensaje accionable.
-var modelsByCLI = map[string][]string{
-	"claude": {
-		// Aliases cortos (preferidos para escribir en YAML).
-		"opus",
-		"sonnet",
-		"haiku",
-		"opusplan",
-		// Nombres completos.
-		"claude-opus-4-7",
-		"claude-sonnet-4-6",
-		"claude-haiku-4-5",
-	},
-	"codex": {
-		"gpt-5.5",
-		"gpt-5.4",
-		"gpt-5.4-mini",
-		"gpt-5.3-codex-spark",
-		"gpt-5.2",
-		"gpt-5.2-codex",
-		"gpt-5.1-codex-max",
-		"gpt-5.1-codex-mini",
-	},
-	"gemini": {
-		"gemini-2.5-pro",
-		"gemini-2.5-flash",
-		"gemini-2.5-flash-lite",
-	},
-}
-
-// defaultModelByCLI es el modelo que el runner pasa cuando un step no
-// declara `model:` en el YAML. Para opencode el default es "" (no se setea
-// flag — queda el que tenga configurado el propio CLI).
-var defaultModelByCLI = map[string]string{
-	"claude":   "opus",
-	"codex":    "gpt-5.5",
-	"gemini":   "gemini-2.5-pro",
-	"opencode": "",
-}
-
-// DefaultModel devuelve el modelo default para el CLI dado. Para CLIs
-// desconocidos devuelve "" (el caller normalmente termina pasando este
-// valor sin flag — los CLIs nuevos no soportan override desde YAML hasta
-// que se agreguen al whitelist).
+// DefaultModel es un re-export thin sobre runnermodels.DefaultModel — la
+// tabla de modelos vive en runnermodels para que el wizard pueda
+// importarla sin crear un ciclo (runner ya importa wizard).
 func DefaultModel(cli string) string {
-	return defaultModelByCLI[cli]
+	return runnermodels.DefaultModel(cli)
 }
 
-// ValidateModel verifica que el modelo declarado en el YAML sea aceptado
-// por el CLI. Reglas:
-//
-//   - model == "" siempre pasa (la rama "sin override" cae al default por
-//     CLI; compat con YAMLs viejos que no declaran el campo).
-//   - cli == "opencode" + model != "" siempre rechaza con un mensaje
-//     accionable. El YAML no es el lugar para configurar el modelo de
-//     opencode.
-//   - Para claude/codex/gemini, el modelo tiene que matchear el whitelist
-//     exactamente (case-sensitive). Si no, error con la lista de aceptados.
-//   - CLIs desconocidos (no en modelsByCLI ni "opencode") pasan: el runner
-//     no opina sobre overrides para CLIs que no soporta como ciudadano
-//     primer-class. Si despues alguien quiere whitelist para un CLI nuevo,
-//     se agrega aca.
+// ValidateModel re-exporta runnermodels.ValidateModel para no romper los
+// call sites internos del runner (preflight).
 func ValidateModel(cli, model string) error {
-	if model == "" {
-		return nil
-	}
-	if cli == "opencode" {
-		return fmt.Errorf("opencode no soporta override de modelo desde YAML; usá la config del propio CLI")
-	}
-	allowed, known := modelsByCLI[cli]
-	if !known {
-		return nil
-	}
-	for _, m := range allowed {
-		if m == model {
-			return nil
-		}
-	}
-	return fmt.Errorf("modelo %q no soportado para cli=%s; aceptados: %s",
-		model, cli, strings.Join(sortedCopy(allowed), ", "))
-}
-
-// sortedCopy devuelve una copia ordenada del slice (no muta el original).
-// La lista en modelsByCLI ya esta razonablemente ordenada por estabilidad
-// (alias cortos primero, despues nombres completos / versiones), pero el
-// error message lo mostramos alfabeticamente para que el usuario pueda
-// scannearlo rapido.
-func sortedCopy(in []string) []string {
-	out := make([]string, len(in))
-	copy(out, in)
-	sort.Strings(out)
-	return out
+	return runnermodels.ValidateModel(cli, model)
 }

--- a/internal/runnermodels/models.go
+++ b/internal/runnermodels/models.go
@@ -1,0 +1,142 @@
+// Package runnermodels expone el whitelist de modelos de IA aceptados por
+// cada CLI soportado por el runner. Es la fuente de verdad compartida
+// entre el runner (que valida + inyecta el flag) y el wizard (que ofrece
+// el selector visual). Antes vivia dentro de internal/runner — se
+// extrajo a su propio paquete para que el wizard pueda importarlo sin
+// crear un ciclo (runner ya importa wizard).
+package runnermodels
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// modelsByCLI es el whitelist hardcoded de modelos aceptados por cada CLI
+// soportado por el runner. Cualquier `model:` declarado en el YAML que no
+// matchee se rechaza en preflight con un error claro ANTES de spawnear.
+//
+// La tabla se actualiza por PR cuando salen modelos nuevos — no hay
+// autodescubrimiento. Cuando un CLI saca un alias nuevo, agregar la entry
+// aca y bumpear el slice en orden alfabetico para que el remedy del
+// preflight liste los validos de forma estable.
+//
+// opencode no esta en la tabla: no soporta override de modelo desde el
+// YAML (el flag --model no es estable en su CLI). ValidateModel maneja el
+// case especial: si un step con cli=opencode trae model: distinto de "",
+// rebota con un mensaje accionable.
+var modelsByCLI = map[string][]string{
+	"claude": {
+		// Aliases cortos (preferidos para escribir en YAML).
+		"opus",
+		"sonnet",
+		"haiku",
+		"opusplan",
+		// Nombres completos.
+		"claude-opus-4-7",
+		"claude-sonnet-4-6",
+		"claude-haiku-4-5",
+	},
+	"codex": {
+		"gpt-5.5",
+		"gpt-5.4",
+		"gpt-5.4-mini",
+		"gpt-5.3-codex-spark",
+		"gpt-5.2",
+		"gpt-5.2-codex",
+		"gpt-5.1-codex-max",
+		"gpt-5.1-codex-mini",
+	},
+	"gemini": {
+		"gemini-2.5-pro",
+		"gemini-2.5-flash",
+		"gemini-2.5-flash-lite",
+	},
+}
+
+// defaultModelByCLI es el modelo que el runner pasa cuando un step no
+// declara `model:` en el YAML. Para opencode el default es "" (no se setea
+// flag — queda el que tenga configurado el propio CLI).
+var defaultModelByCLI = map[string]string{
+	"claude":   "opus",
+	"codex":    "gpt-5.5",
+	"gemini":   "gemini-2.5-pro",
+	"opencode": "",
+}
+
+// DefaultModel devuelve el modelo default para el CLI dado. Para CLIs
+// desconocidos devuelve "" (el caller normalmente termina pasando este
+// valor sin flag — los CLIs nuevos no soportan override desde YAML hasta
+// que se agreguen al whitelist).
+func DefaultModel(cli string) string {
+	return defaultModelByCLI[cli]
+}
+
+// ModelsForCLI devuelve la lista de modelos validos para el CLI dado, en
+// el orden canonico (alias cortos primero). Devuelve nil para CLIs que
+// no aceptan override (ej. opencode) o no estan en el whitelist. La
+// slice devuelta es propiedad del caller — no muta la fuente.
+func ModelsForCLI(cli string) []string {
+	src, ok := modelsByCLI[cli]
+	if !ok {
+		return nil
+	}
+	out := make([]string, len(src))
+	copy(out, src)
+	return out
+}
+
+// SupportsModelOverride reporta si el CLI permite seleccionar modelo desde
+// el YAML. Hoy: claude/codex/gemini si; opencode no; cualquier otro CLI
+// desconocido tambien rechaza (defensive — el preflight ya valida, pero
+// el wizard usa esto para deshabilitar el selector).
+func SupportsModelOverride(cli string) bool {
+	_, ok := modelsByCLI[cli]
+	return ok
+}
+
+// ValidateModel verifica que el modelo declarado en el YAML sea aceptado
+// por el CLI. Reglas:
+//
+//   - model == "" siempre pasa (la rama "sin override" cae al default por
+//     CLI; compat con YAMLs viejos que no declaran el campo).
+//   - cli == "opencode" + model != "" siempre rechaza con un mensaje
+//     accionable. El YAML no es el lugar para configurar el modelo de
+//     opencode.
+//   - Para claude/codex/gemini, el modelo tiene que matchear el whitelist
+//     exactamente (case-sensitive). Si no, error con la lista de aceptados.
+//   - CLIs desconocidos (no en modelsByCLI ni "opencode") pasan: el runner
+//     no opina sobre overrides para CLIs que no soporta como ciudadano
+//     primer-class. Si despues alguien quiere whitelist para un CLI nuevo,
+//     se agrega aca.
+func ValidateModel(cli, model string) error {
+	if model == "" {
+		return nil
+	}
+	if cli == "opencode" {
+		return fmt.Errorf("opencode no soporta override de modelo desde YAML; usá la config del propio CLI")
+	}
+	allowed, known := modelsByCLI[cli]
+	if !known {
+		return nil
+	}
+	for _, m := range allowed {
+		if m == model {
+			return nil
+		}
+	}
+	return fmt.Errorf("modelo %q no soportado para cli=%s; aceptados: %s",
+		model, cli, strings.Join(sortedCopy(allowed), ", "))
+}
+
+// sortedCopy devuelve una copia ordenada del slice (no muta el original).
+// La lista en modelsByCLI ya esta razonablemente ordenada por estabilidad
+// (alias cortos primero, despues nombres completos / versiones), pero el
+// error message lo mostramos alfabeticamente para que el usuario pueda
+// scannearlo rapido.
+func sortedCopy(in []string) []string {
+	out := make([]string, len(in))
+	copy(out, in)
+	sort.Strings(out)
+	return out
+}

--- a/internal/wizard/equiv.go
+++ b/internal/wizard/equiv.go
@@ -40,6 +40,9 @@ func stepEqual(a, b Step) bool {
 	if a.CLI != b.CLI {
 		return false
 	}
+	if a.Model != b.Model {
+		return false
+	}
 	if a.Kind != b.Kind {
 		return false
 	}
@@ -65,5 +68,5 @@ func validatorEqual(a, b *Validator) bool {
 	if a == nil {
 		return true
 	}
-	return a.CLI == b.CLI && a.Kind == b.Kind && a.Content == b.Content
+	return a.CLI == b.CLI && a.Kind == b.Kind && a.Content == b.Content && a.Model == b.Model
 }

--- a/internal/wizard/model.go
+++ b/internal/wizard/model.go
@@ -150,6 +150,11 @@ type StepFieldFocus int
 const (
 	StepFocusName StepFieldFocus = iota
 	StepFocusCLI
+	// StepFocusModel: pill row con los modelos validos para el CLI elegido.
+	// Solo se navega/renderiza si el CLI soporta override (claude/codex/
+	// gemini); opencode lo muestra dim con "(no aplica)" pero la fila igual
+	// existe en el orden visible para mantener layout estable.
+	StepFocusModel
 	StepFocusKind
 	StepFocusContent
 	StepFocusInput
@@ -158,6 +163,7 @@ const (
 	StepFocusValToggle
 	// Bloque validator (visible solo si validatorOn=true).
 	StepFocusValCLI
+	StepFocusValModel
 	StepFocusValKind
 	StepFocusValContent
 	StepFocusValMaxLoops
@@ -263,6 +269,7 @@ type stepEditState struct {
 
 	// selecciones discretas
 	cli   string // claude | codex | gemini | opencode
+	model string // alias o nombre completo del modelo de IA — vacio = default por CLI
 	kind  string // prompt | skill
 	input string // text | pr | issue | file | url | none | previous_output
 
@@ -278,6 +285,7 @@ type stepEditState struct {
 	// perder lo tipeado).
 	validatorOn     bool
 	valCLI          string
+	valModel        string // mismo contrato que `model`; vacio = default del valCLI
 	valKind         string
 	valContentInput textInput // multiline cuando kind=prompt; ignorado cuando kind=skill
 	valSkillCursor  int

--- a/internal/wizard/step.go
+++ b/internal/wizard/step.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/chichex/che/internal/runnermodels"
 	"github.com/chichex/che/internal/skills"
 )
 
@@ -56,8 +57,11 @@ func (m model) enterStepCreate(idx int) (model, tea.Cmd) {
 		nameInput:    newSingleLine("ej: collect-signals"),
 		contentInput: newMultiLine("ej: extrae las metricas anomalas del payload"),
 		cli:          defaultCLI,
-		kind:         KindPrompt,
-		input:        InputText,
+		// model: default segun el CLI elegido (opencode → ""). Si el
+		// usuario cambia el CLI, afterCLIChange resemilla este campo.
+		model: runnermodels.DefaultModel(defaultCLI),
+		kind:  KindPrompt,
+		input: InputText,
 
 		// Bloque validator (B2): off por default. Los defaults del flow
 		// doc — mismo CLI que el step, kind=prompt, max_loops=3,
@@ -66,6 +70,7 @@ func (m model) enterStepCreate(idx int) (model, tea.Cmd) {
 		// del step (un prompt/skill distinto).
 		validatorOn:     false,
 		valCLI:          defaultCLI,
+		valModel:        runnermodels.DefaultModel(defaultCLI),
 		valKind:         KindPrompt,
 		valContentInput: newMultiLine("ej: verifica que el output respete el formato pedido"),
 		valMaxLoops:     3,
@@ -144,16 +149,31 @@ func (m model) enterStepEdit(idx int) (model, tea.Cmd) {
 	valContent := ""
 	valMaxLoops := 3
 	valOnMaxLoops := OnMaxLoopsFail
+	valModel := runnermodels.DefaultModel(valCLI)
 	if st.Validator != nil {
 		valCLI = st.Validator.CLI
 		valKind = st.Validator.Kind
 		valContent = st.Validator.Content
+		valModel = st.Validator.Model
+		if valModel == "" {
+			valModel = runnermodels.DefaultModel(valCLI)
+		}
 		if st.MaxLoops > 0 {
 			valMaxLoops = st.MaxLoops
 		}
 		if st.OnMaxLoops != "" {
 			valOnMaxLoops = st.OnMaxLoops
 		}
+	}
+
+	// Modelo del step: el YAML puede traer vacio (default del CLI) o un
+	// alias/nombre completo. Si esta vacio cargamos el default del CLI
+	// para que la pill correspondiente aparezca seleccionada y que
+	// guardar sin tocar nada conserve el comportamiento previo (no
+	// escribimos `model:` en buildStep si no difiere del default).
+	stepModel := st.Model
+	if stepModel == "" {
+		stepModel = runnermodels.DefaultModel(st.CLI)
 	}
 
 	valContentInput := newMultiLine("ej: verifica que el output respete el formato pedido")
@@ -177,11 +197,13 @@ func (m model) enterStepEdit(idx int) (model, tea.Cmd) {
 		nameInput:       nameInput,
 		contentInput:    contentInput,
 		cli:             st.CLI,
+		model:           stepModel,
 		kind:            st.Kind,
 		input:           st.Input,
 		skillCursor:     skillCursor,
 		validatorOn:     validatorOn,
 		valCLI:          valCLI,
+		valModel:        valModel,
 		valKind:         valKind,
 		valContentInput: valContentInput,
 		valSkillCursor:  valSkillCursor,
@@ -249,6 +271,8 @@ func (m model) updateStep(key tea.KeyMsg) (model, tea.Cmd) {
 		return m.stepHandleNameKey(key)
 	case StepFocusCLI:
 		return m.stepHandleCLIKey(key)
+	case StepFocusModel:
+		return m.stepHandleModelKey(key)
 	case StepFocusKind:
 		return m.stepHandleKindKey(key)
 	case StepFocusContent:
@@ -259,6 +283,8 @@ func (m model) updateStep(key tea.KeyMsg) (model, tea.Cmd) {
 		return m.stepHandleValToggleKey(key)
 	case StepFocusValCLI:
 		return m.stepHandleValCLIKey(key)
+	case StepFocusValModel:
+		return m.stepHandleValModelKey(key)
 	case StepFocusValKind:
 		return m.stepHandleValKindKey(key)
 	case StepFocusValContent:
@@ -316,15 +342,76 @@ func (m model) stepHandleCLIKey(key tea.KeyMsg) (model, tea.Cmd) {
 func (m *model) afterCLIChange() {
 	m.stepEdit.skillCursor = 0
 	m.stepEdit.errMsg = ""
+	// Resemilla model al default del CLI nuevo — el alias del CLI viejo
+	// (ej. "opus" para claude) muy probablemente no es valido para el CLI
+	// nuevo (codex/gemini). Es mejor caer al default que dejar al usuario
+	// con un modelo invalido y un mensaje del preflight despues.
+	m.stepEdit.model = runnermodels.DefaultModel(m.stepEdit.cli)
 	if m.stepEdit.kind == KindSkill && !m.cliHasSkills(m.stepEdit.cli) {
 		m.stepEdit.kind = KindPrompt
 	}
 	if !m.stepEdit.validatorOn {
 		m.stepEdit.valCLI = m.stepEdit.cli
+		m.stepEdit.valModel = runnermodels.DefaultModel(m.stepEdit.valCLI)
 		if m.stepEdit.valKind == KindSkill && !m.cliHasSkills(m.stepEdit.valCLI) {
 			m.stepEdit.valKind = KindPrompt
 		}
 	}
+}
+
+// stepHandleModelKey cyclea entre los modelos validos para el CLI actual.
+// Si el CLI no soporta override (opencode o uno desconocido), la tecla es
+// no-op: la pill se renderiza "(no aplica)" y el campo permanece fijo en
+// "" (que es lo que termina yendo al YAML como omitido).
+func (m model) stepHandleModelKey(key tea.KeyMsg) (model, tea.Cmd) {
+	opts := runnermodels.ModelsForCLI(m.stepEdit.cli)
+	if len(opts) == 0 {
+		return m, nil
+	}
+	switch key.String() {
+	case "left", "h":
+		m.stepEdit.model = stepNeighbor(opts, m.stepEdit.model, -1)
+		m.stepEdit.errMsg = ""
+		return m, nil
+	case "right", "l":
+		m.stepEdit.model = stepNeighbor(opts, m.stepEdit.model, +1)
+		m.stepEdit.errMsg = ""
+		return m, nil
+	}
+	if key.String() >= "1" && key.String() <= "9" {
+		idx := int(key.String()[0] - '1')
+		if idx >= 0 && idx < len(opts) {
+			m.stepEdit.model = opts[idx]
+			m.stepEdit.errMsg = ""
+		}
+	}
+	return m, nil
+}
+
+// stepHandleValModelKey: equivalente para el bloque validator.
+func (m model) stepHandleValModelKey(key tea.KeyMsg) (model, tea.Cmd) {
+	opts := runnermodels.ModelsForCLI(m.stepEdit.valCLI)
+	if len(opts) == 0 {
+		return m, nil
+	}
+	switch key.String() {
+	case "left", "h":
+		m.stepEdit.valModel = stepNeighbor(opts, m.stepEdit.valModel, -1)
+		m.stepEdit.errMsg = ""
+		return m, nil
+	case "right", "l":
+		m.stepEdit.valModel = stepNeighbor(opts, m.stepEdit.valModel, +1)
+		m.stepEdit.errMsg = ""
+		return m, nil
+	}
+	if key.String() >= "1" && key.String() <= "9" {
+		idx := int(key.String()[0] - '1')
+		if idx >= 0 && idx < len(opts) {
+			m.stepEdit.valModel = opts[idx]
+			m.stepEdit.errMsg = ""
+		}
+	}
+	return m, nil
 }
 
 func (m model) stepHandleKindKey(key tea.KeyMsg) (model, tea.Cmd) {
@@ -493,6 +580,7 @@ func (m model) stepHandleValCLIKey(key tea.KeyMsg) (model, tea.Cmd) {
 func (m *model) afterValCLIChange() {
 	m.stepEdit.valSkillCursor = 0
 	m.stepEdit.errMsg = ""
+	m.stepEdit.valModel = runnermodels.DefaultModel(m.stepEdit.valCLI)
 	if m.stepEdit.valKind == KindSkill && !m.cliHasSkills(m.stepEdit.valCLI) {
 		m.stepEdit.valKind = KindPrompt
 	}
@@ -847,6 +935,14 @@ func (m model) buildStep() (Step, error) {
 		Input:   in,
 	}
 
+	// model: solo lo escribimos al YAML si difiere del default del CLI.
+	// Mantener el YAML minimo es consistente con otros campos opcionales
+	// (validator, max_loops, on_max_loops). El runner cae al mismo default
+	// cuando el campo esta vacio, asi que el comportamiento no cambia.
+	if chosen := m.stepEdit.model; chosen != "" && chosen != runnermodels.DefaultModel(cli) {
+		step.Model = chosen
+	}
+
 	if m.stepEdit.validatorOn {
 		v, maxLoops, onMaxLoops, err := m.buildValidator()
 		if err != nil {
@@ -904,7 +1000,13 @@ func (m model) buildValidator() (*Validator, int, string, error) {
 		return nil, 0, "", fmt.Errorf("validator: on_max_loops invalido: %s", onMax)
 	}
 
-	return &Validator{CLI: cli, Kind: kind, Content: content}, maxLoops, onMax, nil
+	v := &Validator{CLI: cli, Kind: kind, Content: content}
+	// Misma regla que buildStep: model: se persiste solo si difiere del
+	// default del CLI del validator.
+	if chosen := m.stepEdit.valModel; chosen != "" && chosen != runnermodels.DefaultModel(cli) {
+		v.Model = chosen
+	}
+	return v, maxLoops, onMax, nil
 }
 
 func contains(haystack []string, needle string) bool {
@@ -978,6 +1080,7 @@ func (m *model) activeFocusOrder() []StepFieldFocus {
 	base := []StepFieldFocus{
 		StepFocusName,
 		StepFocusCLI,
+		StepFocusModel,
 		StepFocusKind,
 		StepFocusContent,
 		StepFocusInput,
@@ -986,6 +1089,7 @@ func (m *model) activeFocusOrder() []StepFieldFocus {
 	if m.stepEdit.validatorOn {
 		base = append(base,
 			StepFocusValCLI,
+			StepFocusValModel,
 			StepFocusValKind,
 			StepFocusValContent,
 			StepFocusValMaxLoops,
@@ -1137,6 +1241,20 @@ func (m model) viewStep() string {
 	}
 	b.WriteString("\n")
 	b.WriteString(renderCLIPills(m, m.stepEdit.focus == StepFocusCLI))
+	b.WriteString("\n")
+
+	// model pills (opcional segun CLI). opencode y CLIs desconocidos no
+	// aceptan override — la fila igual aparece para que el layout no salte.
+	b.WriteString(labelStyle.Render("Modelo"))
+	if m.stepEdit.focus == StepFocusModel {
+		if runnermodels.SupportsModelOverride(m.stepEdit.cli) {
+			b.WriteString(dimStyle.Render("  ← foco · ←/→ cambiar · 1-9 jump"))
+		} else {
+			b.WriteString(dimStyle.Render("  ← foco · " + m.stepEdit.cli + " no soporta elegir modelo desde el YAML"))
+		}
+	}
+	b.WriteString("\n")
+	b.WriteString(renderModelPills(m.stepEdit.cli, m.stepEdit.model, m.stepEdit.focus == StepFocusModel))
 	b.WriteString("\n")
 
 	// kind toggle. Si el CLI elegido no tiene skills, ocultamos la pill
@@ -1440,6 +1558,19 @@ func renderValidatorBlock(m model) string {
 	b.WriteString(renderValCLIPills(m))
 	b.WriteString("\n")
 
+	// Modelo del validator (mismo contrato que el del step).
+	b.WriteString(labelStyle.Render("Modelo"))
+	if m.stepEdit.focus == StepFocusValModel {
+		if runnermodels.SupportsModelOverride(m.stepEdit.valCLI) {
+			b.WriteString(dimStyle.Render("  ← foco · ←/→ cambiar · 1-9 jump"))
+		} else {
+			b.WriteString(dimStyle.Render("  ← foco · " + m.stepEdit.valCLI + " no soporta elegir modelo desde el YAML"))
+		}
+	}
+	b.WriteString("\n")
+	b.WriteString(renderModelPills(m.stepEdit.valCLI, m.stepEdit.valModel, m.stepEdit.focus == StepFocusValModel))
+	b.WriteString("\n")
+
 	// Kind toggle (solo prompt si el CLI no tiene skills).
 	hasSkills := m.cliHasSkills(m.stepEdit.valCLI)
 	b.WriteString(labelStyle.Render("Kind"))
@@ -1549,6 +1680,33 @@ func renderValContent(m model) string {
 		style = style.Width(inner)
 	}
 	return label + "\n" + style.Render(body)
+}
+
+// renderModelPills renderiza la fila de modelos para el CLI dado. Sirve
+// tanto al step principal como al validator — el caller pasa cli + el
+// modelo seleccionado actual + si la fila esta focuseada.
+//
+// Si el CLI no esta en el whitelist (opencode o un CLI custom), en lugar
+// de pills mostramos un texto dimmed "(no aplica — <cli> usa la config
+// del propio CLI)". El cursor puede aterrizar en la fila igual; ←/→ son
+// no-op para que el usuario entienda que es un campo informativo.
+func renderModelPills(cli, selected string, focused bool) string {
+	opts := runnermodels.ModelsForCLI(cli)
+	if len(opts) == 0 {
+		return "  " + dimStyle.Render("(no aplica — "+cli+" usa la config del propio CLI)")
+	}
+	var parts []string
+	for _, m := range opts {
+		switch {
+		case m == selected && focused:
+			parts = append(parts, selectedItem.Render("["+m+"]"))
+		case m == selected:
+			parts = append(parts, selectedOff.Render("["+m+"]"))
+		default:
+			parts = append(parts, dimStyle.Render(" "+m+" "))
+		}
+	}
+	return "  " + strings.Join(parts, "  ")
 }
 
 func renderMaxLoopsPills(m model) string {


### PR DESCRIPTION
## Summary

Dos fixes sobre feedback recibido en `v1.1.0-rc.1`:

- **Bug 1 — dash no muestra pipelines de scope `project`**: el dash hacía `os.Getwd()` cwd-exacto al startup. Si lo arrancabas desde una subcarpeta del proyecto, los pipelines guardados en `<root>/.che/pipelines/` no aparecían. Fix: nuevo `pipelines.FindProjectRoot` con walk-up al primer ancestro con `.che/pipelines/`; el dash lo usa al startup. Si ningún ancestro lo tiene, scope project queda vacío (comportamiento previo preservado).
- **Bug 2 — wizard nunca pedía elegir modelo**: la UI del wizard quedó fuera de alcance en #144 (que solo agregó soporte YAML + preflight). Fix: nueva fila "Modelo" en S2 (step y validator) con pills del whitelist por CLI. Default = `runnermodels.DefaultModel(cli)`; opencode y CLIs desconocidos rinden `(no aplica)` y la pill no se cyclea. `model:` se persiste solo si difiere del default (consistente con `max_loops` / `on_max_loops`).
- Whitelist movido a `internal/runnermodels/` para evitar ciclo `wizard → runner`; `runner.DefaultModel` / `ValidateModel` quedan como re-exports thin.
- `chore`: el commit `4c9af1f` ignoraba `.che/` entero, pero los pipelines de scope project viven ahí y son versionables. Este PR cambia el ignore a `.che/runs/` (solo los runs locales quedan fuera del repo).

## Test plan

- [ ] `che-beta dash` desde una subcarpeta del proyecto muestra pipelines de scope `project` con badge `project`.
- [ ] `che-beta dash` desde un dir sin ancestro con `.che/pipelines/` sigue mostrando solo global + builtin.
- [ ] Wizard: al crear un step con `cli: claude`, la fila "Modelo" cyclea entre `opus` / `sonnet` / `haiku` / nombres completos; con `cli: codex` o `cli: gemini`, cyclea sus whitelists; con `cli: opencode` muestra `(no aplica)`.
- [ ] Wizard: validator del step expone la misma fila "Modelo".
- [ ] YAML resultante: si dejaste el default, no escribe `model:`; si elegiste otro, lo escribe.
- [ ] `go build ./...` + `go vet ./...` OK (verificado local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)