### PR TITLE
Plan for #147: che-funnel close step valida sin mergear

### DIFF
--- a/.harness/plans/147-che-funnel-close-step-validate-no-merge.md
+++ b/.harness/plans/147-che-funnel-close-step-validate-no-merge.md
@@ -1,0 +1,77 @@
+# Plan: che-funnel close step valida sin mergear
+
+Refs #147 - https://github.com/chichex/che/issues/147
+
+## Contexto
+
+El pipeline default `che-funnel` (embebido en `internal/wizard/embedded/che-funnel.yaml`) tiene 4 steps: `idea`, `explore`, `execute`, `close`. Hoy el step `close` automergea el PR con `gh pr merge --merge --delete-branch`, cierra el issue (transicionando a `che:closed`), borra branch + worktree, y postea un scoring template.
+
+La intención es bajar la autonomía del embudo en el cierre: que el pipeline NO mergee, solo valide que el PR está listo (CI verde, sin conflictos) y deje un comment con verdict. El merge queda como decisión humana.
+
+## Objetivo
+
+Modificar el step `close` del pipeline default `che-funnel` para que:
+
+1. Mantenga el fix loop existente (≤3 intentos resolviendo conflictos y esperando CI verde).
+2. NO ejecute `gh pr merge`.
+3. NO borre branch ni worktree.
+4. NO cierre el issue asociado (el `Closes #N` en el body del PR se ejecuta solo cuando el humano mergee).
+5. Aplique label `validated` al PR en lugar de `che:closed` al issue.
+6. Postee siempre el comment final con verdict (passed | failed) reflejando el resultado del fix loop.
+
+## Approach
+
+Editar exclusivamente `internal/wizard/embedded/che-funnel.yaml`, sección del step `close` (líneas ~604-718) y su comentario de cabecera. Cambios:
+
+- Reescribir el comentario header del step para reflejar la nueva semántica (valida-sin-mergear).
+- Sacar el paso de merge (`gh pr merge --merge --delete-branch`) y el cleanup del worktree.
+- Sacar la transición `che:executed → che:closing → che:closed` del issue. El issue queda como estaba al entrar al step (no se cambia de label).
+- Agregar al PR el label `validated` al final del flujo feliz; crear el label con `gh label create validated --force` si no existe.
+- Modificar el scoring-template comment para incluir un campo de **Validation status** (passed | failed) al inicio, y postearlo siempre — tanto si CI quedó verde como si después de 3 intentos siguió rojo/conflictivo. Mantener el resto del template (scoring 1-10, notas libres) intacto porque cumple lo mismo que ya hacía antes.
+- Actualizar el bloque OUTPUT final del step para reflejar `validated: <bool>` en lugar de `merged: <bool>`.
+
+Los otros steps (`idea`, `explore`, `execute`) no se tocan. Tampoco se toca código Go: el YAML es autocontenido y se embebe con `go:embed`.
+
+## Pasos
+
+- [ ] Reescribir comentario de cabecera del step `close` (líneas 604-611 actuales) describiendo el nuevo comportamiento "valida sin mergear".
+- [ ] Editar el `content:` del step `close`: sacar paso 4 (merge + worktree remove) y paso 5 (transición a `che:closed`). Conservar el fix loop (paso 3 actual) tal cual.
+- [ ] Agregar paso nuevo después del fix loop: `gh label create validated --force` + `gh pr edit <PR#> --add-label validated` (mutex con otros validated:* si aplica — usar `--remove-label validated:approve --remove-label validated:changes-requested --remove-label validated:needs-human` para limpieza previa).
+- [ ] Modificar el scoring template: agregar campo `**Validation status:** passed|failed` al inicio del bloque, debajo del header HTML. Postearlo SIEMPRE (incluso si el fix loop no logró mergeable). Mantener scoring y notas libres.
+- [ ] Actualizar el bloque OUTPUT final: cambiar `merged:` por `validated:` y `reason_if_not_merged:` por `reason_if_not_validated:`.
+- [ ] Actualizar las "Reglas duras" del step para que reflejen el nuevo comportamiento (sin force-push, sin cambiar base, no mergear; si CI no pasa después de 3 intentos, postear el comment con status=failed y NO aplicar label `validated`).
+- [ ] Correr `go test ./internal/wizard/...` para chequear que los embedded tests siguen pasando (solo aseguran que existe el step `close` por nombre — la edición de contenido no debería romper nada).
+
+## Archivos afectados
+
+- `internal/wizard/embedded/che-funnel.yaml` — modificar (reescribir step `close` y su comentario header).
+
+## Riesgos
+
+- **Regresión en flujos custom que extiendan `che-funnel`**: el archivo es builtin embebido; cualquier copia que el usuario haya hecho via `che pipeline copy` o similar mantiene la versión vieja. No es responsabilidad de este cambio. Asunción 10 del issue limita el scope a este YAML.
+- **Loss del cleanup del worktree**: dejar el worktree `.worktrees/issue-<N>` puede acumular basura si el usuario ejecuta muchos pipelines. Es intencional según asunción 9; documentar en el comentario header que el cleanup queda manual.
+- **Comportamiento ambiguo del comment "passed" cuando el step se interrumpe a mitad**: si falla por algo ajeno (CLI cae), el comment puede no postearse. Es status-quo: cualquier interrupción del pipeline ya tenía esa ambigüedad.
+
+## Out of scope
+
+- Pipelines custom o de scope user/project en `.che/pipelines/`.
+- Cambios a otros steps (`idea`, `explore`, `execute`).
+- Cambios a la lógica del runner (`internal/runner/`).
+- Migración de pipelines copiados/shadowed que tengan la versión vieja del step `close`.
+- Cambiar el formato del scoring (1-10 completitud / fidelidad / alineación) — se mantiene tal cual.
+
+## Asunciones tecnicas validadas
+
+1. El archivo a editar es `internal/wizard/embedded/che-funnel.yaml`. (Asunción 1 del issue.)
+2. El step a tocar se llama `close`. (Asunción 2.)
+3. La eliminación del merge implica sacar `gh pr merge --merge --delete-branch`, no borrar el step. (Asunción 3.)
+4. El fix loop (≤3 intentos) se conserva. (Asunción 4.)
+5. El comentario que se postea es la variante del scoring template ya existente, extendido con un campo Validation status. (Asunciones 5 y 11.)
+6. El issue no se cierra desde el step; el `Closes #N` del body del PR queda intacto y se ejecutará cuando el humano mergee. (Asunción 6.)
+7. El PR queda con label `validated` al terminar exitoso. (Asunción 7.)
+8. Branch y worktree no se borran. (Asunciones 8 y 9.)
+9. Tests del paquete `internal/wizard/...` no asertan sobre el contenido textual del step `close`, solo sobre su existencia por nombre (`embedded_test.go:54`). Esto significa que la edición de contenido es segura.
+
+---
+
+_Plan generado por `/hs-auto` a partir de #147 (sin labels harness)._

--- a/internal/wizard/embedded/che-funnel.yaml
+++ b/internal/wizard/embedded/che-funnel.yaml
@@ -606,17 +606,24 @@ steps:
   # ───────────────────────────────────────────────────────────────────────────
   # Input: OUTPUT del step execute (PRs validados).
   # Acción: marcar PR ready, esperar CI, fix loop si conflict/CI rojo (≤3),
-  #         mergear, borrar branch, cerrar issues asociados, postear
-  #         comment template de scoring 1-10 (NO gating; el humano lo
-  #         llena después), aplicar che:closing → che:closed.
+  #         validar que el PR está listo (CI verde, sin conflictos), aplicar
+  #         label `validated` al PR, y postear siempre el comment de scoring
+  #         extendido con Validation status (passed|failed).
+  #
+  # El merge queda como decisión humana. El step NO mergea, NO borra branch
+  # ni worktree (el cleanup es responsabilidad del humano), y NO cierra el
+  # issue — el `Closes #N` del body del PR se ejecutará cuando el humano
+  # mergee. El worktree .worktrees/issue-<N> queda en pie; limpiarlo
+  # manualmente con `git worktree remove --force .worktrees/issue-<N>`.
   - name: close
     cli: claude
     kind: prompt
     input: previous_output
     content: |
-      Sos un ingeniero senior cerrando PRs. Tu objetivo es dejarlos
-      mergeados y limpios; el scoring humano lo hace el usuario después
-      via comment template.
+      Sos un ingeniero senior validando PRs antes del merge humano. Tu
+      objetivo es confirmar que el PR está limpio (CI verde, sin
+      conflictos), aplicar el label `validated`, y postear un comment de
+      scoring con el resultado. El merge lo decide el humano.
 
       INPUT — el bloque OUTPUT del step execute contiene una lista `prs:`
       con número, branch e issue asociado. Procesá cada PR:
@@ -629,11 +636,7 @@ steps:
          Si isDraft=true, marcalo ready:
              gh pr ready <PR#>
 
-      2. Aplicá transición al issue asociado:
-             issue=$(gh pr view <PR#> --json closingIssuesReferences -q '.closingIssuesReferences[0].number')
-             gh issue edit "$issue" --add-label che:closing --remove-label che:executed
-
-      3. Fix loop (≤3 intentos): si mergeable=CONFLICTING o el rollup tiene
+      2. Fix loop (≤3 intentos): si mergeable=CONFLICTING o el rollup tiene
          checks failing, invocá el fix:
 
              cd .worktrees/issue-<issue>      # reusá worktree existente
@@ -649,39 +652,29 @@ steps:
          Después del push, esperá CI:
              gh pr checks <PR#> --watch
 
-         Si después de 3 intentos sigue rojo o conflictivo, NO mergees.
-         Posteá comment explicando qué bloquea y dejá el PR en
-         che:closing — el humano decide.
+         Si después de 3 intentos sigue rojo o conflictivo, marcá
+         VALIDATION_STATUS=failed y pasá al paso 4 directamente (sin
+         aplicar label `validated`).
 
-      4. Mergear con merge commit (NO squash, preservamos historia):
-             gh pr merge <PR#> --merge --delete-branch
+      3. Si el fix loop terminó con CI verde y mergeable OK (VALIDATION_STATUS=passed):
 
-         `--delete-branch` borra branch remota y local. Después borrá el
-         worktree:
-             git worktree remove --force .worktrees/issue-<issue> 2>/dev/null || true
+         a. Creá el label `validated` si no existe:
+                gh label create validated --color 0075ca --force
 
-      5. Cerrar issue(s) asociado(s) — el `Closes #N` del body del PR ya
-         los cierra al mergear, pero aplicamos la transición de label:
+         b. Quitá labels validated:* residuales y aplicá `validated`:
+                gh pr edit <PR#> \
+                  --remove-label validated:changes-requested \
+                  --remove-label validated:needs-human || true
+                gh pr edit <PR#> --add-label validated
 
-             gh issue edit "$issue" --add-label che:closed --remove-label che:closing
+      4. Posteá siempre el comment de scoring template (incluso si
+         VALIDATION_STATUS=failed):
 
-         Quitá labels bloqueantes residuales:
-
-             gh issue edit "$issue" \
-               --remove-label plan-validated:changes-requested \
-               --remove-label plan-validated:needs-human || true
-             gh pr edit <PR#> \
-               --remove-label validated:changes-requested \
-               --remove-label validated:needs-human || true
-
-      6. Postear comment de scoring template en el PR (sin gate):
-
-             gh pr comment <PR#> --body-file <scoring-template.md>
-
-         Template:
-
+             gh pr comment <PR#> --body "$(cat <<'SCORING'
              <!-- claude-cli: flow=close iter=1 agent=claude role=scoring-template -->
              ## Scoring del cierre
+
+             **Validation status:** passed|failed   ← reemplazá con el valor real
 
              Para que el humano puntúe del 1 al 10 cuando tenga 5 minutos.
 
@@ -695,24 +688,38 @@ steps:
              _El embudo no usa este score como gate; vive como historia
              del PR. Si querés tracking, usá `gh pr list --json comments`
              y filtrá por este header._
+             SCORING
+             )"
+
+         Sustituí `passed|failed` por el valor real de VALIDATION_STATUS
+         antes de postear.
+
+         Si VALIDATION_STATUS=failed, incluí también en el body del
+         comment una sección `**Blocker:**` con una línea explicando qué
+         impidió que el CI quedara verde (ej: "CI rojo tras 3 intentos —
+         ver run <URL>").
 
       Reglas duras:
-      - Si CI nunca pasa después de 3 intentos, NO mergees. Dejá el PR
-        en che:closing y el issue también, postea comment explicando.
-      - No cambies la base del PR ni abras PRs nuevos.
+      - NO mergees. El merge es siempre decisión humana.
       - No force-push.
+      - No cambies la base del PR ni abras PRs nuevos.
+      - No borrés branch ni worktree (el worktree .worktrees/issue-<N>
+        queda en pie; el humano lo limpia cuando quiera).
+      - No cambiés labels del issue asociado.
+      - Si CI no pasa después de 3 intentos: posteá el comment con
+        status=failed y NO aplicás label `validated`.
 
       Al final devolvé el resumen:
 
           OUTPUT:
-          closed:
+          validated:
             - issue: <N>
               pr: <PR#>
-              merged: <bool>
-              reason_if_not_merged: <opcional>
+              validated: <bool>
+              reason_if_not_validated: <opcional>
             - ...
 
-      PRs a cerrar:
+      PRs a validar:
       <<<
       {{INPUT}}
       >>>


### PR DESCRIPTION
## Plan

Modificar el step `close` del pipeline default `che-funnel` (`internal/wizard/embedded/che-funnel.yaml`) para que **valide** el PR (fix loop CI / conflicts) y **postee un comment con verdict**, sin mergear, sin borrar branch/worktree y sin cerrar el issue.

Ver `.harness/plans/147-che-funnel-close-step-validate-no-merge.md` para approach, pasos, archivos afectados, riesgos y asunciones técnicas.

## Cambios principales del plan

- Sacar `gh pr merge --merge --delete-branch` y el cleanup del worktree.
- Sacar la transición `che:executed → che:closing → che:closed` del issue.
- Aplicar label `validated` al PR al terminar exitoso.
- Postear siempre el scoring template extendido con campo **Validation status: passed | failed**.
- Actualizar el bloque `OUTPUT` final: `validated:` en lugar de `merged:`.

Closes #147
